### PR TITLE
Removed no content link and added new resource

### DIFF
--- a/web_development_101/installations/command_line_basics.md
+++ b/web_development_101/installations/command_line_basics.md
@@ -32,7 +32,7 @@ By the end of this lesson, you should be able to do the following:
 **Note**: Many of these resources assume you're using a Mac or Linux environment. If you did our previous installation lesson, you should already have Linux installed in dual-boot, a virtual machine, or Windows Subsystem for Linux. Or, you might be using MacOS. If you don't have MacOS, or any version of Linux installed, please return to the [operating system installation guide](https://www.theodinproject.com/courses/web-development-101/lessons/prerequisites).
 
 1. Before diving into the command line lesson, you'll want to know how to create a file. You can do so with the `touch` command. Open your terminal and enter `ls`. `ls` will show you the files and folders in the current directory(or will show nothing if the current directory is empty). Create a file called `test.txt` by entering this in your terminal: `touch test.txt`. Now enter `ls` once again. You should see `test.txt` listed in the output. You can also create more than one file at once using the `touch` command. Enter `touch index.html script.js style.css` and press the enter. Then enter `ls` once more. You should see the files in the output. Here is a small way that the terminal reveals it's power. How long would it have take to create all three of those files with your mouse? Thanks, terminal.
-2. Read through [chapter 1 of Conquering the Command Line](http://conqueringthecommandline.com/book/basics).
+2. Work through the [interactive command line tutorial](https://linuxjourney.com/lesson/the-shell) to learn about basic commands.
 
 
 #### Use the Command Line Like a Pro


### PR DESCRIPTION
The online chapters of the book Conquering the Command Line content cannot be displayed when I accessed it. I removed the outdated link and added an interactive tutorial on command line from Linux Journey.