### PR TITLE
fix an incorrect reference to cross-site scripting

### DIFF
--- a/rails/form_basics.md
+++ b/rails/form_basics.md
@@ -62,7 +62,7 @@ You'll find yourself looking at this server output a lot when you start building
 
 ## Railsifying Your Form
 
-The first thing you'll realize if you try to create a plain vanilla form in a Rails view is that it won't work.  You'll either get an error or your user session will get zeroed out (depending on your Rails version).  That's because of a security issue with [cross-site scripting](http://en.wikipedia.org/wiki/Cross-site_scripting), so Rails requires you to verify that the form was actually submitted from a page you generated.  In order to do so, it generates an ["authenticity token"](http://guides.rubyonrails.org/security.html#cross-site-request-forgery-csrf) which looks like gibberish but helps Rails match the form with your session and the application.
+The first thing you'll realize if you try to create a plain vanilla form in a Rails view is that it won't work.  You'll either get an error or your user session will get zeroed out (depending on your Rails version).  That's because Rails by default automatically protects you from [cross-site request forgery](https://en.wikipedia.org/wiki/Cross-site_request_forgery) and it requires you to verify that the form was actually submitted from a page you generated.  In order to do so, it generates an ["authenticity token"](http://guides.rubyonrails.org/security.html#cross-site-request-forgery-csrf) which looks like gibberish but helps Rails match the form with your session and the application.
 
 You'll notice the token in the server output from above:
 


### PR DESCRIPTION
In the Basic Forms lesson it is incorrectly suggested that authenticity tokens are used to protect from cross-site scripting. Most likely the author meant cross-site request forgery instead, see Rails docs or http://stackoverflow.com/questions/941594/understanding-the-rails-authenticity-token