### PR TITLE
Patch typo making title not recognized in markdown

### DIFF
--- a/web_development_101/project_html_css.md
+++ b/web_development_101/project_html_css.md
@@ -1,4 +1,4 @@
-﻿### Introduction
+### Introduction
 
 For this mini-project, you'll deconstruct an existing web page and rebuild it.  Don't worry if the links don't go anywhere and the search box doesn't do anything when you submit it. The goal is to start thinking about how elements get placed on the page and roughly how they get styled and aligned. For some of you, this may be the first time you've actually tried to "build" something in HTML (very exciting!).
 


### PR DESCRIPTION
A possibly invisible character made the title not appear correctly in browser (i.e. literally "### Introduction" instead of "Introduction" as a third-level title).
