### PR TITLE
Added clarification for which page to start from at 'Tower's Learn Ver…

### DIFF
--- a/web_development_101/git_basics/git_basics.md
+++ b/web_development_101/git_basics/git_basics.md
@@ -16,7 +16,7 @@ By the end of this lesson, you should be able to do the following:
 <div class="lesson-content__panel" markdown="1">
 
   1. Watch [this video](https://www.youtube.com/watch?v=HVsySz-h9r4) by Corey Schafer for a great overview of some basic Git commands.
-  2. Complete [Tower's Learn Version Control with Git](https://www.git-tower.com/learn/git/ebook/en/command-line/basics/what-is-version-control#start) lesson. **Please note**: 1. Skip the "Getting Ready" section because you should have already installed Git by now. 2. Ignore the invitation to do the lessons with the Desktop GUI. Complete the Command Line version. 3. Only do "Part 1 - The Basics."
+  2. Complete [Tower's Learn Version Control with Git](https://www.git-tower.com/learn/git/ebook/en/command-line/basics/what-is-version-control#start) lesson. **Please note**: 1. Skip the "Getting Ready" section because you should have already installed Git by now. 2. Ignore the invitation to do the lessons with the Desktop GUI. Complete the Command Line version. 3. Only do "Part 1 - The Basics" starting from the page titled "The Basic Workflow of Version Control."
 
 </div>
 


### PR DESCRIPTION
There is no persistent display for where you are in the course without clicking 'Table of Contents.' The instructions for where to go are informative for their explanations of why you're skipping what you're skipping, but this process is inherently confusing. This edit makes it clear where you ought to start the lesson from. 