### PR TITLE
Add legislators nil urls handler in form_letter.erb

### DIFF
--- a/ruby_programming/intermediate_ruby/project_event_manager.md
+++ b/ruby_programming/intermediate_ruby/project_event_manager.md
@@ -1234,7 +1234,7 @@ return to the application.
         <% legislators.each do |legislator| %>
         <tr>
           <td><%= "#{legislator.name}" %></td>
-          <td><%= "#{legislator.urls.join}" if !legislator.urls.nil? %></td>
+          <td><%= "#{legislator.urls.join}" unless legislator.urls.nil? %></td>
         </tr>
         <% end %>
     <% else %>

--- a/ruby_programming/intermediate_ruby/project_event_manager.md
+++ b/ruby_programming/intermediate_ruby/project_event_manager.md
@@ -1234,7 +1234,7 @@ return to the application.
         <% legislators.each do |legislator| %>
         <tr>
           <td><%= "#{legislator.name}" %></td>
-          <td><%= "#{legislator.urls.join}" %></td>
+          <td><%= "#{legislator.urls.join}" if !legislator.urls.nil? %></td>
         </tr>
         <% end %>
     <% else %>


### PR DESCRIPTION
Came across nil value for `legislator.urls` when `legislator.name` is VACANT, thus breaking the program when `join`ing nil value of `legislator.urls` with `legislator.urls.join` (line 21 of form_letter.erb).
I added an if condition so ERB wouldn't attempt to join (and print) nil value for `legislator.urls`.

Steps to reproduce error:
1. Get legislators for zipcode 14517: `legislators_by_zipcode(14517)`
2. puts each legislator name and urls