### PR TITLE
Copyedit/ruby-array-lesson

### DIFF
--- a/new_course/1_programming_fundementals/arrays.md
+++ b/new_course/1_programming_fundementals/arrays.md
@@ -1,13 +1,13 @@
 ### Introduction
 At the beginning of this section, you learned about creating and manipulating individual numbers and strings and assigning them to variables. In real-world development, where you'll be working with dozens (and even hundreds!) of variables, working with numbers and strings individually will be tedious, if not impossible.
 
-One way Ruby allows you to represent a collection of data types is with the use of **arrays**. Rather than working on individual variables, numbers, or strings at a time, an array allows you to create and manipulate an ordered and indexed collection of them (known as **elements** within the array). Think of arrays as a list! An array can contain any combination of variables, numbers, strings, or other Ruby objects (including other arrays), though it is advised that you keep similar data types in any one array.
+One way Ruby allows you to represent a collection of data types is with the use of **arrays**. Rather than working on individual variables, numbers, or strings at a time, an array allows you to create and manipulate an indexed collection of them (known as **elements** within the array). Think of arrays as a list! An array can contain any combination of variables, numbers, strings, or other Ruby objects (including other arrays).
 
 ### Learning Outcomes
 *Look through these now and then use them to test yourself after doing the assignment*
 
 * What is an array and why is it useful?
-* What are two ways to create a new empty array?
+* What are two ways to create a new, empty array?
 * What are some ways of accessing the elements in an array?
 * What are 3 ways to add data to an array?
 * How can you remove elements from an array?
@@ -56,7 +56,7 @@ str_array.first(2)      #=> ["This", "is"]
 
 ### Adding and Removing Elements
 
-Adding an element to an existing array is as simple as calling `push` or the shovel operator `<<`. Both methods will add elements to the end of an array and return that array, so the methods can be chained. The `pop` method will remove an element from the end of an array and return that element, rather than returning the array. Therefore, it cannot be chained.
+Adding an element to an existing array is as simple as calling `push` or the shovel operator `<<`. Both methods will add elements to the **end** of an array and return that array. Consequently, either method can be repeated or chained with other Array methods. On the other hand, the `pop` method will remove an element from the end of an array and return that element, rather than returning the array. Therefore, if `pop` returns an Integer or String, you will not be able to chain `pop` with another Array method.
 
 ```
 num_array = [1, 2]
@@ -67,16 +67,18 @@ num_array.push(5).push(6) #=> [1, 2, 3, 4, 5, 6]
 num_array << 7            #=> [1, 2, 3, 4, 5, 6, 7]
 
 num_array.pop             #=> 7
-num_array.pop.pop         #=> undefined method `pop' for 6:Integer
+num_array.pop.pop         #=> undefined method `pop' for 7:Integer
 ```
 
-The methods `shift` and `unshift` can also be used to operate at the beginning of an array. While `shift` will remove the first element of an array and return that element (much like `pop`), `unshift` will add elements to the beginning of an array and return that array.
+The methods `shift` and `unshift` can be used to operate at the **beginning** of an array. This may be confusing at first, but `unshift` will *add* elements to the beginning of an array and return that array, while `shift` will *remove* the first element of an array and return that element instead of the array (much like `pop`).
 
 ```
-[1, 2, 3, 4].unshift(0)   #=> [0, 1, 2, 3, 4]
+num_array = [1, 2, 3, 4]
+num_array.unshift(0)   #=> [0, 1, 2, 3, 4]
 
-[1, 2, 3, 4].shift        #=> [1]
-[1, 2, 3, 4].shift(2)     #=> [1, 2]
+num_array = [1, 2, 3, 4]
+num_array.shift        #=> 1
+num_array              #=> [2, 3, 4]
 ```
 
 ### Adding and Subtracting Arrays
@@ -104,7 +106,7 @@ Ruby gives you many methods to manipulate arrays and their contents, many of whi
 Calling the `methods` method on an array will also yield a long list of available methods, like so:
 
 ```
-num_array.methods       #=> A very long list of methods
+[1, 2].methods       #=> A very long list of methods
 ```
 
 ### Other Useful Methods
@@ -128,13 +130,12 @@ Nevertheless, here is a brief look at some other common methods you might run in
 ```
 
 ### Assignment
-* What do you think the methods `#clear`, `#insert`, `#sample`, `#shuffle`, and `#uniq` do? Look at the array class methods at ruby-doc.org [here](http://ruby-doc.org/core-2.4.0/Array.html) and look up the methods. Were you close?
+* What do you think the methods `#clear`, `#insert`, `#sample`, `#shuffle`, and `#uniq` do? Look at the array class methods at [ruby-doc.org](http://ruby-doc.org/core-2.4.0/Array.html) and look up the methods. Were you close?
 * Follow along Launch School's chapter on [Arrays](https://launchschool.com/books/ruby/read/arrays#whatisanarray), and go through the exercises using IRB or any other REPL, such as [repl.it](https://repl.it/languages/ruby).
 * Read through [Ruby Explained: Arrays](http://www.eriktrautman.com/posts/ruby-explained-arrays) by Erik Trautman.
 
-## Further Reading
+### Further Reading
 *This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something*
 
-* Look over the latest Ruby API documentation on Arrays [here](http://ruby-doc.org/) by clicking on "Core API" and searching for "Array". There, you'll find the most up-to-date documentation on the various methods available to the Array object, along with explanations.
 * If you need a different take on Arrays, give this article by [zetcode](http://zetcode.com/lang/rubytutorial/arrays/)
 * Arrays also allow for **set operations**. Read about them [here](http://blog.endpoint.com/2011/06/using-set-operators-with-ruby-arrays.html). Don't worry about the simple bookshelf example. Classes and Rails will be covered later!


### PR DESCRIPTION
## Description

* Remove advise on using consistent data types in an Array. Not a hard and fast rule, kind of implied
* Clarify method chaining
* Fix example pertaining to `#pop`
* Flip description of `#shift` & `#unshift` to match description order of `#push` & `#pop`
* Fix and clarify examples for `#shift` & `#unshift`
* Remove further reading on Array docs (already mentioned twice in lesson)
* Other minor edits