### PR TITLE
swapped link for "list of term definitions" #1430

### DIFF
--- a/web_development_101/terms_to_know.md
+++ b/web_development_101/terms_to_know.md
@@ -8,12 +8,12 @@ Web technology land is full of strange terms and an alphabet soup of acronyms an
 *Look through these now and then use them to test yourself after doing the assignment*
 
 
-* How to define each of the terms in the Flatiron list below.
+* How to define each of the terms in the Viking Code School list below.
 * The basics of each term on the list from Smashing Magazine below.
 
 ## Assignment:
 
-1. Take a look at this [list of term definitions](http://prework.flatironschool.com/web-development/#tocAnchor-1-5-1) and make sure you have at least a competent understanding of each one (click on it to bring up the full definition).  Don't skip this and assume you know it all -- there will be at least a few that are worth nailing down.  Flashcards help.
+1. Take a look at this [list of term definitions](http://www.vikingcodeschool.com/web-development-basics/terms-to-know) and make sure you have at least a competent understanding of each one (click on it to bring up the full definition).  Don't skip this and assume you know it all -- there will be at least a few that are worth nailing down.  Flashcards help.
 2. Browse through this [great (though design-focused) list of terms from Smashing Magazine](http://www.smashingmagazine.com/2009/05/21/web-design-industry-jargon-glossary-and-resources/).  It's not essential that you know all the unfamiliar ones down cold, but you'll keep seeing this stuff again and again so it's good to have a working knowledge of what they are.  The article also contains lots of great links to dig deeper into anything you don't understand.
 
 ## Additional Resources


### PR DESCRIPTION
changed the link from the non-working Flatiron School link, to the Viking Code School Prep page.