### PR TITLE
Should clarify that tip doesn't guarantee a balanced tree

### DIFF
--- a/ruby_programming/computer_science/project_data_structures_algorithms.md
+++ b/ruby_programming/computer_science/project_data_structures_algorithms.md
@@ -29,7 +29,7 @@ You'll build a simple binary search tree in this assignment. In this lesson, our
   8. Write a `#balanced?` method which checks if the tree is balanced. A balanced tree is one where the difference between heights of left subtree and right subtree is not more than 1.
 
   9. Write a `#rebalance!` method which rebalances an unbalanced tree.
-  **Tip:** You'll want to create a level-order array of the tree before passing the array back into the `#build_tree` method.
+  **Tip:** You can create a level-order array of the tree before passing the array back into the `#build_tree` method, but this way is not garaunteed to rebalance your tree.
 
   10. Write a simple driver script that does the following:
 


### PR DESCRIPTION
Spent 2 hours wondering why my level-ordered array couldn't produce a balanced tree, as suggested by the tip in step 9. Turns out that it's not a guaranteed way to rebalance a tree. Kept referring back to my notes and debugging until I realized it wasn't a guarantee. Found this [GeekForGeek](https://www.geeksforgeeks.org/sorted-array-to-balanced-bst/) page about rebalancing.

(Example array that doesn't work: [12, 5 ,15, 3, 7, 13, 17, 1, 4, 9, 14, 20, 8, 11, 8])

I'd suggest **at least** mentioning that the tip isn't a guaranteed way to rebalance a tree and that the reader should research their own way.

