### PR TITLE
Turbolinks is not by default.

### DIFF
--- a/rails/views.md
+++ b/rails/views.md
@@ -206,8 +206,8 @@ As you may have seen in the application layout file we talked about above, Rails
 Will render something like:
 
 ```language-ruby
-    <link data-turbolinks-track="true" href="/assets/your_stylesheet.css" media="all" rel="stylesheet">
-    <script data-turbolinks-track="true" src="/assets/your_stylesheet.js"></script>
+    <link href="/assets/your_stylesheet.css" media="all" rel="stylesheet">
+    <script src="/assets/your_stylesheet.js"></script>
     <img src="/assets/happy_cat.jpg">
 ```
 


### PR DESCRIPTION
I was looking at the Rails API documentation and the attribute `data-turbolinks-track="true"` doesn't seem to be by default when calling `#stylesheet_link_tag` or `#javascript_include_tag`.
Examples from the documentation:
```language-ruby
# CSS
stylesheet_link_tag "style"
# => <link href="/assets/style.css" media="screen" rel="stylesheet" />

# Javascript
javascript_include_tag "xmlhr"
# => <script src="/assets/xmlhr.js?1284139606"></script>
```