### PR TITLE
Remove deprecated sections/web pages and Update Device Mode

### DIFF
--- a/web_development_101/javascript_basics/developer_tools_2.md
+++ b/web_development_101/javascript_basics/developer_tools_2.md
@@ -18,8 +18,7 @@ There are three ways to open the Developer Tools menu:
 1. Head to the [Chrome DevTools Documentation](https://developers.google.com/web/tools/chrome-devtools/) by Google. The following subsections cover what you'll be using the Developer Tools for 95% of the time.  Feel free to skip the elements you are already familiar with (i.e. the Elements Panel):
     - Open DevTools
     - Device Mode
-        1. Device Mode
-        2. Test Responsive and Device-specific Viewports
+        1. Device Mode (Simulate Mobile Devices with Device Mode)
     - Elements panel
         1. Get Started With Viewing and Changing CSS
         2. Inspect and Tweak Your Pages


### PR DESCRIPTION
In the Device Mode section, the two sub-sections; "Test Responsive and Device-specific Viewports" and "Emulate Sensors: Geolocation & Accelerometer" web pages are now deprecated.  Those two web pages in addition to the main "device mode" link are now all combined into one whole web page titled "Simulate Mobile Devices with Device Mode in Chrome DevTools".  

Here are the deprecated pages for reference
https://developers.google.com/web/tools/chrome-devtools/device-mode/emulate-mobile-viewports
https://developers.google.com/web/tools/chrome-devtools/device-mode/device-input-and-sensors

Here is the web page which merged all 3 sections into one.
https://developers.google.com/web/tools/chrome-devtools/device-mode/