### PR TITLE
Update hyperlink to chatrooms

### DIFF
--- a/web_development_101/gearing_up.md
+++ b/web_development_101/gearing_up.md
@@ -129,7 +129,7 @@ following processes to get unstuck:
 * Google it - you can be sure someone else out there has had the same problem as
 you at some point, a quick Google can often lead to a solution.
 * Take a break - allow your diffuse state to work on the problem.
-* Ask for help in our [chat](http://www.theodinproject.com/chat) - come prepared
+* Ask for help in one of our [chats](https://gitter.im/orgs/TheOdinProject/rooms) - come prepared
 with your research done, people will be more willing to help you when they can see
 you have already put effort into trying to figure out the solution.
 


### PR DESCRIPTION
```
This is a PR template, If you are adding a solution link to the curriculum leave this as is. If you are not, then delete it and write the message you wish.
Thank you,
The Odin Project team.

```

Existing link to http://www.theodinproject.com/chat is broken, update link to direct students instead to The Odin Project rooms page on Gitter for help.