### PR TITLE
Replaced submission statement and added link to repo

### DIFF
--- a/javascript/testing/testing-practice.md
+++ b/javascript/testing/testing-practice.md
@@ -55,7 +55,7 @@ npm i -D @babel/preset-env
 This will allow you to use import statements. Note that in the Jest docs a similar instruction is laid out [here](https://jestjs.io/docs/en/getting-started#using-babel)
 
 ###  Student Solutions
-Send us your solution so we can show others! Submit a link to the Github repo with your files in it by using any of the methods listed on the contributing page.  See the Google Homepage project for examples.
+To add your solution to the list below, edit this [file](https://github.com/TheOdinProject/curriculum/blob/master/javascript/testing/testing-practice.md) (located on The Odin Project's "curriculum" github repository). See the section on [Contributing](http://github.com/TheOdinProject/curriculum/blob/master/contributing.md) for more instructions.
 
 <details markdown="block">
   <summary> Show Student Solutions </summary>


### PR DESCRIPTION
The submission statement on this page doesn't have a link to the repo page that must be altered, nor does it have a link to the contributing guide. 

Switched out the submission statement with the one found on other pages that contains both a link to the repo page that must be edited, as well as the hyperlink to the Contributing guide.