### PR TITLE
Update unstable link to use the original source

### DIFF
--- a/html_css/design_ux.md
+++ b/html_css/design_ux.md
@@ -25,9 +25,9 @@ Remember that your goal here is to absorb the most important concepts and contin
 
 <div class="lesson-content__panel" markdown="1">
 1. Read [Startups, This is How Design Works](http://startupsthisishowdesignworks.com/)
-2. Read [UX 101 -- What is User Experience from homestead.com](https://www.homestead.com/blog/06/2013/ux-101-what-user-experience-infographic)
-3. Get [A more detailed look at what UX really is from Smashing Magazine](http://uxdesign.smashingmagazine.com/2010/10/05/what-is-user-experience-design-overview-tools-and-resources/).  Don't worry about absorbing all the tools and techniques... focus on the high level stuff at the top.
-4. Read [A very simple overview of Visual Hierarchy from 52weeksofUX](http://52weeksofux.com/post/443828775/visual-hierarchy)
+2. Read [UX 101 -- What is User Experience](https://www.homestead.com/blog/06/2013/ux-101-what-user-experience-infographic)
+3. Get [a more detailed look at what UX really is from Smashing Magazine](http://uxdesign.smashingmagazine.com/2010/10/05/what-is-user-experience-design-overview-tools-and-resources/).  Don't worry about absorbing all the tools and techniques... focus on the high level stuff at the top.
+4. Read [a very simple overview of Visual Hierarchy from 52weeksofUX](http://52weeksofux.com/post/443828775/visual-hierarchy)
 5. Read about the [C.R.A.P Design Principles](http://www.presentationzen.com/chapter6_spread.pdf), which you've been subconsciously aware of for years.
 </div>
 

--- a/html_css/design_ux.md
+++ b/html_css/design_ux.md
@@ -25,7 +25,7 @@ Remember that your goal here is to absorb the most important concepts and contin
 
 <div class="lesson-content__panel" markdown="1">
 1. Read [Startups, This is How Design Works](http://startupsthisishowdesignworks.com/)
-2. Read [UX 101 -- What is User Experience from Dashburst.com](https://blog.dashburst.com/infographic/ux-101-what-is-user-experience/)
+2. Read [UX 101 -- What is User Experience from homestead.com](https://www.homestead.com/blog/06/2013/ux-101-what-user-experience-infographic)
 3. Get [A more detailed look at what UX really is from Smashing Magazine](http://uxdesign.smashingmagazine.com/2010/10/05/what-is-user-experience-design-overview-tools-and-resources/).  Don't worry about absorbing all the tools and techniques... focus on the high level stuff at the top.
 4. Read [A very simple overview of Visual Hierarchy from 52weeksofUX](http://52weeksofux.com/post/443828775/visual-hierarchy)
 5. Read about the [C.R.A.P Design Principles](http://www.presentationzen.com/chapter6_spread.pdf), which you've been subconsciously aware of for years.


### PR DESCRIPTION
On [html_css/design_ux.md](https://github.com/TheOdinProject/curriculum/blob/master/html_css/design_ux.md) there is a link to this resource:

https://blog.dashburst.com/infographic/ux-101-what-is-user-experience/

But that link more often than not produces an `Error establishing a database connection`.

I could access the page using Google cache:

https://webcache.googleusercontent.com/search?q=cache:NvYcYL1eOCEJ:https://blog.dashburst.com/infographic/ux-101-what-is-user-experience/

At the end of the page is the source to the original publication, by homestead.com, which is working fine:

https://www.homestead.com/blog/06/2013/ux-101-what-user-experience-infographic

This pull request updates the broken link to point to the original source of the infographic.
