### PR TITLE
Fix broken link, replace with link to forum

### DIFF
--- a/jobs_jobs_jobs/conclusion.md
+++ b/jobs_jobs_jobs/conclusion.md
@@ -1,6 +1,6 @@
 ### Final Words
 
-I hope you're reading this from your new office.  If you got a job after doing the Odin Project, [drop us a line!](/contact) We'd love to hear how everything went.  The whole reason for putting this project out there is to try and onboard more people into the web development profession and tech in general.  Hopefully your success will inspire even more people to give it a shot.
+I hope you're reading this from your new office.  If you got a job after doing the Odin Project, [drop us a line!](https://forum.theodinproject.com/) We'd love to hear how everything went.  The whole reason for putting this project out there is to try and onboard more people into the web development profession and tech in general.  Hopefully your success will inspire even more people to give it a shot.
 
 So build some kick ass software, learn as much as you can, and pay it forward when you're able.  **Thanks for participating in the project!!!**
 


### PR DESCRIPTION
The old link is broken as there is no contact page on the TOP website anymore, at least I couldn't find one. I replaced it with a link to the forums.
