### PR TITLE
Remove Code Schools Git Course From Assignments

### DIFF
--- a/web_development_101/git_basics.md
+++ b/web_development_101/git_basics.md
@@ -53,9 +53,7 @@ By the end of this you should be able to:
 <div class="lesson-content__panel" markdown="1">
 
   1. Complete the first interactive lesson in the Codecademy [Basic Git Workflow](https://www.codecademy.com/learn/learn-git). Try to look for an emerging pattern with the commands you are running.
-  2. Now [try Git from codeschool](https://try.github.io/levels/1/challenges/1).
-Follow the exercises up to and including "1.11 Pushing Remotely" then jump back here.
-  3. Watch this [video](https://www.youtube.com/watch?v=HVsySz-h9r4) by Corey Schafer for a great overview of some basic git commands.
+  2. Watch this [video](https://www.youtube.com/watch?v=HVsySz-h9r4) by Corey Schafer for a great overview of some basic git commands.
 
 </div>
 


### PR DESCRIPTION
Pluralsight have recently shut down Codeschool. Any links to any of Codeschool's courses redirect to Pluralsight now. This removes their Git course from the assignments of this lesson.
