### PR TITLE
fix broken link to ruby monk

### DIFF
--- a/web_development_101/the_back_end/ruby_basics_lesson.md
+++ b/web_development_101/the_back_end/ruby_basics_lesson.md
@@ -32,7 +32,7 @@ Look through these now and then use them to test yourself after doing the assign
 <div class="lesson-content__panel" markdown="1">
   1. Read through the [Ruby in 100 Minutes](http://tutorials.jumpstartlab.com/projects/ruby_in_100_minutes.html) project from Jumpstart Lab.  If you can't get IRB running, check out the [Installations Section](https://www.theodinproject.com/courses/web-development-101/lessons/your-first-rails-application?ref=lnav), which you should have done already.
   2. Dive in a little deeper by reading chapters 1-10 of Chris Pine's [Learn to Program](http://pine.fm/LearnToProgram/?Chapter=00).  Try to do the exercises at the end of each chapter.  Take a crack at chapter 10, but don't feel disheartened if it still doesn't click for you.  Answers to the exercises are available at [learntoprogramanswers.blogspot.com](http://learntoprogramanswers.blogspot.com/)
-  3. Finally go through the first five sections of [Ruby Monks Ruby Primer book](https://rubymonk.com/learning/books/1-ruby-primer) (up to and including the Hashes in Ruby section)
+  3. Finally go through the first five sections of [Ruby Monks Ruby Primer book](https://web.archive.org/web/20170712025715/http://rubymonk.com:80/learning/books/1-ruby-primer) (up to and including the Hashes in Ruby section)
 </div>
 
 ### Bonus Assignment:


### PR DESCRIPTION
I replaced the current link with a link to the web archived version of the website, because Ruby Monk seems to be down for a few months now. This fixes #8460 .

