### PR TITLE
Ruby Rogues Podcast URL Update

### DIFF
--- a/web_development_101/the_basics/gearing_up.md
+++ b/web_development_101/the_basics/gearing_up.md
@@ -61,7 +61,7 @@ You can practice this method of learning by helping others in our community.
 
 * To learn more about the best ways to learn, [learning how to learn on Coursera](https://www.coursera.org/learn/learning-how-to-learn) is highly recommended.
 
-* The Ruby Rogues have a [podcast on How to Learn](http://rubyrogues.com/131-rr-how-to-learn/), which should be motivational and useful to you, so check it out for some useful thoughts on learning.
+* The Ruby Rogues have a [podcast on How to Learn](http://rubyrogues.com/ruby-rogues/131-rr-how-to-learn/), which should be motivational and useful to you, so check it out for some useful thoughts on learning.
 
 ### What To Do When You're Stuck
 


### PR DESCRIPTION
Ruby Rogues podcast added in another layer in the URL. I went through the podcasts on the site and located the original one.

Updated the URL link.