### PR TITLE
Fixed student's submission that was outside closing tag

### DIFF
--- a/javascript/organizing-js/tic-tac-toe-project.md
+++ b/javascript/organizing-js/tic-tac-toe-project.md
@@ -115,5 +115,5 @@ To add your solution to the list below, edit this [file](https://github.com/TheO
 - [Jkraf002's Solution](https://github.com/jkraf002/tic-tac-toe) - [View in Browser](https://jkraf002.github.io/tic-tac-toe/)
 - [AlexGioffDev's Solution](https://github.com/AlexGioffDev/JS_TicTacToeGame) - [View in Browser](https://alexgioffdev.github.io/JS_TicTacToeGame/)
 - [Supasus's Solution](https://supasus.github.io/js-tictactoe/) - [View in Browser](https://github.com/supasus/js-tictactoe)
-</details>
 - [mmboyce's Solution](https://github.com/mmboyce/tic-tac-toe/) - [View in Browser](https://mmboyce.github.io/tic-tac-toe/)
+</details>


### PR DESCRIPTION
A student's solution was outside of the `</details>` tag, causing it to appear outside of the expandable list.

Moved the student's solution so it is contained within the `<details> </details>` tags.