### PR TITLE
Vacancy in legislator

### DIFF
--- a/ruby_programming/intermediate_ruby/project_event_manager.md
+++ b/ruby_programming/intermediate_ruby/project_event_manager.md
@@ -1234,7 +1234,7 @@ return to the application.
         <% legislators.each do |legislator| %>
         <tr>
           <td><%= "#{legislator.name}" %></td>
-          <td><%= "#{legislator.urls.join}" %></td>
+          <%= "<td>#{legislator.urls.join}</td>" if !legislator.urls.nil? %>
         </tr>
       <% end %>
     <% else %>


### PR DESCRIPTION
When there's vacancy in the legislator, API returns "VACANT" in legislator.name but doesn't have a legislators.urls. Calling join will break the code. Probably most simple way to get around this is to display "VACANT" without the URL.