### PR TITLE
Update migration section

### DIFF
--- a/rails/active_record_basics.md
+++ b/rails/active_record_basics.md
@@ -110,10 +110,10 @@ These are great questions, and you should feel comfortable asking them even if y
 
 ### Your Assignment
 
-1. Read the [Migrations chapter of Rails Guides](http://guides.rubyonrails.org/migrations.html).  
+1. Read the [Migrations chapter of Rails Guides](http://edgeguides.rubyonrails.org/active_record_migrations.html).  
     * Don't worry about 3.6-3.8.
-    * Just skim sections 7 and 8
-    * Seeds (section 9) are useful and you'll be using them later.  It saves you a lot of work, especially when you're learning and will end up blowing away your database and starting over a lot.
+    * Just skim section 7.
+    * Seeds (section 8) are useful and you'll be using them later.  It saves you a lot of work, especially when you're learning and will end up blowing away your database and starting over a lot.
 
 ## Basic Validations
 


### PR DESCRIPTION
The [Migration Chapter of Rails Guides](http://edgeguides.rubyonrails.org/active_record_migrations.html) has been updated, and it only has 8 sections, where section 8 is the Seeds section.
See [here](http://edgeguides.rubyonrails.org/active_record_migrations.html#migrations-and-seed-data).
I also updated the link since the previous one redirects you to that link.