### PR TITLE
fix minor typo

### DIFF
--- a/web_development_101/installations/installing_ruby.md
+++ b/web_development_101/installations/installing_ruby.md
@@ -141,7 +141,7 @@ In your Applications folder, find "Utilities" and double click "Terminal". Alter
 
 The rest of the instructions are done inside this terminal window.
 
-#### Step 1.2: Install Xode
+#### Step 1.2: Install Xcode
 
 First, you need to install Xcode, which is a program provided by Apple for programming. Xcode will install many programs that are needed for Ruby and Git and should take 10-15 minutes to install.
 


### PR DESCRIPTION
Just spotted a minor typo ("Xode" instead of "Xcode") while going through the curriculum.
