### PR TITLE
Fix broken forum Categories link

### DIFF
--- a/web_development_101/join_the_odin_community.md
+++ b/web_development_101/join_the_odin_community.md
@@ -15,7 +15,7 @@ Working and collaborating with other people on a project, whether it be big or s
 
 We have chat rooms for every development topic covered by Odin and beyond. You can view all the rooms we currently have [here](https://gitter.im/orgs/TheOdinProject/rooms).
 
-We also have forum categories for introducing yourself, asking for help, working on Odin, and hanging out. You can view all the categories we have [here](https://forums.theodinproject.com/categories).
+We also have forum categories for introducing yourself, asking for help, working on Odin, and hanging out. You can view all the categories we have [here](https://forum.theodinproject.com/categories).
 
 Read on to find out how to make use of our community.
 


### PR DESCRIPTION
The "view all the categories we have" link incorrectly had the pluralized (and non-working) "forums.theodinproject.com" URL

```
This is a PR template, If you are adding a solution link to the curriculum leave this as is. If you are not, then delete it and write the message you wish.
Thank you,
The Odin Project team.

```
