### PR TITLE
Update new repo setup instructions

### DIFF
--- a/web_development_101/the_front_end/project_html_css.md
+++ b/web_development_101/the_front_end/project_html_css.md
@@ -26,7 +26,7 @@ If you do not know how to setup a repository, follow the instructions found in [
 
 1. If you haven't already, create a folder on your computer called `the_odin_project` and `cd` into it. This folder will house all the projects you do at Odin.
 2. Create a new repo for this project on GitHub.com and call it `google-homepage` (instead of `git-test`).
-3. Then move that repository onto your local machine. The command should look like: `git clone https://github.com/YourUserName/google-homepage`
+3. Then move that repository onto your local machine. The command should look like: `git clone git@github.com:username/google-homepage.git` (use SSH)
 4. Now `cd` into the `google-homepage` project directory that is now on your local machine; setup your `README.md` file and write a brief introduction for what the current project is and what skills you have demonstrated once you have completed it. (You can do this as a self-reflection at the end of the project which is a good way to review what you have learned.)
 5. If you want to share this project, include a link in the `README.md` file - it can look something like this: `From The Odin Project's [curriculum](http://www.theodinproject.com/courses/web-development-101/lessons/html-css)`
 


### PR DESCRIPTION
In the instructions, you're right now telling the user to clone the https link from git (git clone https://github.com/YourUserName/google-homepage). If the user does this, they'll have to enter user/password in their console everytime they make a commit. This happened to me. Therefore I suggest to tell the user to git clone the SSH link instead (see edit).