### PR TITLE
Fix another typo

### DIFF
--- a/ruby_programming/intermediate_ruby/project_event_manager.md
+++ b/ruby_programming/intermediate_ruby/project_event_manager.md
@@ -1461,7 +1461,7 @@ contents.each do |row|
 end
 ~~~
 
-The method `save_thank_you_letter` requires the id of the attendee and the form letter
+The method `save_thank_you_letters` requires the id of the attendee and the form letter
 output.
 
 ## Iteration: Clean Phone Numbers


### PR DESCRIPTION
Example code's method `save_thank_you_letters` is referenced in the explaining text as `save_thank_you_letter` (without an 's' in the end).