### PR TITLE
DELETE is a specialized version of POST not GET

### DIFF
--- a/rails/web_refresher.md
+++ b/rails/web_refresher.md
@@ -12,7 +12,7 @@ HTTP is just a way of structuring the request-and-response conversation between 
 
 One key component to pay attention to is the fact that the request and response both have header and (usually) body components.  The header contains information about the request or response itself (meta data), including which website to send or return to and what the status of the response is.  The body of the request can contain things like data submitted by a form or cookies or authentication tokens while the response will usually contain the HTML page you're trying to access.
 
-The other key component is that each request uses one of four main "verbs" -- GET, POST, PUT, and DELETE.  These days, you almost only see GET and POST requests (even if you're trying to do a delete of something they usually fake it using a GET request), but it's important to understand the difference between the verbs.
+The other key component is that each request uses one of four main "verbs" -- GET, POST, PUT, and DELETE.  These days, you almost only see GET and POST requests (even if you're trying to do a delete of something they usually fake it using a POST request), but it's important to understand the difference between the verbs.
 
 ## REST
 


### PR DESCRIPTION
In the tutsplus  HTTP tutorial explains that PUT and DELETE are specialized versions of a POST request not GET, since POST is used to create a resource, it could be used to do a deletion or an update. Here is the section where he explains that:
>
* **GET**: fetch an existing resource. The URL contains all the necessary information the server needs to locate and return the resource.
* **POST**: create a new resource. POST requests usually carry a payload that specifies the data for the new resource.
* **PUT**: update an existing resource. The payload may contain the updated data for the resource.
* **DELETE**: delete an existing resource.

>The above four verbs are the most popular, and most tools and frameworks explicitly expose these request verbs. PUT and DELETE are sometimes considered specialized versions of the POST verb, and they may be packaged as POST requests with the payload containing the exact action: create, update or delete.
