### PR TITLE
change link to backbone tutorials

### DIFF
--- a/javascript/project_js_frameworks.md
+++ b/javascript/project_js_frameworks.md
@@ -4,7 +4,7 @@ This project has two possibilities -- you can use Backbone.js if you'd like some
 
 ## Your Task
 
-If you've chosen Backbone, [do the beginner and intermediate tutorials here](http://backbonetutorials.com/) to learn Backbone and get a great overview of Javascript frameworks.
+If you've chosen Backbone, [do the beginner and intermediate tutorials here](http://cssor.com/wp-content/uploads/2012/10/Backbone-Tutorials.pdf) to learn Backbone and get a great overview of Javascript frameworks.
 
 If you've chosen Angular instead, first glance over the beginner tutorial from the link above to get a feel for how these frameworks operate, then [do this Angular.js tutorial which has you build a real web app](http://docs.angularjs.org/tutorial).
 


### PR DESCRIPTION
Found a PDF version of the exact same lessons. (Apparently the site has been down since at least April and this was a workaround suggested by the author.)