### PR TITLE
Fix link to Wikipedia Hangman game article

### DIFF
--- a/ruby/project_file_io.md
+++ b/ruby/project_file_io.md
@@ -26,7 +26,7 @@ Files are a great way to save and reload a game, so we'll give it a shot here.
 
 ### Your Task
 
-You will be building a simple command line Hangman game where one player plays against the computer, but a bit more advanced.  If you're unfamiliar with how Hangman works, see [Wikipedia](http://en.wikipedia.org/wiki/Hangman_(game\)).
+You will be building a simple command line Hangman game where one player plays against the computer, but a bit more advanced.  If you're unfamiliar with how Hangman works, see <a href="http://en.wikipedia.org/wiki/Hangman_(game)">Wikipedia</a>.
 
 1. Download the `5desk.txt` dictionary file from [http://scrapmaker.com/](http://scrapmaker.com/view/twelve-dicts/5desk.txt).
 2. When a new game is started, your script should load in the dictionary and randomly select a word between 5 and 12 characters long for the secret word.


### PR DESCRIPTION
Changed the markdown link to Wikipedia's Hangman game (which contains parentheses) to an explicit anchor tag. Old link didn't work, new one does.
