### PR TITLE
Update rbenv bash instructions

### DIFF
--- a/web_development_101/installations/installing_ruby.md
+++ b/web_development_101/installations/installing_ruby.md
@@ -224,7 +224,7 @@ If the previous message stated you should append to your bash_profile then run:
 echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
 ~~~
 
-If the previous message stated you should append to your zshrc then run:
+Otherwise if it mentioned zshrc then run:
 
 ~~~bash
 echo 'eval "$(rbenv init -)"' >> ~/.zshrc

--- a/web_development_101/installations/installing_ruby.md
+++ b/web_development_101/installations/installing_ruby.md
@@ -196,7 +196,9 @@ Then, run this command:
 rbenv init
 ~~~
 
-You should see the following after the command has run:
+You should see one of two messages after the command has run.
+
+Either:
 
 ~~~bash
 # Load rbenv automatically by appending
@@ -205,10 +207,27 @@ You should see the following after the command has run:
 eval "$(rbenv init -)"
 ~~~
 
-You'll do as it suggests by running the following command in the terminal:
+Or:
+
+~~~bash
+# Load rbenv automatically by appending
+# the following to ~/.zshrc:
+
+eval "$(rbenv init -)"
+~~~
+
+You'll do as it suggests by running either of the following commands in the terminal.
+
+If the previous message stated you should append to your bash_profile then run:
 
 ~~~bash
 echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
+~~~
+
+If the previous message stated you should append to your zshrc then run:
+
+~~~bash
+echo 'eval "$(rbenv init -)"' >> ~/.zshrc
 ~~~
 
 You'll notice nothing happened in the terminal. That's okay and is typical response for many terminal commands. At this point, you'll need to restart the terminal for the changes to take effect. Click the red "x" and then re-open the terminal (see Step 1.1).


### PR DESCRIPTION
The current instructions assume a bash shell. As the new MacOS uses zsh this update includes instructions for appending to the zshrc.