### PR TITLE
reorder conditionals flow so that student has knowledge of conditiona…

### DIFF
--- a/web_development_101/javascript_basics/fundamentals-2.md
+++ b/web_development_101/javascript_basics/fundamentals-2.md
@@ -35,11 +35,12 @@ Depending on what kind of work you're doing, you might end up working more with 
 
 Now it's time for the fun stuff...  So far we haven't done much with our programming that you couldn't do with simple math skills.  Sure, we've told our computer how to do the math, so that makes it quicker, but the essence of programming is teaching the computer how to make decisions in order to do more involved things.  Conditionals are how we do that.
 
-1. Step one in learning about conditionals is making sure you have a good grasp on [comparisons](http://javascript.info/comparison) and [logical operators](http://javascript.info/logical-operators).
+1. Step one in learning about conditionals is making sure you have a good grasp on [comparisons](http://javascript.info/comparison).
 2. [This tutorial](https://www.w3schools.com/js/js_if_else.asp) is a great first glance at conditionals in JavaScript.
-3. [This article](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/conditionals) reinforces the concept and provides several interesting examples of how you could use it building websites.
-4. [This article](http://javascript.info/ifelse) covers the same basic concept \(read through it as a review!\) And more importantly offers the usual 'tasks' at the bottom of the page!
-5. [This tutorial](https://www.digitalocean.com/community/tutorials/how-to-use-the-switch-statement-in-javascript) teaches you about the `switch` statement, which comes in handy when you have multiple conditions.
+3. [This tutorial](http://javascript.info/logical-operators) will teach you about logical operators.
+4. [This article](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/conditionals) reinforces the concept and provides several interesting examples of how you could use it building websites.
+5. [This article](http://javascript.info/ifelse) covers the same basic concept \(read through it as a review!\) And more importantly offers the usual 'tasks' at the bottom of the page!
+6. [This tutorial](https://www.digitalocean.com/community/tutorials/how-to-use-the-switch-statement-in-javascript) teaches you about the `switch` statement, which comes in handy when you have multiple conditions.
 
 ### Practice
 


### PR DESCRIPTION
…ls prior to logical operators

(below is the copy of a previous pull request that I closed. I had to do it this way because this pull request was previously pending, and I needed to create a new pull request. I could not do it because I didn't have branches set up at the time. I'm sure there was probably a better way, but the only way I could figure out how to created 2 pull requests at the same time was to delete the old one, create branches, and resubmit it.)

In the current Fundamentals Part 2 lesson in JavaScript Basics, the student encounters a lesson about logical operators before learning about conditionals (the lesson about conditionals is listed directly below the logical operators lesson.) But the logical operators lesson requires knowledge of conditionals to complete the exercises on the page. (knowledge of [if, else, etc...] is required, but not included in any lesson previously.)

I discovered this when completing the lesson. I was eventually able to learn on my own and finish the final exercise on the logical operators page, but it would have certainly been much less difficult, not to mention confusing, if the lesson that taught me about conditionals took place prior to, and not after, I needed knowledge of them.

I did my best to reorder the lessons in a way that made sense. But feel free to change the wording and structure to whatever works best, but I do believe the lesson about conditionals should be included before the lesson on logical operators.
