### PR TITLE
move student solution back inside details dropdown

### DIFF
--- a/ruby_programming/basic_ruby/project_building_blocks.md
+++ b/ruby_programming/basic_ruby/project_building_blocks.md
@@ -914,8 +914,8 @@ Submit a link below to this [file](https://github.com/TheOdinProject/curriculum/
 * [Robert Suazo's Solution](https://github.com/rsuazo/ruby_exercises/blob/master/stock_picker/stock_picker.rb)
 * [DalandanJuice's Solution](https://github.com/DalandanJuice/stock-picker/blob/master/stock-picker.rb)
 * [hyperturing's Solution](https://github.com/hyperturing/building-blocks/blob/master/stock_picker.rb)
-</details>
 * [Dave Guymon's Solution](https://github.com/daveguymon/the_odin_project/blob/master/ruby_programming/stock_picker.rb)
+</details>
 
 ### Project 3: Substrings
 


### PR DESCRIPTION
The last student solution for basic ruby project #2 (stock picker) was added outside the dropdown. This change moves it back inside.
