### PR TITLE
Remove unnecessary git subcommand

### DIFF
--- a/web_development_101/installations/project_your_first_rails_app.md
+++ b/web_development_101/installations/project_your_first_rails_app.md
@@ -208,7 +208,7 @@ heroku create
 Then, run
 
 ~~~bash
-git remote show
+git remote
 ~~~
 
 Verify that you see `heroku` in the output.


### PR DESCRIPTION
Thank you for this awesome project. I've started following the tutorials and they are great.

While following [Web Development 101 - PROJECT: YOUR FIRST RAILS APPLICATION - Step 3.4: Create a Heroku Application](https://github.com/TheOdinProject/curriculum/blob/master/web_development_101/installations/project_your_first_rails_app.md#step-34-create-a-heroku-application) I found it was confusing to use `git remote show` to list the remotes.

The git command `remote`, when used with no arguments, shows a list of existing remotes:

https://git-scm.com/docs/git-remote#_commands

The `show` subcommand is not necessary and might be confusing to use it as it is used to give information about a given remote, i.e.,  `git remote show heroku`:

https://git-scm.com/docs/git-remote#Documentation/git-remote.txt-emshowem

As all the information that is needed is the list of remotes to check if `heroku` is there, the command should be `git remote`.