### PR TITLE
Updated section name from Chrome DevTools Documentation

### DIFF
--- a/web_development_101/javascript_basics/developer_tools_2.md
+++ b/web_development_101/javascript_basics/developer_tools_2.md
@@ -22,8 +22,8 @@ There are three ways to open the Developer Tools menu:
     - Elements panel
         1. Get Started With Viewing and Changing CSS
         2. Inspect and Tweak Your Pages
-        3. CSS Reference
-        4. DOM - Get Started
+        3. Edit Styles
+        4. Edit the DOM
     - Using the Console
     - Sources panel
         1. Get Started With Debugging JavaScript


### PR DESCRIPTION
In Web Development 101 > JavaScript Basics > Developer Tools 2 > Assignment > Elements Panel, we need to go over 2 sections called "CSS Reference" and "DOM - Get Started".

On Chrome DevTools there are no such sections but there are 2 sections called "Edit Styles" and "Edit the DOM". I am not sure if these are the same 2 sections only renamed, or if they are completely different from what the curriculum is currently pointing too.