### PR TITLE
Fix the broken SDK link in the project description

### DIFF
--- a/rails_programming/advanced_forms_and_activerecord/project_forms_advanced.md
+++ b/rails_programming/advanced_forms_and_activerecord/project_forms_advanced.md
@@ -9,7 +9,7 @@ A typical airline booking flow:
 3. Enter passenger information for all passengers
 4. Enter billing information
 
-Step 4 would be done via integration of something like [Paypal](http://coding.smashingmagazine.com/2011/09/05/getting-started-with-the-paypal-api/), via [a gem](https://github.com/nov/paypal-express) or [an SDK](http://www.tommyblue.it/2013/07/03/paypal-express-checkout-with-ruby-on-rails-and-paypal-sdk-merchant) or [Stripe](https://stripe.com/docs/checkout/guides/rails).
+Step 4 would be done via integration of something like [Paypal](http://coding.smashingmagazine.com/2011/09/05/getting-started-with-the-paypal-api/), via [a gem](https://github.com/nov/paypal-express) or [an SDK](https://www.tommyblue.it/2013/07/02/paypal-express-checkout-with-ruby-on-rails-and-paypal-sdk-merchant/) or [Stripe](https://stripe.com/docs/checkout/guides/rails).
 
 ### Assignment
 


### PR DESCRIPTION
The link to the tommyblue page had a '3' in the url that needed to be a '2'