### PR TITLE
fixed broken link in Web Dev 101 Ruby Basics

### DIFF
--- a/web_development_101/the_back_end/ruby_basics_lesson.md
+++ b/web_development_101/the_back_end/ruby_basics_lesson.md
@@ -52,7 +52,7 @@ Look through these now and then use them to test yourself after doing the assign
 ### Additional Resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something.
 
-* Read [Smashing Magazine's Intro to Ruby article](https://hackhands.com/beginners-guide-ruby/) for another good beginner-level treatment of the language as a whole.
+* Read [Smashing Magazine's Intro to Ruby article](https://www.smashingmagazine.com/2012/05/beginners-guide-ruby/) for another good beginner-level treatment of the language as a whole.
 * [Ruby on Rails tutor has free videos that include Ruby](http://rubyonrailstutor.github.io/)
 * [OverAPI's (dense) Ruby Cheat Sheet](http://overapi.com/ruby)
 * Hunter Ducharme compiled together [an e-book](http://hgducharme.gitbooks.io/ruby-programming/) which covers all the basics in Ruby.


### PR DESCRIPTION
The link to Marc Gayle's article on Ruby was broken as HackHands.com has been shut down (redirects to Pluralsight). I've updated the link to point to the original article source at Smashing Magazine.
