### PR TITLE
change Win 10 RVM to simpler solution and match style

### DIFF
--- a/web_development_101/project_installations.md
+++ b/web_development_101/project_installations.md
@@ -4,7 +4,7 @@
      Add a few more text editior options to the text editior section. Atom, brackets etc
      Extract the join gitter section to the very first lesson in this course -->
 
-One step which can be unnecessarily frustrating is making sure everything is installed on your computer so you can begin developing. It can be even more frustrating if you're not already comfortable using a Mac or Linux system before you start, so because of that, this step is often one of the primary reasons that people give up on coding before they even start. 
+One step which can be unnecessarily frustrating is making sure everything is installed on your computer so you can begin developing. It can be even more frustrating if you're not already comfortable using a Mac or Linux system before you start, so because of that, this step is often one of the primary reasons that people give up on coding before they even start.
 
 Even so, if you're interested in being at least a half-serious web developer you *will* need to get this stuff up and running on your machine at some point and it's best to get it done early.  
 
@@ -165,11 +165,9 @@ These installfests will take you through the steps to install everything on your
      * If you get the error `The system cannot find the path specified.` when attempting to run `bundle install --without production`:
           * run `gem install bundler`
           * try `bundle install --without production` again
-     * **Note for Bash on Windows users**: As of December 2016, if you are not on the Windows Insider "Fast Ring," inotify will not work yet. This causes some gems in your rails app like listener, guard, and spring to fail.
-     * This can be worked around by commenting out the line, `config.file_watcher = ActiveSupport::EventedFileUpdateChecker` in `config/environments/development.rb`
-     * Also, RVM requires you to use the login shell (by the way you can't use RVM as root), you can access the login shell using the command `bash --login`. In order to make the login shell the default one, you can edit the Bash shortcut on Windows:
-     * Right click the Bash shortcut and click in "Properties".
-     * In the field "Target" add "--login" to the end of the path, so it should become something like this "C:\Windows\System32\bash.exe ~ --login". Click "Ok" and that's it! Next time you open the Bash (through the shortcut) it will be the login shell.
+     * **Notes for Bash on Windows users**: As of December 2016, if you are not on the Windows Insider "Fast Ring," inotify will not work yet. This causes some gems in your rails app like listener, guard, and spring to fail.
+          * This can be worked around by commenting out the line, `config.file_watcher = ActiveSupport::EventedFileUpdateChecker` in `config/environments/development.rb`
+          * if you do not receive `rvm is a function` in response to `type rvm | head -1`, after following the installfest instructions for installing rvm, type `echo 'source ~/.rvm/script/rvm' >> ~/.bashrc` then restart the Bash shell and try it again. It should work.
 2. Typing `$ ruby -v` on your command line (ignore the $, it stands for the prompt) should output something that includes `2.2` or a above.  `$ rails -v` should give you something like `5.0.0` or above.
 
 


### PR DESCRIPTION
Add a more 'linux-y' solution to the problem of using rvm on Bash on Windows and also keep the brevity and voice of the lesson consistent.
