### PR TITLE
Make link more specific

### DIFF
--- a/rails/project_ar_basics.md
+++ b/rails/project_ar_basics.md
@@ -125,5 +125,5 @@ If any of those don't work, double check your associations.  Sometimes the error
 *This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something*
 
 
-* The [Rails API](http://api.rubyonrails.org/) has good documentation for these things, in addition to the Edge Guides you've already read.  Often it can be easier to search Google for the proper API page than navigating the site, e.g. "rails api has_many".
+* The [Rails API](http://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html) has good documentation for these things, in addition to the Edge Guides you've already read.  Often it can be easier to search Google for the proper API page than navigating the site, e.g. "rails api has_many".
 * 


### PR DESCRIPTION
Make link to api.rubyonrails.org more specific to the associations page : http://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html
