### PR TITLE
Remove CodeAnywhere from Online Editors

### DIFF
--- a/web_development_101/installations/installation_overview.md
+++ b/web_development_101/installations/installation_overview.md
@@ -61,6 +61,5 @@ Finally, there are a variety of online code sandboxes that can be quite handy wh
 * [Repl.it](https://repl.it/)
 * [Codepen.io](https://codepen.io/)
 * [JSFiddle.net](https://jsfiddle.net/)
-* [codeanywhere.com](https://codeanywhere.com/)
 
 These sites can be used to complete small exercises or to sketch out a concept you don't quite understand. However, you shouldn't use these sites as your main development environment.


### PR DESCRIPTION
Remove CodeAnywhere from Online IDE recommendations as they've moved to a 7 day trial only instead of unlimited free offering.
