### PR TITLE
Fix links in ruby/advanced_building_blocks.md

### DIFF
--- a/ruby/advanced_building_blocks.md
+++ b/ruby/advanced_building_blocks.md
@@ -128,10 +128,10 @@ This lesson gets more into the topics you may have been shaky on before like *Co
 
 Make sure you can do the following quizzes from [Code Quizzes](http://www.codequizzes.com/).  They're pretty quick and should give you an idea of what you still need to brush up on.
 
-2. [Beginner Ruby Quiz #2](http://www.codequizzes.com/learn-ruby/arrays-conditionals-loops)
-3. [Quiz #3](http://www.codequizzes.com/learn-ruby/variable-scope-methods)
-4. [Quiz #4](http://www.codequizzes.com/learn-ruby/symbols-array-methods-hashes)
-5. [Quiz #6](http://www.codequizzes.com/learn-ruby/iteration-nested-data-structures) 
+2. [Beginner Ruby Quiz #2](http://www.codequizzes.com/ruby/beginner/arrays-conditionals-loops)
+3. [Quiz #3](http://www.codequizzes.com/ruby/beginner/variable-scope-methods)
+4. [Quiz #4](http://www.codequizzes.com/ruby/beginner/symbols-array-methods-hashes)
+5. [Quiz #6](http://www.codequizzes.com/ruby/beginner/iteration-nested-data-structures) 
 
 ## Additional Resources
 


### PR DESCRIPTION
The links on codequizzes.com were broken as they must have changed their structure.  This has been updated.