### PR TITLE
Corrected example code for #bubble_sort_by

### DIFF
--- a/ruby/project_advanced_building_blocks.md
+++ b/ruby/project_advanced_building_blocks.md
@@ -28,7 +28,7 @@ There's also [an entry on Bubble Sort on Wikipedia](http://en.wikipedia.org/wiki
 
     ```language-bash
         > bubble_sort_by(["hi","hello","hey"]) do |left,right|
-        >   right.length - left.length
+        >   left.length - right.length
         > end
         => ["hi", "hey", "hello"]
     ```


### PR DESCRIPTION
Example code as right.length - left.length would result in the return of ["hello", "hey", "hi"], not the ["hi", "hey", "hello"] given in the example.
right.length - left.length will return negative whenever the left value is longer than the right, thus being in reverse of the example's output.