### PR TITLE
Fixed broken link to CodeCademy command line track

### DIFF
--- a/web_development_101/command_line_basics.md
+++ b/web_development_101/command_line_basics.md
@@ -98,7 +98,7 @@ Note: Many of these assume you're using a Mac or a Linux environment. You can sk
 <div class="lesson-content__panel" markdown="1">
   1. To get an initial high-level overview of the command line, check out [A Command Line Crash Course](http://www.vikingcodeschool.com/web-development-basics/a-command-line-crash-course) from the Viking Code School Prep Work.
   2. To layer on a bit more depth, read through [chapter 1 of conquering the command line](http://conqueringthecommandline.com/book/basics).
-  3. (Optional) If you'd still like some more practice, complete the first 2 sections of [this interactive Codecademy course](https://www.codecademy.com/en/courses/learn-the-command-line) to get practice navigating and manipulating directories and files.
+  3. (Optional) If you'd still like some more practice, complete the first 2 sections of [this interactive Codecademy course](https://www.codecademy.com/learn/learn-the-command-line) to get practice navigating and manipulating directories and files.
 </div>
 
 ### Exercise


### PR DESCRIPTION
Corrected issue: https://github.com/TheOdinProject/curriculum/issues/7784 (broken link to CodeCademy in the Web Development 101 Command Line Basics lesson)

Thanks.

Kyle  (@jklemon17) and Paul (@PolarisTLX)

