### PR TITLE
Adds an example for command generating SSH key.

### DIFF
--- a/web_development_101/installations/setting_up_git.md
+++ b/web_development_101/installations/setting_up_git.md
@@ -95,7 +95,7 @@ If the message in the console contains `No such file or directory`, then you don
 To create a new SSH key, run the following command inside your terminal. The `-C` flag followed by our email address ensures that GitHub knows who we are.
 
 ~~~bash
-ssh-keygen -C youremail
+ssh-keygen -C <youremail>
 ~~~
 
 For example: `ssh-keygen -C youremail@email.com`

--- a/web_development_101/installations/setting_up_git.md
+++ b/web_development_101/installations/setting_up_git.md
@@ -95,8 +95,10 @@ If the message in the console contains `No such file or directory`, then you don
 To create a new SSH key, run the following command inside your terminal. The `-C` flag followed by our email address ensures that GitHub knows who we are.
 
 ~~~bash
-ssh-keygen -C <youremail>
+ssh-keygen -C youremail
 ~~~
+
+For example: `ssh-keygen -C youremail@email.com`
 
 * When it prompts you for a location to save the generated key, just push `Enter`.
 * Next, it will ask you for a password; enter one if you wish, but it's not required.

--- a/web_development_101/installations/setting_up_git.md
+++ b/web_development_101/installations/setting_up_git.md
@@ -92,13 +92,13 @@ ls ~/.ssh/id_rsa.pub
 
 If the message in the console contains `No such file or directory`, then you don't have an SSH key, and you'll need to create one. If you do not see `No such file or directory` in the output, you already have a key; proceed to step 2.4.
 
-To create a new SSH key, run the following command inside your terminal. The `-C` flag followed by our email address ensures that GitHub knows who we are. 
+To create a new SSH key, run the following command inside your terminal. The `-C` flag followed by your email address ensures that GitHub knows who you are. 
+
+**Note:** The angle brackets (`< >`) in the code snippet below indicate that you should replace that part of the command with the appropriate information. Do not include the brackets themselves in your command. For example, if your email address is `odin@valhalla.com`, then you would type `ssh-keygen -C odin@valhalla.com`. You will see this convention of using angle brackets to indicate placeholder text used throughout The Odin Project's curriculum and other coding websites, so it's good to be familiar with what it means.
 
 ~~~bash
 ssh-keygen -C <youremail>
 ~~~
-
-Be aware that angle brackets ( `< >`) indicate that you should replace that part of the command with the appropriate information. Do not include the brackets themselves in the command line. For example: `ssh-keygen -C youremail@email.com`
 
 * When it prompts you for a location to save the generated key, just push `Enter`.
 * Next, it will ask you for a password; enter one if you wish, but it's not required.

--- a/web_development_101/installations/setting_up_git.md
+++ b/web_development_101/installations/setting_up_git.md
@@ -92,13 +92,13 @@ ls ~/.ssh/id_rsa.pub
 
 If the message in the console contains `No such file or directory`, then you don't have an SSH key, and you'll need to create one. If you do not see `No such file or directory` in the output, you already have a key; proceed to step 2.4.
 
-To create a new SSH key, run the following command inside your terminal. The `-C` flag followed by our email address ensures that GitHub knows who we are.
+To create a new SSH key, run the following command inside your terminal. The `-C` flag followed by our email address ensures that GitHub knows who we are. 
 
 ~~~bash
 ssh-keygen -C <youremail>
 ~~~
 
-For example: `ssh-keygen -C youremail@email.com`
+Be aware that angle brackets ( `< >`) indicate that you should replace that part of the command with the appropriate information. Do not include the brackets themselves in the command line. For example: `ssh-keygen -C youremail@email.com`
 
 * When it prompts you for a location to save the generated key, just push `Enter`.
 * Next, it will ask you for a password; enter one if you wish, but it's not required.


### PR DESCRIPTION
I removed the < > from the SSH generation command and added an example. I've noticed plenty of folks get tripped up on this step.  Hopefully this will help. 