### PR TITLE
Change link text for clarity

### DIFF
--- a/rails_programming/apis_mailers_advanced_topics/conclusion.md
+++ b/rails_programming/apis_mailers_advanced_topics/conclusion.md
@@ -64,5 +64,6 @@ This section contains helpful links to other content. It isn't required, so cons
 * [Why not to hardcode your application's secret token in production](http://daniel.fone.net.nz/blog/2013/05/20/a-better-way-to-manage-the-rails-secret-token/)
 * [How I Test by Ryan Bates](http://railscasts.com/episodes/275-how-i-test)
 * [Why use the `%Q` methods?](http://stackoverflow.com/questions/10144543/what-is-the-use-case-for-rubys-q-q-quoting-methods)
-* [Ruby on Rails Tutor](http://rubyonrailstutor.github.io/) has free videos that highlight specific sections of Rails.
+* [Build 10 Apps video series by Web-Crunch](https://www.youtube.com/watch?v=4ABesTeDKmQ&list=PL01nNIgQ4uxNkDZNMON-TrzDVNIk3cOz4)
 * [Mackenzie Child 12 apps in 12 weeks](https://medium.com/ruby-on-rails/how-i-finally-learned-rails-95e9b832675b#.mw99m5wat)
+* [Intro to API Video](https://www.youtube.com/watch?v=oBW_VNg4qD0)

--- a/rails_programming/databases_and_activerecord/active_record_basics.md
+++ b/rails_programming/databases_and_activerecord/active_record_basics.md
@@ -67,7 +67,7 @@ The best part is that Rails knows that you want to do this and has given you a h
   create      spec/models/testmodel_spec.rb
 ~~~
 
-The model file that the generator creates is just a bare-bones model file in the `app/models` directory (which you could easily have created yourself).  The other main file is the migration file in the `db/migrations` folder, which starts with a complicated looking timestamp like `20130924230504_create_users.rb`. The number is simply the time that the migration was created so that rails can keep track of different migration files. 
+The model file that the generator creates is just a bare-bones model file in the `app/models` directory (which you could easily have created yourself).  The other main file is the migration file in the `db/migrate` folder, which starts with a complicated looking timestamp like `20130924230504_create_users.rb`. The number is simply the time that the migration was created so that rails can keep track of different migration files. 
 
 If you dive into that file, you'll see that there's not much in it except another bare-bones ruby class that inherits from `ActiveRecord::Migration` and some timestamps. The timestamps just create `created_at` and `updated_at` columns for you so you can track when your database records were created or modified. These two columns are just helpful enough that they are included as standard practice.
 

--- a/rails_programming/databases_and_activerecord/active_record_basics.md
+++ b/rails_programming/databases_and_activerecord/active_record_basics.md
@@ -93,7 +93,7 @@ A final note, you never want to rollback migrations unless you've screwed someth
 
 Migrations don't involve writing SQL, but you do need to understand enough about databases to know how you want yours structured!  Which columns do you want?  Which ones should be indexed (and why)? Should you set a default value?  What data type will be stored in your column... a string or text?
 
-These are great questions, and you should feel comfortable asking them even if you aren't totally sure about the answers.  If you have no idea what I'm talking about, you'll need to go back and read up on basic databases in the [previous lesson](/courses/web-development-101/lessons/databases).
+These are great questions, and you should feel comfortable asking them even if you aren't totally sure about the answers.  If you have no idea what I'm talking about, you'll need to go back and read up on basic databases in the [SQL course](/courses/web-development-101/lessons/databases).
 
 ### Basic Validations
 

--- a/rails_programming/routes_views_controllers_assets/controller_basics.md
+++ b/rails_programming/routes_views_controllers_assets/controller_basics.md
@@ -220,4 +220,5 @@ That's really just a taste of the Rails controller, but you should have a pretty
 ### Additional Resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something.
 
+* [Controller & Routes Video Demo](https://vimeo.com/168501163)
 * [Rails 3 Rendering and Partials via YouTube](http://www.youtube.com/watch?v=m-tw2OCHPMI)


### PR DESCRIPTION
Change _previous lesson_ to _sql course_ for clarity as the link sends readers to the SQL course.