### PR TITLE
replaced Gitter with Discord

### DIFF
--- a/web_development_101/installations/project_your_first_rails_app.md
+++ b/web_development_101/installations/project_your_first_rails_app.md
@@ -388,7 +388,7 @@ heroku run rails db:migrate
 
 You might see some strange output, as long as you do not have an error, you have successfully deployed a rails application! 
 
-If you have an error, come to the [Gitter tech support chat room](https://gitter.im/TheOdinProject/tech_support), and ask for help, be sure to include the entire output from your terminal.
+If you have an error, come to our [chat room](https://discord.gg/5v6s6rs), and ask for help, be sure to include the entire output from your terminal.
 
 #### Step 4.9: Visit your new application
 


### PR DESCRIPTION
Hello!

I decided as a practice on learning how to use Git that I should fix a very minor thing that I noticed and reported in the Discord chat. Apparently the link was still pointing in the Gitter chat which I assume it's your old chatroom.

Feel free to fix anything as this is the first time that I'm doing this.