### PR TITLE
Removed link

### DIFF
--- a/jobs_jobs_jobs/preparing_to_interview.md
+++ b/jobs_jobs_jobs/preparing_to_interview.md
@@ -61,7 +61,6 @@ You'll need to read up on a variety of things that weren't focused on in the pre
 * [Coding for Interviews: Know Thy Standard Libraries](http://blog.codingforinterviews.com/reading-code-standard-libraries/) may be a bit of overkill for a junior, but never hurts if you've got the time.
 * [Project Euler](http://projecteuler.net/) has more generic and challenging problems that must be solved efficiently (they can be very computationally intensive).
 * [Coding Bat](http://codingbat.com/) has practice questions in Java and Python.
-* [A Thinking Ape's logic problem](http://www.athinkingape.com/unlock)
 
 ### Algorithms Training:
 


### PR DESCRIPTION
The link for http://www.athinkingape.com/unlock is getting redirected to http://www.athinkingape.com/work/ which doesn't have the content that it was being linked for originally.

```
This is a PR template, If you are adding a solution link to the curriculum leave this as is. If you are not, then delete it and write the message you wish.
Thank you,
The Odin Project team.

```
