### PR TITLE
Remove railscasts episode

### DIFF
--- a/rails/project_mailers.md
+++ b/rails/project_mailers.md
@@ -42,6 +42,5 @@ You'll be dusting off your [Flight Booker project](/ruby-on-rails/building-advan
 
 
 * [`letter_opener` docs](https://github.com/ryanb/letter_opener)
-* [Creating a Mailer in Rails 3](http://railscasts.com/episodes/206-action-mailer-in-rails-3) (should still work in Rails 4).
 * [Setting up email: Rails, Heroku, SendGrid, Figaro](http://howilearnedrails.wordpress.com/2014/02/25/setting-up-email-in-a-rails-4-app-with-action-mailer-in-development-and-sendgrid-in-production-using-heroku/comment-page-1/#comment-79)
 


### PR DESCRIPTION
For this to work you actually have to configure things differently. Setup all variables in the environment you are currently on, in rails 4 there is no need to create a `setup_email.rb` file, since all config goes in `config/$RAILS_ENV.rb`.
Sources: [Ruby on Rails Guides - Action Mailer configuration](http://guides.rubyonrails.org/action_mailer_basics.html#action-mailer-configuration)