### PR TITLE
Update Flickr REST API Endpoint

### DIFF
--- a/rails_programming/apis_mailers_advanced_topics/project_apis.md
+++ b/rails_programming/apis_mailers_advanced_topics/project_apis.md
@@ -7,7 +7,7 @@ In this warmup, you'll get a chance to poke around with an existing API from Fli
 <div class="lesson-content__panel" markdown="1">
 1. Head over to the [Flickr API Documentation Page](http://www.flickr.com/services/api/).  You can just google `XYZ API docs` to locate these pages, which is usually much faster and easier than trying to find them by navigating the websites themselves.
 2. Look around at the different methods available.  They have a couple of different request formats, but check out the RESTful API format by clicking on the link on the left under "Request Formats" called [Rest](http://www.flickr.com/services/api/request.rest.html).
-3. This shows you the format that a typical API call would take -- you will make your request to the endpoint at `http://api.flickr.com/services/rest/` and include any required data in the GET query string or the POST body.
+3. This shows you the format that a typical API call would take -- you will make your request to the endpoint at `http://www.flickr.com/services/rest/` and include any required data in the GET query string or the POST body.
 4. Look around at the various methods.  How would you upload a photo?  How about getting your contacts list?  Lots of these methods will require you to authenticate your application or user account first.
 5. Check out the [Search method docs](http://www.flickr.com/services/api/flickr.photos.search.html).  This request doesn't require you to authenticate, just provide an API key (which you would get by registering as a developer on their platform).  Browse through all the arguments that can be used.
 6. If you go to the bottom of the Search docs, you'll see a link to the [Search API Explorer](http://www.flickr.com/services/api/explore/flickr.photos.search).  This tool lets you actually execute requests using Flickr's API key for illustrative purposes.  You just enter the options you want and it will make the request for you.  Try entering "puppies" under the "tags" argument, then scroll to the bottom.  Change the response "Output" dropdown to JSON then click "Call Method".
@@ -20,7 +20,7 @@ In this warmup, you'll get a chance to poke around with an existing API from Fli
    More interestingly, you can see the URL they used to make the request below that.  I've broken it apart here to show the parameters more clearly:
 
    ~~~bash
-   http://api.flickr.com/services/rest/
+   http://www.flickr.com/services/rest/
    ?method=flickr.photos.search
    &api_key=e0eb58bf4b3e29b253e86d6092e69dee
    &tags=puppies


### PR DESCRIPTION
The Flickr endpoint changed. As you can see [here](https://www.flickr.com/services/api/request.rest.html) the subdomain is no longer "api" and instead is now the normal "www".