### PR TITLE
sublime text 2 -> sublime text

### DIFF
--- a/web_development_101/project_installations.md
+++ b/web_development_101/project_installations.md
@@ -120,7 +120,7 @@ Actually, we won't need to install any of these -- they come with your web brows
 
 ### Text Editor
 
-We recommend using a text editor like [Sublime Text 2](http://www.sublimetext.com/) to make sure everyone's using basically the same type of text editor and you'll all be able to work together and ask questions of each other without that getting in the way.  Sublime also has lots of handy shortcuts, code highlighting and other nifty features that'll make your life easier, and that's just on the surface.
+We recommend using a text editor like [Sublime Text](http://www.sublimetext.com/) to make sure everyone's using basically the same type of text editor and you'll all be able to work together and ask questions of each other without that getting in the way.  Sublime also has lots of handy shortcuts, code highlighting and other nifty features that'll make your life easier, and that's just on the surface.
 
 Check out [this "Quick Guide to Sublime Text" from Jennifer Mann](http://jennifermann.ghost.io/a-quick-guide-to-sublime-text/) for some helpful hints and tricks.  She refers to [this tutorial (~2.5 hrs of video) from NetTuts](https://tutsplus.com/course/improve-workflow-in-sublime-text-2/) which explains some of the awesomeness of Sublime Text 2 in depth.  The first chunk of the video is the most important, don't stress out about picking up the details in the rest (but you should come back to it once you've gotten more comfortable with the editor).
 


### PR DESCRIPTION
Sublime text 3 is just referred to as Sublime Text now. Since what is on the ST homepage is actually ST3, i'd suggest removing the mention of ST2 to avoid confusion. If you'd rather people use ST2, since 3 is technically still in beta, change the link to https://www.sublimetext.com/2