### PR TITLE
Added note regarding OpenWeather API key waiting period

### DIFF
--- a/javascript/async-apis/APIs.md
+++ b/javascript/async-apis/APIs.md
@@ -208,8 +208,13 @@ If you've gotten lost along the way, check out [this jsbin project](http://jsbin
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">
+
 1. Read the fetch documentation [here](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch). It's not all that complicated to use, but we've only really scratched the surface at this point.
+
 2. Check out [this list](https://github.com/abhishekbanthia/Public-APIs) of free, open APIs and let your imagination go wild.
+
 3. Expand on our little project here by adding a button that fetches a new image without refreshing the page.
+
 4. Add a search box so users can search for specific gifs. You should also investigate adding a `.catch()` to the end of the promise chain in case Giphy doesn't find any gifs with the searched keyword. Add a default image, or an error message if the search fails.
+
 </div>

--- a/javascript/async-apis/APIs.md
+++ b/javascript/async-apis/APIs.md
@@ -42,6 +42,8 @@ Once you get a key (try this now if you like!) you can paste the URL into the br
 {"coord":{"lon":-77.73,"lat":38.77},"weather":[{"id":800,"main":"Clear","description":"clear sky","icon":"01d"}],"base":"stations","main":{"temp":75.74,"pressure":1017,"humidity":57,"temp_min":71.6,"temp_max":78.8},"visibility":16093,"wind":{"speed":3.87,"deg":291},"clouds":{"all":1},"dt":1504188900,"sys":{"type":1,"id":2886,"message":0.0053,"country":"US","sunrise":1504175992,"sunset":1504222878},"id":4775660,"name":"New Baltimore","cod":200}
 ~~~
 
+**Note:** There is a waiting period for the OpenWeather API key to become active which could take up to 2 hours. If you encounter a 401 error, try again at a later stage.
+
 ### Fetching Data
 
 So how do we actually get the data from an API into our code?


### PR DESCRIPTION
The API key for OpenWeather might not work immediately, leading to a 401 error message as follows:

> message | "Invalid API key. Please see http://openweathermap.org/faq#error401 for more info.

This will let the learner know that if they encounter the error it is most likely due to their API key not being made active yet.

Here is the OpenWeather FAQ which states that the API key would be activated `within the next couple of hours`.

https://openweathermap.org/faq

> Q: API calls return an error 401
> ...
> Your API key is not activated yet. Within the next couple of hours, it will be activated and ready to use.

---
Fixed numbered list formatting which resulted in:
1. Numbers correctly being displayed;
2. URL being parsed correctly.

