### PR TITLE
Remove specific ruby versioning from instructions

### DIFF
--- a/web_development_101/installations/installing_ruby.md
+++ b/web_development_101/installations/installing_ruby.md
@@ -125,8 +125,9 @@ ruby -v
 which should return ruby 2.5.3:
 
 ~~~bash
-ruby 2.5.3p57 (2018-03-29 revision 63029) [x86_64-linux]
+ruby 2.5.3pxx (20xx-xx-xx revision xxxx) [x86_64-linux]
 ~~~
+where x represents the versioning available at the time you install ruby.
 
 Well Done! Pat yourself on the back. The hard part is done! Go ahead and move on to the next lesson!
 


### PR DESCRIPTION
The current installation instructions give the specific ruby version installed. Somebody in the forums has sought feedback because their versioning doesn't match that so it would be better to be less specific and only provide a guide to what feedback they should see on the screen. Any version specific information has been replaced.
