### PR TITLE
Update links to https://gitter.im

### DIFF
--- a/extra_stuff/lessons_in_progress/join_the_odin_community.md
+++ b/extra_stuff/lessons_in_progress/join_the_odin_community.md
@@ -1,8 +1,8 @@
 # Join the Odin Community
 
-Working and collaborating with other people on a project, whether it be big or small, is an important part of becoming a web developer. Therefore at Odin we encourage you to participate in our online community chat where we can all grow together towards becoming web developers. You can [sign in directly]((https://gitter.im/orgs/TheOdinProject/rooms) once you've made a GitHub account, which you will find later on, becomes an integral part of your development workflow.
+Working and collaborating with other people on a project, whether it be big or small, is an important part of becoming a web developer. Therefore at Odin we encourage you to participate in our online community chat where we can all grow together towards becoming web developers. You can [sign in directly]((https://gitter.im/TheOdinProject/home) once you've made a GitHub account, which you will find later on, becomes an integral part of your development workflow.
 
-<!-- Call to Action GITTER SIGN IN BUTTON using this link https://gitter.im/orgs/TheOdinProject/rooms -->
+<!-- Call to Action GITTER SIGN IN BUTTON using this link https://gitter.im/TheOdinProject/home -->
 
 ## Introductions: 'Hello World!'
 Jump in and introduce yourself; tell us your story! Where are you from? What made you aspire to become a web developer? What are your hopes and dreams? We encourage you to keep on sharing your thoughts AND your code.
@@ -61,4 +61,4 @@ Show us a **screenshot** if you can't pinpoint the problem - you should use this
 
 ## Lets jump right in!
 
-<!-- Call to Action GITTER SIGN IN BUTTON using this link https://gitter.im/orgs/TheOdinProject/rooms -->
+<!-- Call to Action GITTER SIGN IN BUTTON using this link https://gitter.im/TheOdinProject/home -->

--- a/web_development_101/gearing_up.md
+++ b/web_development_101/gearing_up.md
@@ -126,7 +126,7 @@ following processes to get unstuck:
 * Google it - you can be sure someone else out there has had the same problem as
 you at some point, a quick Google can often lead to a solution.
 * Take a break - allow your diffuse state to work on the problem.
-* Ask for help in one of our [chats](https://gitter.im/orgs/TheOdinProject/rooms) - come prepared
+* Ask for help in one of our [chats](https://gitter.im/TheOdinProject/home) - come prepared
 with your research done, people will be more willing to help you when they can see
 you have already put effort into trying to figure out the solution.
 

--- a/web_development_101/installfest_first_rails_app.md
+++ b/web_development_101/installfest_first_rails_app.md
@@ -524,7 +524,7 @@ First we'll open [GitHub.com](https://github.com/) in the browser and sign in (i
 
 On your `Create Repository` page you'll see various commands listed. We know that we want to use SSH to connect to GitHub so **make sure `SSH` has been selected.** Look for the section that says "... or push an existing repository from the command line" and click the icon to the right of it to copy the text to your clipboard. Then paste it into the terminal we have open (Using CTRL + SHIFT + V in Linux or CTRL + V in WSL).
 
-The terminal will start it's work, pausing to verify that you're okay connection to GitHub ('The authenticity of host 'github.com'...' will be displayed and you can safely click yes). After the terminal finishes, return to your GitHub profile and refresh the page. You should see a lot of files, starting with a folder called "app." If you do not see this in on your GitHub repository, ask for help in the [the Gitter chat room](https://gitter.im/TheOdinProject)
+The terminal will start it's work, pausing to verify that you're okay connection to GitHub ('The authenticity of host 'github.com'...' will be displayed and you can safely click yes). After the terminal finishes, return to your GitHub profile and refresh the page. You should see a lot of files, starting with a folder called "app." If you do not see this in on your GitHub repository, ask for help in the [the Gitter chat room](https://gitter.im/TheOdinProject/theodinproject)
 
 This marks the start of your Odin Journey! Later on you'll be able to look back at this repository and marvel over how far you've come!
 
@@ -692,8 +692,8 @@ heroku open
 
 and play around with it! 
 
-If you are using WSL, `heroku open` will not open automatically, but remember that link in step 4.7? If you already visited it out of excitement, just refresh the page, if you haven't copy/paste it now and have a look! If nothing shows up, come ask for help in [the Gitter chat room](https://gitter.im/TheOdinProject)
+If you are using WSL, `heroku open` will not open automatically, but remember that link in step 4.7? If you already visited it out of excitement, just refresh the page, if you haven't copy/paste it now and have a look! If nothing shows up, come ask for help in [the Gitter chat room](https://gitter.im/TheOdinProject/theodinproject)
 
 ### Step 5: Let us know how it went!
 
-You have successfully completed the installations. Congratulations! If you have any comments, or suggestions, we would love to hear them. Talk to us either in the [the Gitter chat room](https://gitter.im/TheOdinProject), or on the Odin Project forms. You can always find these links in the top right corner, under community.
+You have successfully completed the installations. Congratulations! If you have any comments, or suggestions, we would love to hear them. Talk to us either in the [the Gitter chat room](https://gitter.im/TheOdinProject/theodinproject), or on the Odin Project forms. You can always find these links in the top right corner, under community.

--- a/web_development_101/join_the_odin_community.md
+++ b/web_development_101/join_the_odin_community.md
@@ -13,7 +13,7 @@ Working and collaborating with other people on a project, whether it be big or s
 
 </div>
 
-We have chat rooms for every development topic covered by Odin and beyond. You can view all the rooms we currently have [here](https://gitter.im/orgs/TheOdinProject/rooms).
+We have chat rooms for every development topic covered by Odin and beyond. You can view all the rooms we currently have [here](https://gitter.im/TheOdinProject/home).
 
 We also have forum categories for introducing yourself, asking for help, working on Odin, and hanging out. You can view all the categories we have [here](https://forum.theodinproject.com/categories).
 
@@ -79,7 +79,7 @@ Show us a **screenshot** if you can't pinpoint the problem. This is especially u
 * Have fun with giphys: type `/giphy hi` to say hi to everyone.
 * Navigate the chatroom better by typing `/help` for more info.
 * Show your appreciation to those who have helped you on your journey with `@odin-bot ++`.
-* Don't forget about all the [available rooms](https://gitter.im/orgs/TheOdinProject/rooms) that you can join. They're categorised by development topic.
+* Don't forget about all the [available rooms](https://gitter.im/TheOdinProject/home) that you can join. They're categorised by development topic.
 
 ### Forum-specific features
 


### PR DESCRIPTION
It looks like there were some updates to gitter.im's url structure.

https://gitter.im/orgs/TheOdinProject/rooms -> https://gitter.im/TheOdinProject/home

and

https://gitter.im/TheOdinProject -> 404.

I updated all references to /room and changed https://gitter.im/TheOdinProject to point to https://gitter.im/TheOdinProject/theodinproject