### PR TITLE
Fix link to Wikipedia Mastermind game article

### DIFF
--- a/ruby/project_oop.md
+++ b/ruby/project_oop.md
@@ -31,7 +31,7 @@ Build a tic-tac-toe game on the command line where two human players can play ag
 
 ## Project 2: Mastermind
 
-If you've never played Mastermind, a game where you have to guess your opponent's secret code within a certain number of turns (like hangman with colored pegs), check it out on [Wikipedia](http://en.wikipedia.org/wiki/Mastermind_(board_game\)).  Each turn you get some feedback about how good your guess was -- whether it was exactly correct or just the correct color but in the wrong space.
+If you've never played Mastermind, a game where you have to guess your opponent's secret code within a certain number of turns (like hangman with colored pegs), check it out on <a href="http://en.wikipedia.org/wiki/Mastermind_(board_game)">Wikipedia</a>.  Each turn you get some feedback about how good your guess was -- whether it was exactly correct or just the correct color but in the wrong space.
 
 ### Your Task
 


### PR DESCRIPTION
The link to Wikipedia's Mastermind article doesn't work because of the parentheses in the URL. I changed the link to an anchor tag. I don't know if you would not like this in the markdown file, but this link works.
