### PR TITLE
Removed confusing 'rake' line from Time Travel project description

### DIFF
--- a/ruby/project_testing.md
+++ b/ruby/project_testing.md
@@ -8,7 +8,7 @@ You still may feel shaky on RSpec at this point (which is totally normal), so le
 
 ### Your Task
 
-1. Go back to the [Building Blocks Project](/ruby-programming/building-blocks) and write tests for your "Caesar's Cipher" code.  It shouldn't take more than a half-dozen tests to cover all the possible cases.  Do you remember how to make your tests run using `$ rake`?
+1. Go back to the [Building Blocks Project](/ruby-programming/building-blocks) and write tests for your "Caesar's Cipher" code.  It shouldn't take more than a half-dozen tests to cover all the possible cases. 
 1. Go back to the [Advanced Building Blocks Project](/ruby-programming/advanced-building-blocks) and write tests for any 6 of the enumerable methods you wrote there.  In this case, identify several possible inputs for each of those functions and test to make sure that your implementation of them actually makes the tests pass.  Be sure to try and cover some of the odd edge cases where you can.
 2. Write tests for your [Tic Tac Toe project](/ruby-programming/oop).  In this situation, it's not quite as simple as just coming up with inputs and making sure the method returns the correct thing.  You'll need to make the tests determine victory or loss conditions are correctly assessed.
 


### PR DESCRIPTION
```
Confusing line on the time travel project in the testing section removed because it referenced the "rake" command. 

```
