### PR TITLE
adds the sample app in the first RoR project text

### DIFF
--- a/rails/project_feet_wet.md
+++ b/rails/project_feet_wet.md
@@ -13,7 +13,7 @@ Next comes the [Jumpstart Lab Blogger Tutorial](http://tutorials.jumpstartlab.co
 
 1. If you haven't already, do the [Installations project](http://www.theodinproject.com/web-development-101/installations).  If you've already got Rails on your system, it's still worth skipping to the bottom and verifying that you've got **Rails 4** and **Ruby 2** working properly.  The section says:
 
-    Even if you didn't use the Railsbridge installation instructions, verify your installation by following their instructions for [creating and deploying a sample Rails app](http://docs.railsbridge.org/intro-to-rails/deploying_to_heroku).
+    Even if you didn't use the Railsbridge installation instructions, verify your installation by following their instructions for [creating a sample Rails app](http://installfest.railsbridge.org/installfest/create_a_rails_app) and then [deploying it](http://installfest.railsbridge.org/installfest/deploy_a_rails_app). 
 
 2. If you haven't already, do the [Blogger Tutorial](http://tutorials.jumpstartlab.com/projects/blogger.html).
 3. If you hadn't done either of these, you should go back to the [Web Development 101](/web-development-101) course and at least do the [Web Development Frameworks section](/web-development-101/#section-web-development-frameworks).


### PR DESCRIPTION
the original part was confusing as the link leads to a tutorial for deploying to Heroku when you already have a RoR app. If thats not the case then you can't follow the tutorial. 
The pull request updates the text with first a small tutorial to create a app and then a link to a deploy tutorial.

the text was copied from the web development part of the odinproject:
http://www.theodinproject.com/web-development-101/installations (just above the 'checklist' part)