### PR TITLE
Fix typo from yahoo to flickr

### DIFF
--- a/rails_programming/apis_mailers_advanced_topics/project_apis.md
+++ b/rails_programming/apis_mailers_advanced_topics/project_apis.md
@@ -173,7 +173,7 @@ Remember way back in the warm-up when you played with the Flickr API?  Now it's 
 
 <div class="lesson-content__panel" markdown="1">
 1. Go back to the [Flickr API Docs](http://www.flickr.com/services/api/) and click [Create an App](http://www.flickr.com/services/apps/create/) at the top.
-2. Follow the steps for getting your API key.  You'll have to sign in or sign up for Yahoo (someone has to these days) and give them some basic information about your app.  Select "Apply for a non-commercial key" and let them know how awesome your photo feed app will be.  You'll automatically get a key generated for you, in addition to a secret key.  Copy both of these somewhere you can get to them later.
+2. Follow the steps for getting your API key.  You'll have to sign in or sign up for Flickr (someone has to these days) and give them some basic information about your app.  Select "Apply for a non-commercial key" and let them know how awesome your photo feed app will be.  You'll automatically get a key generated for you, in addition to a secret key.  Copy both of these somewhere you can get to them later.
 3. Use the [idGettr](http://idgettr.com/) website to look up your ID by pasting in your flickr username in the example URL, e.g. `http://www.flickr.com/photos/eriktrautman/`.  You'll need that later for some of the API methods.
 4. Upload a few photos to your photostream!
 5. Create a new Rails app and add a gem for the [Flickr API](http://lmgtfy.com/?q=flickr+api+gem). There are gems for pretty much every API out there. They will all require you to include your API keys and secret keys somehow. Look for gems that are maintained (have recent commits) and well-adopted (GitHub stars is one way to get a good gauge for how valuable a gem is).


### PR DESCRIPTION
Yahoo isn't required to get flickr developer api. I'm fairly certain it was meant to say flickr instead of yahoo.
