### PR TITLE
Change broken image link

### DIFF
--- a/ruby/project_data_structures_algorithms.md
+++ b/ruby/project_data_structures_algorithms.md
@@ -63,7 +63,7 @@ A knight in chess can move to any square on the standard 8x8 chess board from an
 
 All the possible places you can end up after one move look like this:
 
-<img src="http://www.thechesszone.com/images/articles/chess_rules_knight_moves.gif">
+<img src="http://0.tqn.com/d/chess/1/0/6/-/-/-/KnightMoves.gif">
 
 ### Your Task
 


### PR DESCRIPTION
The previous image link is broken, but I managed to find the image on the internet archive [here](https://web.archive.org/web/20140513202531/http://www.thechesszone.com/images/articles/chess_rules_knight_moves.gif) but I'm not sure if it's such a good idea to use the internet archive as image source so I searched for a similar image and included that link instead.