### PR TITLE
Adds UTF-8 charset meta to the basic HTML skeleton

### DIFF
--- a/web_development_101/javascript_basics/fundamentals-1.md
+++ b/web_development_101/javascript_basics/fundamentals-1.md
@@ -42,6 +42,7 @@ You can easily run your own JavaScript code from files you create on your comput
 <html>
 <head>
   <title>Page Title</title>
+  <meta charset="UTF-8"/>
 </head>
 <body>
   <script>


### PR DESCRIPTION
If there is no charset meta, the web console logs an error. With this fix, you get a cleaner console.