### PR TITLE
Show body of successful RestClient query

### DIFF
--- a/rails_programming/apis_mailers_advanced_topics/project_apis.md
+++ b/rails_programming/apis_mailers_advanced_topics/project_apis.md
@@ -79,7 +79,7 @@ Now it's time to make the Kittens resource available via API.
 2. You should get a sloppy mess of HTML.  If you check out your server output, it's probably processing as XML, e.g. `Processing by KittensController#index as XML`
 3. Try asking specifically for a JSON response by adding the option `:accept => :json`, e.g. `RestClient.get("http://localhost:3000/kittens", :accept => :json)`.  It should throw an error.
 4. Now modify your KittenController's `#index` method to `#respond_to` JSON and render the proper variables.
-5. Test it out by making sure your RestClient calls return the proper JSON strings.
+5. Test it out by making sure your RestClient calls return the proper JSON strings, e.g. `$ r = RestClient.get("http://localhost:3000/kittens", :accept => :json)`, `$ puts r.body`.
 6. Do the same for your `#show` method, which will require you to provide an ID when making your request.  Your CSRF protection will prevent you from creating, updating or deleting kittens via the API, so it's not necessary to implement those.
 
 This project may seem simple, but now you've got a website that is both a normal HTML-producing back end AND an API that can be used to pull data from it.  You could use Javascript calls from the front end to dynamically refresh your data now or even to load the whole page in the first place.  Or maybe you'll be hooking up a Kittens app to your iPhone and need a back end.  It doesn't matter, since now you've got a RESTful API.


### PR DESCRIPTION
The Kittens project does not specify how to view the entire body of the JSON request. If the project example irb commands are followed, only a truncated response will be shown.

SOLUTION: Add example (in this pull request) to specify how to show the request response body in full:
`$ r = RestClient.get("http://localhost:3000/kittens", :accept => :json)`
`$ puts r.body`
