### PR TITLE
Possible typo in the Ruby event-manager project

### DIFF
--- a/ruby_programming/intermediate_ruby/project_event_manager.md
+++ b/ruby_programming/intermediate_ruby/project_event_manager.md
@@ -691,7 +691,7 @@ end
 We now have our list of attendees with their valid zip codes (at least for most
 of them). Using their zip code and the
 [Google Civic Information](https://developers.google.com/civic-information/)
-webservice we are able query for the representatives for a given area.
+webservice we are able to query for the representatives for a given area.
 
 The Civic Information API allows registered individuals (registration is free) to obtain some information about the representatives for each level of government for an address.
 


### PR DESCRIPTION
I'm not a native but the sentence "we are able query for the representatives" doesn't sound right to me. I'm pretty sure it is missing a "to".
