### PR TITLE
Update link

### DIFF
--- a/rails_programming/apis_mailers_advanced_topics/api_basics.md
+++ b/rails_programming/apis_mailers_advanced_topics/api_basics.md
@@ -2,7 +2,7 @@
 
 Working with APIs is awesome and frustrating at the same time.  On the one hand, interfacing with other applications out there can greatly improve the reach and "cool factor" of your own app.  On the other, it involves lots of reading through documentation, figuring out authentication strategies, and parsing bad (or nonexistent) error messages.
 
-Backing up, if you're still unclear on what an API (Application Programming Interface) basically is, [read the Skillcrush explanation](http://skillcrush.com/2012/07/04/api-2/) and then [read the first bit of this article](http://money.howstuffworks.com/business-communications/how-to-leverage-an-api-for-conferencing1.htm) to catch up.
+Backing up, if you're still unclear on what an API (Application Programming Interface) basically is, [read the Skillcrush explanation](https://skillcrush.com/2012/04/16/api/1346413073000/) and then [read the first bit of this article](http://money.howstuffworks.com/business-communications/how-to-leverage-an-api-for-conferencing1.htm) to catch up.
 
 "API" is an incredibly broad concept -- any time your application talks to another application, that's via some sort of API.  The components within your own application, e.g. the different pieces of Rails, also talk to each other via APIs... they are more or less independent sub-applications that pass along the data they each need to complete their particular task.  Everything's an API in application-land!
 


### PR DESCRIPTION
On lesson [Ruby on Rails: APIs and Building Your Own](https://www.theodinproject.com/courses/ruby-on-rails/lessons/apis-and-building-your-own)

The old link was dead and redirected to `https://skillcrush.com/blog/`. I found another Skillcrush article with a brief, introductory explanation of APIs and replaced it with that.