### PR TITLE
remove explicit 'use rails' instruction from Final JS lesson

### DIFF
--- a/javascript/finishing-up/project_final_js.md
+++ b/javascript/finishing-up/project_final_js.md
@@ -1,14 +1,10 @@
 ### Introduction
-I hope you enjoyed this course and the projects you've completed.  This isn't just the end of the Javascript projects, but all the programming course projects!  It represents the entire spectrum of knowledge you've acquired so far (which is a whole lot).
-
-The Where's Waldo project was a particularly integrated one, but this project is the first time you will put everything together and build a full website.  To do so, you will clone your favorite website.  
-
-This is a fantastic exercise because it allows you to build something meaningful and impressive without worrying about coming up with a full site on your own.  When you show employers, they'll likely already have experience with the site and you can focus on the technical implementation details instead of why you chose to build another social network for cats.
+I hope you enjoyed this course and the projects you've completed.
 
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">
-Copy your favorite website as well as you can.  Pinterest, Facebook, Twitter... Just make sure it's got lots of interesting functionality.  You'll be integrating your full array of Rails and Javascript skills into this one.  This should prove to you that you now have all the tools you need to build a website just like the ones you use every day.  
+Copy your favorite website as well as you can.  Pinterest, Facebook, Twitter... Just make sure it's got lots of interesting functionality.  You'll be integrating your full array skills into this one.... if you're following the Rails track definitely set up the project with Ruby on Rails!  This should prove to you that you now have all the tools you need to build a website just like the ones you use every day.  
 
 Of course, you can't copy every single feature and a lot of the user interface will be a bit clunkier, but you can get yourself 80% of the way there.  And that's darn impressive.
 


### PR DESCRIPTION
This is a PR template. If you are adding a solution link to the curriculum, leave this as is. If not, delete it and write the message you wish.

Thank you,

The Odin Project team.
