### PR TITLE
Fix typos

### DIFF
--- a/javascript/frameworks/vue.md
+++ b/javascript/frameworks/vue.md
@@ -21,7 +21,7 @@ For complete Vue projects you can use the [vue-cli](https://github.com/vuejs/vue
 
 ### Assignment
 
-1. Read the 'Getting started' in the [offial vue doc](https://vuejs.org/v2/guide/index.html#Getting-Started), specially check out the "declarative rendering" section and try it out in jsfiddle of codepen.
+1. Read the 'Getting started' in the [official Vue doc](https://vuejs.org/v2/guide/index.html#Getting-Started), specially check out the "declarative rendering" section and try it out in JSFiddle or CodePen.
 2. Check out this awesome complete getting started blog guide [here](https://www.sitepoint.com/up-and-running-vue-js-2-0/). Read the first three section including "Writing Our First Vue.js 2.0 App" and follow along to see how easy it is, and if you find it nice I definitely recommend reading the whole thing.
 
 ### Additional Resources


### PR DESCRIPTION
Fixed the typo by changing _'of'_ to _'or'_.
Also fixed the capitalization of the words _'vue', 'jsfiddle'_ and _'codepen'_.