### PR TITLE
change depreciated Edit Styles to CSS Reference

### DIFF
--- a/web_development_101/javascript_basics/developer_tools_2.md
+++ b/web_development_101/javascript_basics/developer_tools_2.md
@@ -22,7 +22,7 @@ There are three ways to open the Developer Tools menu:
     - Elements panel
         1. Get Started With Viewing and Changing CSS
         2. Inspect and Tweak Your Pages
-        3. Edit Styles
+        3. CSS Reference
         4. Edit the DOM
     - Using the Console
     - Sources panel


### PR DESCRIPTION
Edit Styles has been depreciated and documentation says to see CSS Reference instead.