### PR TITLE
Change Apple website link from http to https

### DIFF
--- a/html_css/project_backgrounds.md
+++ b/html_css/project_backgrounds.md
@@ -4,7 +4,7 @@ In this project you'll clone the website of one of the most design-forward compa
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">
-1. Go to this old version of [apple.com](http://web.archive.org/web/20140301004610/http://www.apple.com/) and have a look around.
+1. Go to this old version of [apple.com](https://web.archive.org/web/20140301004610/http://www.apple.com/) and have a look around.
 2. Follow the instructions atop the [Google Homepage project](/courses/web-development-101/lessons/html-css) to set up a Github repository for this project (of course you'll need to change the title).
 3. Create a new HTML document.
 4. Think about all the elements on the page and how they are grouped together.


### PR DESCRIPTION
By connecting to http link, it doesn't provide a proper page (connection error, missing css).
Changing the link to use https fixes the problem.