### PR TITLE
Remove Codelearn's dead link

### DIFF
--- a/web_development_101/project_rails.md
+++ b/web_development_101/project_rails.md
@@ -164,6 +164,5 @@ Because you'll be doing so much stuff that we haven't taught you yet, this is a 
 
 *This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something*
 
-* [Code Learn's Rails Directory Overview](http://www.codelearn.org/ruby-on-rails-tutorial/rails-directory-overview)
 * An older and slightly more technical [1.5 hour video introduction to Rails](http://www.youtube.com/watch?v=LuuKDyUYFTU) from Armando Fox of UC Berkeley.
 * [Another Ruby on Rails Guide](http://guides.rubyonrails.org/getting_started.html).  This walks through a similar blogger app and will help you add some extra features to your blog such as deleting comments.


### PR DESCRIPTION
Sadly, it seems codelearn.org has not been working for some time.

[](http://web.archive.org/web/*/codelearn.org)