### PR TITLE
Added fix for error "E: Package 'make' has no installation candidate"

### DIFF
--- a/web_development_101/installations/prerequisites.md
+++ b/web_development_101/installations/prerequisites.md
@@ -63,7 +63,7 @@ While your VM is running, do the following steps:
 
   1. Click "Devices" -> "Insert Guest additions CD image" in the menu bar
   2. Open a terminal by pushing `ctrl + alt+ t` on the keyboard, if a terminal does not open, click anywhere on the desktop of the VM and try again.
-  3. Type the following commands into the terminal: `sudo apt-get update`, then `sudo apt-get upgrade`. You will be asked to type in the password you setup earlier. As you type your password, you'll notice there is no visual feedback. This is a security measure. Trust that it is taking you input. (Just type it and then push Enter).
+  3. The following commands will ask you to type the password you setup earlier. As you type your password, you'll notice there is no visual feedback as this is a security measure. When prompted for your password, just type it and then push Enter on your keyboard. Enter the following command into the terminal: `sudo apt-get update`. Once the command has finished, enter `sudo apt-get upgrade`. 
   4. Type the following command into the terminal: `sudo apt install gcc make perl`. You might be requested to enter in your password again. If an error is thrown, reboot the VM and try the steps in this list again.
   5. Run: `sudo /media/$USER/VBox*/VBoxLinux*.run` This might also require you to enter your password.
   6. Run `reboot` in the terminal, and the VM should reboot. If this does not work, reboot the VM by clicking the "start" menu, and selecting "reboot."

--- a/web_development_101/installations/prerequisites.md
+++ b/web_development_101/installations/prerequisites.md
@@ -70,6 +70,7 @@ While your VM is running, do the following steps:
   
   **NOTE**: 
 
+* If you encounter the error `... E: Package 'make' has no installation candidate` when running the command `sudo apt install gcc make perl`, please run the two following commands and then try again: `sudo apt-get update`, then `sudo apt-get upgrade`.
 * If upon trying to start the VM you only get a black screen, close and "power off" the VM, click "Settings -> Display" and make sure "Enable 3D Acceleration" is UNCHECKED, and Video memory is set to AT LEAST 128mb. 
 * If you receive an error when trying to mount the Guest Additions CD image ("Unable to insert the virtual optical disk"), please reboot your host (Windows/OSX) operating system. Afterwards, ensure that there is no image file mounted in *both* Virtual Box as well as in the file system of the VM. 
 

--- a/web_development_101/installations/prerequisites.md
+++ b/web_development_101/installations/prerequisites.md
@@ -63,14 +63,14 @@ While your VM is running, do the following steps:
 
   1. Click "Devices" -> "Insert Guest additions CD image" in the menu bar
   2. Open a terminal by pushing `ctrl + alt+ t` on the keyboard, if a terminal does not open, click anywhere on the desktop of the VM and try again.
-  3. Type the following command into the terminal: `sudo apt install gcc make perl` You will be asked to type in the password you setup earlier. As you type your password, you'll notice there is no visual feedback. This is a security measure. Trust that it is taking you input. (Just type it and then push enter). If an error is thrown, reboot the VM and try the steps in this list again.
-  4. Run: `sudo /media/$USER/VBox*/VBoxLinux*.run` This may ask you for a password as well.
-  5. Run `reboot` in the terminal, and the VM should reboot. If this does not work, reboot the VM by clicking the "start" menu, and selecting "reboot."
-  6. Click `devices` in the menu bar and go to `shared clipboard` then select the `bidirectional` option.
+  3. Type the following commands into the terminal: `sudo apt-get update`, then `sudo apt-get upgrade`. You will be asked to type in the password you setup earlier. As you type your password, you'll notice there is no visual feedback. This is a security measure. Trust that it is taking you input. (Just type it and then push Enter).
+  4. Type the following command into the terminal: `sudo apt install gcc make perl`. You might be requested to enter in your password again. If an error is thrown, reboot the VM and try the steps in this list again.
+  5. Run: `sudo /media/$USER/VBox*/VBoxLinux*.run` This might also require you to enter your password.
+  6. Run `reboot` in the terminal, and the VM should reboot. If this does not work, reboot the VM by clicking the "start" menu, and selecting "reboot."
+  7. Click `devices` in the menu bar and go to `shared clipboard` then select the `bidirectional` option.
   
   **NOTE**: 
 
-* If you encounter the error `... E: Package 'make' has no installation candidate` when running the command `sudo apt install gcc make perl`, please run the two following commands and then try again: `sudo apt-get update`, then `sudo apt-get upgrade`.
 * If upon trying to start the VM you only get a black screen, close and "power off" the VM, click "Settings -> Display" and make sure "Enable 3D Acceleration" is UNCHECKED, and Video memory is set to AT LEAST 128mb. 
 * If you receive an error when trying to mount the Guest Additions CD image ("Unable to insert the virtual optical disk"), please reboot your host (Windows/OSX) operating system. Afterwards, ensure that there is no image file mounted in *both* Virtual Box as well as in the file system of the VM. 
 


### PR DESCRIPTION
**Issue:**

Some individuals encounter an error in point 3 of Step 3: Install and Enable Guest Additions: https://www.theodinproject.com/courses/web-development-101/lessons/prerequisites#step-3-install-and-enable-guest-additions

Point 3 reads as follows:
> 3. Type the following command into the terminal: `sudo apt install gcc make perl` You will be asked to type in the password you setup earlier. As you type your password, you'll notice there is no visual feedback. This is a security measure. Trust that it is taking you input. (Just type it and then push enter). If an error is thrown, reboot the VM and try the steps in this list again.

The error typically encountered states: 
> Reading dependency lists... Done
> Building dependency tree
> Reading state information... Done
> Package make is not available, but is referred to by another package.
> This may mean that the package is missing, has been obsoleted, or is only available from another source
> 
> E: Package 'make' has no installation candidate 

**Fix:**

Running `sudo apt-get update` and `sudo apt-get upgrade` in the respective order should clear the issue, whereafter `sudo apt install gcc make perl` should run successfully.

**Proof/Example of it working:**

Discord #general channel chat logs on 2 November 2019 at 13:08 - 13:13 GMT +2.
![image](https://user-images.githubusercontent.com/52622303/68070467-5cb7dd80-fd77-11e9-8781-81ffcc903cea.png)

