### PR TITLE
Replace typing trainer Keybr with Klavarog

### DIFF
--- a/web_development_101/gearing_up.md
+++ b/web_development_101/gearing_up.md
@@ -210,4 +210,4 @@ Without further ado, lets jump in to learning Web development.
 * [Managing Inspiration and Motivation](https://markmanson.net/do-something)
 * [Learning to code when it gets dark](https://medium.freecodecamp.com/learning-to-code-when-it-gets-dark-e485edfb58fd#.yjh0fehje)
 * [Why learning to code is so damn hard](https://www.vikingcodeschool.com/posts/why-learning-to-code-is-so-damn-hard)
-* [Improve your typing skills with Keybr](http://www.keybr.com/#!profile) Use this website if you find your typing speed is holding you back. It's a great free interactive learning tool.
+* [Improve your typing skills with Klavarog](http://klava.org) Use this keyboard trainer if you find your typing speed is holding you back. We recommend to spend 5 mins everyday after you start your PC.


### PR DESCRIPTION
At the end of the "Gear Up" page there is a link to the typing trainer **Keybr**. I checked it and compared to the one I've been using for the past 4 years (**Klavarog**) and I think this one will fit newcomers' needs a little better.
Pros:
* floating hand picture above next key of the virtual keyboard showing which finger to use — helped me a lot to remember each finger's placement during typing
* built-in texts of programming languages to train
* timer
* cleaner UI (distraction-free mode by clicking on the logo)
* no ads

Cons:
* no social features (registration, multiplayer, highscores)
* no dark layout
* a bit of Russian in the interface (the website is in English though)

Give it a [try](http://klava.org/#eng_code_js).
I think overall it's more suited for quick everyday exercises.