### PR TITLE
Remove codecademy

### DIFF
--- a/web_development_101/the_front_end/html_css_basics.md
+++ b/web_development_101/the_front_end/html_css_basics.md
@@ -29,11 +29,12 @@ Look through these now and then use them to test yourself after doing the assign
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">
-
-  1. Do the [Codecademy HTML course](https://www.codecademy.com/learn/learn-html) and the [Codecademy CSS course](https://www.codecademy.com/learn/learn-css) (only the free stuff) for a healthy baseline understanding of HTML and CSS.  It can be helpful to take notes or make flashcards to keep track of the most commonly used elements.
-  2. To fill in the gaps, read through the [HTML Dog beginner HTML tutorial](http://www.htmldog.com/guides/html/beginner/), the [HTML Dog beginner CSS tutorial](http://www.htmldog.com/guides/css/beginner/) and the [HTML Dog intermediate CSS tutorial](http://www.htmldog.com/guides/css/intermediate/).  They should go relatively quickly since you've seen much of it before but you'll find a fair bit of new information as well.
-  3. Learn more about basic forms from [this W3Schools page](http://www.w3schools.com/html/html_forms.asp). The page could also be used as a reference.
-  4. Optional: Learn about your browser's default stylesheet and CSS resets [in this video](http://www.youtube.com/watch?v=14Vb6tZCjEY) (reset starting at the 2:00 mark).  This is why there are some spaces that show up in your layout even if you haven't specified CSS.  Real developers almost always use a CSS reset to blow away the default stylesheet and let them work from scratch.  If you're still curious, here's a [longer video](http://www.youtube.com/watch?v=HqRFPLP7Ffs) on resets.
+ 
+  1. To get a good baseline, read through, and follow along with the [HTML Dog beginner HTML tutorial](http://www.htmldog.com/guides/html/beginner/), the [HTML Dog beginner CSS tutorial](http://www.htmldog.com/guides/css/beginner/) and the [HTML Dog intermediate CSS tutorial](http://www.htmldog.com/guides/css/intermediate/).
+ 
+  2. Learn more about basic forms from [this W3Schools page](http://www.w3schools.com/html/html_forms.asp). The page could also be used as a reference.
+ 
+  3. Optional: Learn about your browser's default stylesheet and CSS resets [in this video](http://www.youtube.com/watch?v=14Vb6tZCjEY) (reset starting at the 2:00 mark).  This is why there are some spaces that show up in your layout even if you haven't specified CSS.  Real developers almost always use a CSS reset to blow away the default stylesheet and let them work from scratch.  If you're still curious, here's a [longer video](http://www.youtube.com/watch?v=HqRFPLP7Ffs) on resets.
 </div>
 
 ### Additional Resources


### PR DESCRIPTION
Removes codecademy from curriculum


Removing due to Codecademy changing their business model, there is no longer a free section due to the onset of the "premium" membership