### PR TITLE
Add additional resource on has_many :through

### DIFF
--- a/rails/project_associations_2.md
+++ b/rails/project_associations_2.md
@@ -22,3 +22,4 @@ As an added bonus, you'll get a chance to touch a bit of AJAX when making it so 
 
 
 * [Railscast on Many-to-Many Self-Referential Relationships (2010)](http://railscasts.com/episodes/163-self-referential-association?view=asciicast).  This is old but should be helpful to see the concept covered.
+* [Screencast on Many-to-Many Self-Referential Relantionships with has_many :through](https://www.youtube.com/watch?v=PD0-efs7s_A)


### PR DESCRIPTION
It's a screencast that explains `Many-To-Many self-referential` relantionships using `has_many :through`, the example is about followers<--->following. I thought about adding this because it's newer than the Railscasts video and it also shows a bit of testing with RSpec. 
https://www.youtube.com/watch?v=PD0-efs7s_A