### PR TITLE
Changed the URL of You can learn anything link

### DIFF
--- a/web_development_101/gearing_up.md
+++ b/web_development_101/gearing_up.md
@@ -68,7 +68,7 @@ To learn more about the growth mindset use these resources:
 
 * [Believe you can get better](https://www.ted.com/talks/carol_dweck_the_power_of_believing_that_you_can_improve)
 * [Grit](https://www.ted.com/talks/angela_lee_duckworth_the_key_to_success_grit)
-* [You can learn anything](https://www.khanacademy.org/about/blog/post/95208400815/the-learning-myth-why-ill-never-tell-my-son-hes)
+* [You can learn anything](https://www.khanacademy.org/talks-and-interviews/conversations-with-sal/a/the-learning-myth-why-ill-never-tell-my-son-hes-smart)
 * [Start Here - The Motivation Episode and Becoming a Programming Super Learner](http://starthere.fm/webdev/23-the-motivation-episode-and-becoming-a-programming-super-learner)
 
 ## The Best ways to Learn


### PR DESCRIPTION
Right above the section 'The Best Ways to Learn', there are four links. The third one from the top is called 'You can learn anything'. 

It used to link to 
https://www.khanacademy.org/about/blog/post/95208400815/the-learning-myth-why-ill-never-tell-my-son-hes 

I changed this link to : 
https://www.khanacademy.org/talks-and-interviews/conversations-with-sal/a/the-learning-myth-why-ill-never-tell-my-son-hes-smart

Same end result, but skipped the redirect page.