### PR TITLE
replaces a dead link with another relevant link

### DIFF
--- a/rails_programming/advanced_forms_and_activerecord/active_record_associations.md
+++ b/rails_programming/advanced_forms_and_activerecord/active_record_associations.md
@@ -245,7 +245,8 @@ In this lesson we covered some of the more advanced associations material.  Asso
 This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something.
 
 * [Brush up Your Knowledge of Rails Associations](https://www.sitepoint.com/brush-up-your-knowledge-of-rails-associations/)
-* [An example of polymorphic associations](http://www.xyzpub.com/en/ruby-on-rails/3.2/activerecord_polymorphic.html)
+* [Rails' Polymorphic Associations](https://dev.to/adjoa/rails-polymorphic-associations-511n)
+* [Understanding Polymorphic Associations in Rails](https://launchschool.com/blog/understanding-polymorphic-associations-in-rails)
 * [RailsCasts #154 Polymorphic Association](http://railscasts.com/episodes/154-polymorphic-association-revised)
 * [Comments with Polymorphic Associations](https://gorails.com/episodes/comments-with-polymorphic-associations)
 * [RailsCasts Pro #394 STI and Polymorphic Associations](http://railscasts.com/episodes/394-sti-and-polymorphic-associations)

--- a/rails_programming/advanced_forms_and_activerecord/active_record_associations.md
+++ b/rails_programming/advanced_forms_and_activerecord/active_record_associations.md
@@ -245,7 +245,7 @@ In this lesson we covered some of the more advanced associations material.  Asso
 This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something.
 
 * [Brush up Your Knowledge of Rails Associations](https://www.sitepoint.com/brush-up-your-knowledge-of-rails-associations/)
-* [An example of polymorphic associations](http://terenceponce.github.io/blog/2012/03/02/polymorphic-associations-in-rails-32/)
+* [An example of polymorphic associations](http://www.xyzpub.com/en/ruby-on-rails/3.2/activerecord_polymorphic.html)
 * [RailsCasts #154 Polymorphic Association](http://railscasts.com/episodes/154-polymorphic-association-revised)
 * [Comments with Polymorphic Associations](https://gorails.com/episodes/comments-with-polymorphic-associations)
 * [RailsCasts Pro #394 STI and Polymorphic Associations](http://railscasts.com/episodes/394-sti-and-polymorphic-associations)


### PR DESCRIPTION
The former link "http://terenceponce.github.io/blog/2012/03/02/polymorphic-associations-in-rails-32/" responds with 404. So I looked for another resource on the topic "Polymorphic Association" and replaced it.