### PR TITLE
Fix typo by changing 'by' to 'when'

### DIFF
--- a/rails_programming/forms_and_authentication/project_auth.md
+++ b/rails_programming/forms_and_authentication/project_auth.md
@@ -24,7 +24,7 @@ In this project, you'll be building an exclusive clubhouse where your members ca
 
 This will be a chance for you to "roll your own" authentication system, very similar to how you did in the tutorial.  As usual, we will be focusing on data and function, not style.  If you want to add your own stylistic flourishes, consider it extra credit.
 
-It's easy to feel a bit overwhelmed by building your own authentication.  That's because there are several moving parts -- the session controller/form, hanging onto and refreshing the remember token when necessary, and using that token to check up on the current user.  It may help if you write out the steps as you understand them prior to getting started, so you know what you're shaky on and will need to pay attention to.
+It's easy to feel a bit overwhelmed when building your own authentication.  That's because there are several moving parts -- the session controller/form, hanging onto and refreshing the remember token when necessary, and using that token to check up on the current user.  It may help if you write out the steps as you understand them prior to getting started, so you know what you're shaky on and will need to pay attention to.
 
 ### Your Task
 


### PR DESCRIPTION
I fixed a typo in the rails authentication "Members Only!" project section.