### PR TITLE
Removed a dead link

### DIFF
--- a/getting_hired/strategy.md
+++ b/getting_hired/strategy.md
@@ -1,4 +1,4 @@
-The first step is to have a strategy.  You've come this far with a deliberate and strategic approach to learning, why abandon it at the most important phase?  Getting a job can itself be a full-time job so use your time wisely and plan ahead.  There are some things you can and should do ahead of time, which we talked about a bit in the [lesson on Getting Hired in the Introduction to Web Development course](/introduction-to-web-development/getting-hired-as-a-web-developer) but will cover in greater depth below.
+The first step is to have a strategy.  You've come this far with a deliberate and strategic approach to learning, why abandon it at the most important phase?  Getting a job can itself be a full-time job so use your time wisely and plan ahead.  There are some things you can and should do ahead of time, which we will cover in greater depth below.
 
 The path to working takes the following form:
 


### PR DESCRIPTION
Removed a dead link to "lesson on Getting Hired in the Introduction to Web Development course", the link was redirecting to 404 page.

This is a PR template. If you are adding a solution link to the curriculum, leave this as is. If not, delete it and write the message you wish.

Thank you,

The Odin Project team.
