### PR TITLE
Update Ruby installaion link to correct lesson

### DIFF
--- a/web_development_101/the_back_end/introduction_to_the_backend_lesson.md
+++ b/web_development_101/the_back_end/introduction_to_the_backend_lesson.md
@@ -19,7 +19,7 @@ As we covered back in the [Installations section](https://www.theodinproject.com
 
   1. Check out [this blog post on back end vs front end programming](http://blog.teamtreehouse.com/i-dont-speak-your-language-frontend-vs-backend) for a quick refresher on the difference between the two.
   2. Read over [this quick interview with Matt Jording](https://generalassemb.ly/blog/what-is-back-end-web-development/) about what back end web development is.
-  3. Type `$ ruby -v` and `$ rails -v` into your command line (remember, the `$` just represents the command prompt).  You should get back versions similar to `2.0.0` or above and `5.0.0` or above. If you didn't get those values, you'll need to go back to the [Installations Unit](https://www.theodinproject.com/courses/web-development-101/lessons/your-first-rails-application) and get everything installed properly.  
+  3. Type `$ ruby -v` and `$ rails -v` into your command line (remember, the `$` just represents the command prompt).  You should get back versions similar to `2.0.0` or above and `5.0.0` or above. If you didn't get those values, you'll need to go back to the [Installing Ruby Unit](https://www.theodinproject.com/courses/web-development-101/lessons/installing-ruby) and get everything installed properly.  
   4. You should also be able to use `$ which git` and see the directory where you installed Git.
 
 </div>


### PR DESCRIPTION
Update ruby installtion hyperlink to redirect to Installing ruby unit instead of Installation Unit lesson in introduction_to_the_backend_lesson.md
