### PR TITLE
Fix the link to the additional sections in the Codeacademy Javascript…

### DIFF
--- a/web_development_101/javascript_basics.md
+++ b/web_development_101/javascript_basics.md
@@ -320,5 +320,5 @@ This lesson will tend to focus on understanding the programming side of Javascri
 * A straight-to-the-point [primer on Javascript from discovermeteor.com](https://www.discovermeteor.com/blog/javascript-for-meteor/)
 * More videos about [Javascript Functions from wickedlysmart.com](http://wickedlysmart.com/learning-javascript-functions-part-2/)
 * Reading: The first several sections of the [hsablonniere's Javascript 101 Course](http://hsablonniere.github.io/markleft/prezas/javascript-101.html#1.0).
-* Interactive: Do the additional sections in the [Codeacademy Javascript Track](http://www.codecademy.com/tracks/jvascript).
+* Interactive: Do the additional sections in the [Codeacademy Javascript Track](http://www.codecademy.com/tracks/javascript).
 * [OverAPI's Javascript cheat sheet](http://overapi.com/javascript)


### PR DESCRIPTION
I've fixed the link in the end of the page "http://www.theodinproject.com/web-development-101/javascript-basics?ref=lnav" where it links to the additional sections in the Codeacademy Javascript Track (it missed an "a").