### PR TITLE
Remove Beginning Ruby book

### DIFF
--- a/ruby_programming/intermediate_ruby/lesson_serialization.md
+++ b/ruby_programming/intermediate_ruby/lesson_serialization.md
@@ -27,9 +27,7 @@ Look through these now and then use them to test yourself after doing the assign
   2. Watch [icc0612's introduction to serialization](https://www.youtube.com/watch?v=uS37TujnLRw). It will explain the concept of serialization before you implement it in Ruby.
   3. Read [Alan Skorkin's](http://www.skorks.com/2010/04/serializing-and-deserializing-objects-with-ruby/) post about serialization. It's from 2010 so some of the code is outdated, but it's a good introduction to the subject.
   4. Read [Choosing the Right Serialization Format](https://www.sitepoint.com/choosing-right-serialization-format/) for more information about the various serialization options you can choose from.
-  5. Read [Beginning Ruby](https://www.amazon.co.uk/Beginning-Ruby-Professional-Peter-Cooper/dp/1484212797) Chapter 4: `Developing Your First Ruby Application` and follow along with the tutorial. This will be review for you but it'll set you up for the next step.
-  6. Read [Beginning Ruby](https://www.amazon.co.uk/Beginning-Ruby-Professional-Peter-Cooper/dp/1484212797) Chapter 9: `Files and Databases`.  Much of the databases stuff will be review from the Web Development 101 course and at first you won't often use the connection methods yourself (often an ORM like ActiveRecord for Rails will have that code already written for you), so feel free to skim over it but do try to see what Ruby is capable of.
-  7. Read the [Chapter on File I/O](http://ruby.bastardsbook.com/chapters/io/) of the Bastard's Book of Ruby.  Much of it will go quickly for you given what you've already read, but there are some new nuggets in there.
+  5. Read the [Chapter on File I/O](http://ruby.bastardsbook.com/chapters/io/) of the Bastard's Book of Ruby.
 </div>
 
 ### Additional Resources


### PR DESCRIPTION
As part of [this issue](https://github.com/TheOdinProject/curriculum/issues/9197), I removed the Beginning Ruby book from the lessons.