### PR TITLE
Changes to DOM Enlightenment links and text

### DIFF
--- a/web_development_101/javascript_basics/DOM-manipulation.md
+++ b/web_development_101/javascript_basics/DOM-manipulation.md
@@ -210,7 +210,7 @@ div.setAttribute('style', 'color: blue; background: white');
 // adds several style rules
 ~~~
 
-See DOM Enlightenment's [section on CSS Style rules](http://domenlightenment.com/#6.2) for more info on inline styles.
+See [Chapter 6 - Element Node Inline Styles](http://domenlightenment.com/#chapter6) of DOM Enlightenment for more info on inline styles.
 
 Generally style rules are the same as in CSS with the exception that hyphenated rules are changed to camelCase. I.E. "background-color" becomes "backgroundColor".
 


### PR DESCRIPTION
The original para reads as follows:

> See DOM Enlightenment’s section on CSS Style rules for more info on inline styles.

This sentence becomes problematic as it does not refer to where this section is in the book. There is only one chapter and title in the book which contains the term "CSS Style" (_Chapter 9 - CSS Style Sheets & CSS rules_) however this is not the correct chapter that the course material refers to. 

The correct chapter is in fact _Chapter 6 - Element Node Inline Styles_.

The change involves:
1. Stating which chapter is to be used, in case the book's formatting changes;
2. Changing the hyperlink to an anchor link for Chapter 6.

This is a PR template. If you are adding a solution link to the curriculum, leave this as is. If not, delete it and write the message you wish.

Thank you,

The Odin Project team.
