### PR TITLE
Removed confusing "VSCode" emboldened text

### DIFF
--- a/web_development_101/installations/text_editors.md
+++ b/web_development_101/installations/text_editors.md
@@ -23,10 +23,10 @@ As a reminder, if you're using a **virtual machine**, you should install your te
 
 On Windows and Linux, you can open VSCode from the command line by typing `code`, and you can open folders or files by adding the name of the location after it: `code my_first_rails_app/`.
 
-**MacOS Users:** MacOS can do this too, but you need to set it up. After installing VSCode, launch it any way you're comfortable with. Once it's running, open the Command palette with `CMD + Shift + P`. In the little dialog that appears, type `shell command`. One of the choices that appears will be `Shell Command: Install 'code' command in PATH`. Select that option, and restart the terminal if you have it open.
+#### MacOS Users:
 
-#### WSL Users
+MacOS can do this too, but you need to set it up. After installing VSCode, launch it any way you're comfortable with. Once it's running, open the Command palette with `CMD + Shift + P`. In the little dialog that appears, type `shell command`. One of the choices that appears will be `Shell Command: Install 'code' command in PATH`. Select that option, and restart the terminal if you have it open.
 
-Although you just installed Ubuntu on your computer, you should still install the Windows version of the code editor you choose. You will edit the files in your Projects directory with the code editor, and WSL will be able to read these files.
+#### WSL Users:
 
-If you are using VSCode, be sure to install the *"Remote - WSL"* extension when prompted. This extension will allow you to directly access your Linux files. Once installed, select the green icon in the lower left corner to connect to WSL.
+Although you just installed Ubuntu on your computer, you should still install the Windows version of the code editor you choose. You will edit the files in your Projects directory with the code editor, and WSL will be able to read these files. If you are using VSCode, be sure to install the *"Remote - WSL"* extension when prompted. This extension will allow you to directly access your Linux files. Once installed, select the green icon in the lower left corner to connect to WSL.

--- a/web_development_101/installations/text_editors.md
+++ b/web_development_101/installations/text_editors.md
@@ -29,4 +29,4 @@ On Windows and Linux, you can open VSCode from the command line by typing `code`
 
 Although you just installed Ubuntu on your computer, you should still install the Windows version of the code editor you choose. You will edit the files in your Projects directory with the code editor, and WSL will be able to read these files.
 
-**VSCode Users:** Be sure to install the "Remote - WSL" extension when prompted. This extension will allow you to directly access your Linux files. Once installed, select the green icon in the lower left corner to connect to WSL.
+If you are using VSCode, be sure to install the *"Remote - WSL"* extension when prompted. This extension will allow you to directly access your Linux files. Once installed, select the green icon in the lower left corner to connect to WSL.


### PR DESCRIPTION
The statement `VSCode Users:` can be confusing for beginners. The emphasis was removed so it reads as a 2nd paragraph to this section.

This might be part of a bigger issue where the bold text for emphasis (`*VSCode Users*`) has the same formatting as the 2nd level heading text (`#### WSL Users ####`)

[Edit: Changed the formatting of MacOS to be a 4th level heading to be consistent with the page.]