### PR TITLE
Update legislators_by_zipcode method

### DIFF
--- a/ruby_programming/intermediate_ruby/project_event_manager.md
+++ b/ruby_programming/intermediate_ruby/project_event_manager.md
@@ -949,7 +949,7 @@ def clean_zipcode(zipcode)
   zipcode.to_s.rjust(5,"0")[0..4]
 end
 
-def legislators_by_zipcode(zip)
+def legislators_by_zipcode(zipcode)
   civic_info = Google::Apis::CivicinfoV2::CivicInfoService.new
   civic_info.key = 'AIzaSyClRzDqDh5MsXwnCWi0kOiiBivP6JsSyBw'
 


### PR DESCRIPTION
Line 952: def legislators_by_zipcode(zip) -> def legislators_by_zipcode(zipcode)

I noticed that "zip" returned the string under rescue instead of the legislators (for all of them). "zipcode" returns each legislator as I suppose it should.

(Great exercise btw!)
