### PR TITLE
Fix unordered list of Learning Outcomes

### DIFF
--- a/nodeJS/express-basics/Express-Lesson-3.md
+++ b/nodeJS/express-basics/Express-Lesson-3.md
@@ -4,6 +4,7 @@ If you remember from our earlier lessons, a controller is, as you'll see the cod
 
 ### Learning Outcomes
 By the end of this lesson, you should be able to do the following:
+
 - Create simple routes.
 - Create route-handler callback functions.
 - Create catalog route module.

--- a/nodeJS/express-basics/Express-Lesson-4.md
+++ b/nodeJS/express-basics/Express-Lesson-4.md
@@ -2,6 +2,7 @@ This lesson is fun! You'll be setting up several views, and you'll start to see 
 
 ### Learning Outcomes
 By the end of this lesson, you should be able to do the following:
+
 - Describe asynchronous functions.
 - Manage asynchronous operations in controller functions.
 - Manage flow control when using asynchronous operations.

--- a/nodeJS/express-basics/Express-Lesson-5.md
+++ b/nodeJS/express-basics/Express-Lesson-5.md
@@ -6,6 +6,7 @@ This is the last lesson on the MDN tutorial. The last step, listed below takes y
 
 ### Learning Outcomes
 By the end of this lesson, you should be able to do the following:
+
 - Describe form handling process.
 - Describe validation and sanitization.
 - Describe routes.


### PR DESCRIPTION
The list is not rendering properly in the website.

https://www.theodinproject.com/courses/nodejs/lessons/express-103-routes-and-controllers
https://www.theodinproject.com/courses/nodejs/lessons/express-104-view-templates
https://www.theodinproject.com/courses/nodejs/lessons/express-105-forms-and-deployment

I looked at lessons 101 and 102 to figure out why.
Markdown:
<img src="https://user-images.githubusercontent.com/17718201/61271031-a8954580-a7cd-11e9-9996-4a474047aee9.png" width="500">
<img src="https://user-images.githubusercontent.com/17718201/61271000-826fa580-a7cd-11e9-95ed-fc6e823f76b6.png" width="400">
