### PR TITLE
Replace railsbridge dead link with new one

### DIFF
--- a/rails/project_feet_wet.md
+++ b/rails/project_feet_wet.md
@@ -13,7 +13,7 @@ Next comes the [Jumpstart Lab Blogger Tutorial](http://tutorials.jumpstartlab.co
 
 1. If you haven't already, do the [Installations project](http://www.theodinproject.com/web-development-101/installations).  If you've already got Rails on your system, it's still worth skipping to the bottom and verifying that you've got **Rails 4** and **Ruby 2** working properly.  The section says:
 
-    Even if you didn't use the Railsbridge installation instructions, verify your installation by following their instructions for [creating and deploying a sample Rails app](http://installfest.railsbridge.org/installfest/create_and_deploy_a_rails_app). 
+    Even if you didn't use the Railsbridge installation instructions, verify your installation by following their instructions for [creating and deploying a sample Rails app](http://docs.railsbridge.org/intro-to-rails/deploying_to_heroku). 
 
 2. If you haven't already, do the [Blogger Tutorial](http://tutorials.jumpstartlab.com/projects/blogger.html).
 3. If you hadn't done either of these, you should go back to the [Web Development 101](/web-development-101) course and at least do the [Web Development Frameworks section](/web-development-101/#section-web-development-frameworks).


### PR DESCRIPTION
Railsbridge [Create and Deploy a Rails App (wayback)](http://web.archive.org/web/20130622140324/http://installfest.railsbridge.org/installfest/create_and_deploy_a_rails_app)  article linked in that section is no longer in use (and broken), having been replaced by [Deploying to heroku](http://docs.railsbridge.org/intro-to-rails/deploying_to_heroku).
