### PR TITLE
How to use LESS to avoid Bootstrap classes in HTML

### DIFF
--- a/html_css/preprocessors.md
+++ b/html_css/preprocessors.md
@@ -27,5 +27,6 @@ Preprocessors (aka precompilers) can make your life much easier by eliminating c
 
 *This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something*
 
+* [How to use LESS to avoid Bootstrap classes in HTML](http://ruby.bvision.com/blog/please-stop-embedding-bootstrap-classes-in-your-html)
 * [SASS's main website](http://sass-lang.com/)
 * [LESS's main website](http://www.lesscss.org/)


### PR DESCRIPTION
Article introduces best practice of using LESS mixins for Bootstrap classes in order to avoid cluttering HTML and keep content and style separate.
