### PR TITLE
Removed Screenhero

### DIFF
--- a/web_development_101/pair_programming/prepare_to_remote_pair.md
+++ b/web_development_101/pair_programming/prepare_to_remote_pair.md
@@ -3,7 +3,6 @@
 As you learned in the last lesson, pairing in person is the best option, but if that isn't a viable solution, we have many options for pairing remotely. To get underway, you will need a way to share a screen and a way to communicate:
 
 * Screen Sharing Options. There may be more, but these are a few of the most popular:
-  * [Screenhero](https://screenhero.com/) is a popular option, but as of December 2016 it is not open to new accounts while they are integrating with [Slack](https://slack.com/) but if you both already have Screenhero accounts, by all means use it.
   * If you both are using Macs, you can use its [built in screen sharing app](https://support.apple.com/kb/PH18686).
   * The Odin Project currently recommends [Cloud 9](https://c9.io). It's free, doesn't need to be installed, and it is easy to share your screen.
 * Communication Options. You can always text chat, but for true Pair Programming, you will need voice communication. The Odin Project does not have a preference, just find one that works for you and your partner:


### PR DESCRIPTION
Screenhero has been bought by slack. Clicking the link now redirects to the slack video conferencing page.

This is a PR template. If you are adding a solution link to the curriculum, leave this as is. If not, delete it and write the message you wish.

Thank you,

The Odin Project team.
