### PR TITLE
Miscellaneous typopgrahical updates to the Gearing Up page.

### DIFF
--- a/web_development_101/the_basics/gearing_up.md
+++ b/web_development_101/the_basics/gearing_up.md
@@ -29,11 +29,11 @@ To give your motivation a bit of a boost you can read about the success of other
 
 * [A woman who taught herself enough to land a job in 5 months](http://newcodegirl.blogspot.co.uk)
 * [A blacksmith who taught himself how to code](http://joshuakemp.blogspot.co.uk/2013/11/how-blacksmith-learned-to-code-and-9.html)
-* [This 32 year old who taught himself programming using the odin project over the period of a year and landed a job](https://www.reddit.com/r/learnprogramming/comments/34r807/im_32_years_old_and_just_started_my_first/?)
-* [Another guy who used the odin project to get a job](https://www.reddit.com/r/learnprogramming/comments/4goiwx/i_got_hiredagain/?)
+* [This 32 year old who taught himself programming using The Odin Project over the period of a year and landed a job](https://www.reddit.com/r/learnprogramming/comments/34r807/im_32_years_old_and_just_started_my_first/?)
+* [Another guy who used The Odin Project to get a job](https://www.reddit.com/r/learnprogramming/comments/4goiwx/i_got_hiredagain/?)
 
 #### The Growth Mindset
-There is a wide body of research that supports that intelligence is not fixed, that
+There is a wide body of research that supports that intelligence is not fixed; that
 it can be developed. People usually fall into one of the following two mindsets:
 
 #### Fixed Mindset:
@@ -88,11 +88,11 @@ programming concepts and techniques actually operate.
 When learning, your mind will consistently switch between the following two states:
 
 
-#### Focus mode
+#### Focus mode:
 This state occurs when you are consciously focusing on learning, reading,
 watching videos, or working on a project.
 
-#### Diffuse mode
+#### Diffuse mode:
 This state occurs subconsciously, at times when you are not actively learning,
 such as doing the dishes, exercising, sleeping, etc. When in this state your mind
 goes about the business of connecting what you have been learning to the other
@@ -107,13 +107,13 @@ first and then take a break.
 
 In short, understand it, practice it, and finally teach it.
 
-Teaching what you know to others is a great way to solidify what you have learnt
+Teaching what you know to others is a great way to solidify what you have learned
 and can often reveal holes in your knowledge that you wouldn't have identified
 otherwise.
 
 You can practice this method of learning by helping others in our community.
 
-* To learn more about the best ways to learn, [learning how to learn on coursera](https://www.coursera.org/learn/learning-how-to-learn) is highly recommended.
+* To learn more about the best ways to learn, [learning how to learn on Coursera](https://www.coursera.org/learn/learning-how-to-learn) is highly recommended.
 
 * The Ruby Rogues have a [podcast on How to Learn](http://rubyrogues.com/131-rr-how-to-learn/) which should be motivational and useful to you, so check it out for some useful thoughts on learning.
 

--- a/web_development_101/the_basics/introduction_to_web_development.md
+++ b/web_development_101/the_basics/introduction_to_web_development.md
@@ -48,8 +48,8 @@ These are some of the basic tools you will use regularly. You may not know what 
 * **Text Editor**
 * **Command Line Interface (CLI)**
 * **[Stack Overflow](http://stackoverflow.com/)**
-* **Git**
-* **GitHub**
+* **[Git](https://git-scm.com/)**
+* **[GitHub](https://github.com/)**
 
 ### Motivation
 
@@ -96,9 +96,9 @@ And it might be life-changing too.
 ### Additional Resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something.
 
-* [How can I Become a Really Good Web Developer?](http://www.quora.com/Computer-Programming/How-can-I-become-a-really-good-Web-Developer-starting-from-now-at-age-20-before-age-25) on Quora.
+* [Quora: How can I Become a Really Good Web Developer?](http://www.quora.com/Computer-Programming/How-can-I-become-a-really-good-Web-Developer-starting-from-now-at-age-20-before-age-25)
 * [Quora: What makes a great web developer?](http://www.quora.com/What-makes-a-great-web-developer)
 * [Jared the Nerd: What makes a good web developer?](http://jaredthenerd.com/2013/05/What-Makes-A-Good-Developer/)
-* [Things I Wish Someone Had Told Me When I Was Learning How To Code](https://medium.com/learning-to-code/565fc9dcb329)
-* [Don't Believe Anyone who Tells you Learning to Code is Easy](http://techcrunch.com/2014/05/24/dont-believe-anyone-who-tells-you-learning-to-code-is-easy/): it's okay if it's really frustrating.
-* [Deliberate Programming Practice](https://codequizzes.wordpress.com/2013/04/28/deliberate-programming-practice/)
+* [Medium: Things I Wish Someone Had Told Me When I Was Learning How To Code](https://medium.com/learning-to-code/565fc9dcb329)
+* [TechCrunch: Don't Believe Anyone who Tells you Learning to Code is Easy](http://techcrunch.com/2014/05/24/dont-believe-anyone-who-tells-you-learning-to-code-is-easy/): it's okay if it's really frustrating.
+* [Code Quizzes: Deliberate Programming Practice](https://codequizzes.wordpress.com/2013/04/28/deliberate-programming-practice/)


### PR DESCRIPTION
-Title cased website names (The Odin Project, Coursera).
-Replaced a comma with semicolon in "The Growth Mindset" paragraph.
-Added colon after titles of "Focus mode" and "Diffuse mode" to match formatting with "Fixed Mindset" and "Growth Mindset" earlier.
-Changed use of "learnt" to "learned". Both are grammatically correct. However, "learnt" is not common in American English. "Learned" is common in both American and British English.