### PR TITLE
Typo fix in installing_ruby.md

### DIFF
--- a/web_development_101/installations/installing_ruby.md
+++ b/web_development_101/installations/installing_ruby.md
@@ -168,7 +168,7 @@ Congratulations! You've installed the prerequisites!
 
 Heroku is a place to host your Rails applications
 
-#### Step 1.1: Install Heroku
+#### Step 2.1: Install Heroku
 
 Next, install Heroku:
 


### PR DESCRIPTION
Numbering on the macOS subsection is out of order. Changed from 1.1 to 2.1 (header is under #2).
