### PR TITLE
Fixed broken link to Mac support page

### DIFF
--- a/web_development_101/pair_programming/prepare_to_remote_pair.md
+++ b/web_development_101/pair_programming/prepare_to_remote_pair.md
@@ -3,7 +3,7 @@
 As you learned in the last lesson, pairing in person is the best option, but if that isn't a viable solution, we have many options for pairing remotely. To get underway, you will need a way to share a screen and a way to communicate:
 
 * Screen Sharing Options. There may be more, but these are a few of the most popular:
-  * If you both are using Macs, you can use its [built in screen sharing app](https://support.apple.com/kb/PH18686).
+  * If you both are using Macs, you can use its [built in screen sharing app](https://support.apple.com/guide/mac-help/mh11848/mac).
   * Another option is to use [Teletype for Atom](https://teletype.atom.io/). It is a free plugin for Atom that allows you to easily share your workspace with other Atom users remotely.
 * Communication Options. You can always text chat, but for true Pair Programming, you will need voice communication. The Odin Project does not have a preference, just find one that works for you and your partner:
   * [Screenhero](https://screenhero.com/) has its own built in voice chat, but as mentioned above, unless you already have an account you are currently out of luck.


### PR DESCRIPTION
The previous link opened to an error message of 'We're sorry. We can't find the article you're looking for.' . I have replaced it to a new updated link that goes to the correct support page on screen sharing.

This is a PR template. If you are adding a solution link to the curriculum, leave this as is. If not, delete it and write the message you wish.

Thank you,

The Odin Project team.
