### PR TITLE
fix return value for User#authenticate

### DIFF
--- a/rails/project_auth.md
+++ b/rails/project_auth.md
@@ -48,7 +48,7 @@ If you'd like to challenge yourself, don't even follow the steps below, just go 
         > user.authenticate("somethingelse")
         => false
         > user.authenticate("foobar")
-        => true
+        => #<User id: 1, name: "foobar", email: "foo@bar.com", password_digest: "$2a$10$9Lx...", created_at: "2016...", updated_at: "2016...">
     ```
 
 #### Sessions and Sign In


### PR DESCRIPTION
In the console output shown in project instructions `User#authenticate` should return `self` as opposed to `true`, see http://api.rubyonrails.org/classes/ActiveModel/SecurePassword/InstanceMethodsOnActivation.html#method-i-authenticate.