### PR TITLE
Remove obsolete warning and update old link

### DIFF
--- a/web_development_101/database_basics.md
+++ b/web_development_101/database_basics.md
@@ -40,6 +40,7 @@ Compared to a normal programming language like you've already learned, SQL (Stru
 * A brief [Simple Wiki article describing relational databases](http://simple.wikipedia.org/wiki/Relational_database)
 * Hunter Ducharme created [an e-book](http://hgducharme.gitbooks.io/sql-basics/) which is a great documentation on how to do all the basics in SQL.
 
-    Also, skip the stuff on relational algebra, XML, and JSON unless you're feeling ambitious.  All of these database videos can be a bit technical, so don't worry if you don't absorb it all at first -- we'll cover it again in the Rails course.  
+    Also, skip the stuff on relational algebra, XML, and JSON unless you're feeling ambitious.
+    Don't worry if you don't absorb it all at first -- we'll cover it again in the Rails course.  
 
 * For more repetitions with the material, check out [SQL Teaching](http://www.sqlteaching.com), the "Codecademy for SQL" (and let us know what you think).

--- a/web_development_101/introduction_to_frameworks.md
+++ b/web_development_101/introduction_to_frameworks.md
@@ -16,7 +16,7 @@ A final thing to note is about licensing -- frameworks are typically (though not
 
 ## Your Assignment:
 
-1. Get introduced to frameworks by reading [this brief article from WebMonkey](http://www.webmonkey.com/2010/02/get_started_with_web_frameworks/).
+1. Get introduced to frameworks by reading [this brief article from Wired (originally from WebMonkey](https://www.wired.com/2010/02/get_started_with_web_frameworks/).
 2. Glance over [Choosing a Web Development Framework (2010)](http://www.crossbrowser.net/449/choosing-a-web-development-framework/) for some of the thought process that goes into picking a framework.
 
 ## Additional Resources


### PR DESCRIPTION
After the recent revamp in the "Additional Resources", the warning about "technical videos" no longer makes sense.