### PR TITLE
Update RubyMonk link

### DIFF
--- a/ruby/serialization.md
+++ b/ruby/serialization.md
@@ -39,4 +39,4 @@ Finally, files and serialization overlaps in a lot of ways with the idea and pur
 
 
 * [Zetcode's section on Input/Output in Ruby](http://zetcode.com/lang/rubytutorial/io/) should be another useful perspective on the material.
-* [Ruby Monk's section on Serializing](http://rubymonk.com/learning/books/4-ruby-primer-ascent/chapters/45-more-classes/lessons/104-serializing)
+* [Ruby Monk's section on Serializing](https://web.archive.org/web/20160505174806/http://rubymonk.com/learning/books/4-ruby-primer-ascent/chapters/45-more-classes/lessons/104-serializing)


### PR DESCRIPTION
RubyMonk website is gone so link changed to use a snapshot of the page via WaybackMachine