### PR TITLE
Remove link to nonexistent sql tutorial

### DIFF
--- a/rails/project_databases.md
+++ b/rails/project_databases.md
@@ -11,10 +11,6 @@ SQL Zoo is one of the few resources online that actually lets you build and run 
 
 1. Go to [SQL Zoo](http://sqlzoo.net/wiki/Main_Page) and do all 10 tutorials listed under the "Tutorial Section" and the quizzes listed at the end of each.  The first is the ["Select" tutorial](http://sqlzoo.net/wiki/SELECT_basics).  Make sure the dropdown on the left of the main page for "Engine" says "MySQL" (the default).  Large results will be cut off and not all rows or columns shown, so the "answers" may not look 100% correct.
 
-### Extra Credit
-
-1. Check out [SQL PQL](http://sql-pql.com), a newer version of SQL zoo that isn't quite as filled out (yet) but should help you hammer home the concepts.  Please let us know if this is more helpful/effective!
-
 ### Student Solutions
 
 *If you've been keeping track of the SQL Zoo solutions, put them here! Some that we found online are provided in the "Additional Resources" section below but are incomplete.  Submit a link to your solutions below by using a pull request.  See the section on [Contributing](http://github.com/TheOdinProject/curriculum/blob/master/contributing.md) for how.*


### PR DESCRIPTION
The SQL-PQL demo site at http://sql-pql.com/ is no longer up. Its code does exist at https://github.com/mluu510/SQL-PQL but is a bit of work to get running locally. Deploying to Heroku was much easier but I was not able to seed the database there using the instructions in the project README.

**If anyone wants to, instead of deleting the extra credit item, add instructions to get the tutorial running, that would be awesome,** but I'm not confident the steps (below) that got the site running locally for me (Debian 8.2, Jessie) are helpful to enough students.
* set Ruby version to 1.9.3 in the project directory because the debugger dependency is not compatible with Ruby 2.x: ```rvm --ruby-version use ruby-1.9.3-p551``` (I then ran ```gem install debugger``` but am not entirely sure this was necessary)
* install libpq-dev: ```sudo apt-get install libpq-dev```. at this point ```bundle install``` could succeed.
* edit config/database.yml, adding the following lines under ```development```:

    ```username: [your_username_here]```

    ```password: ```
* create role by running ```sudo -u postgres createuser [your_username_here]```
* then create, migrate, and seed database as described in project README