### PR TITLE
Removed non-working link to old Coursera course

### DIFF
--- a/web_development_101/database_basics.md
+++ b/web_development_101/database_basics.md
@@ -45,6 +45,6 @@ Compared to a normal programming language like you've already learned, SQL (Stru
 * If the Stanford databases course above isn't working, check out their [playlist on YouTube](https://www.youtube.com/playlist?list=PL6hGtHedy2Z4EkgY76QOcueU8lAC4o6c3).  Watch lectures 1-3 (introductory material) and 11-13 (SQL).  Note -- this refers to the *lecture number* not the video's position in the playlist (they're all out of order).
 * Hunter Ducharme created [an e-book](http://hgducharme.gitbooks.io/sql-basics/) which is a great documentation on how to do all the basics in SQL.
 
-    Also, skip the stuff on relational algebra, XML, and JSON unless you're feeling ambitious.  All of these database videos can be a bit technical, so don't worry if you don't absorb it all at first -- we'll cover it again in the Rails course.  The original Coursera course can be found [here](https://class.coursera.org/db/lecture/index).
+    Also, skip the stuff on relational algebra, XML, and JSON unless you're feeling ambitious.  All of these database videos can be a bit technical, so don't worry if you don't absorb it all at first -- we'll cover it again in the Rails course.  
 
 * For more repetitions with the material, check out [SQL Teaching](http://www.sqlteaching.com), the "Codecademy for SQL" (and let us know what you think).


### PR DESCRIPTION
The link to the old Coursera course did not work and it does not appear (after a quick search) to be anywhere else on the Coursera site.

