### PR TITLE
Hartl tutorial now uses Bootstrap 3.2

### DIFF
--- a/rails/project_basic_rvc.md
+++ b/rails/project_basic_rvc.md
@@ -83,8 +83,6 @@ In this chapter of the tutorial you will build out the look and feel of the appl
 
 Bootstrap will do a lot of the heavy lifting for you -- instead of having to figure out how to make your navbar stick to the top of the screen, you just have to put the correct class onto some `<div>` tags and Bootstrap's style files will take over for you.  It's a good way to quickly get something half decent up and running.  In the course on HTML and CSS, you'll get the chance to design your own CSS framework, but for now Bootstrap is a good weapon of choice.
 
-**If you're looking for help on Bootstrap, note that the newest version is version 3.0 while the tutorial uses the previous version, 2.3.** See Additional Resources for links to the docs.  They went and renamed a bunch of the classes for the new Bootstrap so be careful if you're going around looking for help with Bootstrap -- you may be looking at the new version instead.
-
 ### Your Task
 
 1. Do the [Rails Tutorial Chapter 5](https://www.railstutorial.org/book/filling_in_the_layout), "Filling in the Layout"
@@ -94,7 +92,6 @@ Bootstrap will do a lot of the heavy lifting for you -- instead of having to fig
 *This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something*
 
 
-* [Bootstrap's Current Version Docs](http://getbootstrap.com/) (NOT used by the tutorial)
-* [Bootstrap's Version 2.3 Docs](http://getbootstrap.com/2.3.2/) (used by the tutorial)
+* [Bootstrap's Current Version Docs](http://getbootstrap.com/)
 * [RestClient Documentation](https://github.com/rest-client/rest-client)
 * [Creating Rails Routes, Controllers and Views from CodeLearn](http://www.codelearn.org/ruby-on-rails-tutorial/introducing-controller-view-routes)


### PR DESCRIPTION
Current version of Bootstrap (3.3.6) is compatible with the tutorial - I had no problems using it instead of the 3.2.0 that Hartl specifies.