### PR TITLE
Google API Client Install Error

### DIFF
--- a/ruby_programming/intermediate_ruby/project_event_manager.md
+++ b/ruby_programming/intermediate_ruby/project_event_manager.md
@@ -735,6 +735,10 @@ Successfully installed google-api-client-0.15.0
 1 gem installed
 ~~~
 
+If you recieve a signet error when installing the Google API gem, it is due to modern Ruby updates 
+requiring an updated version of signet that is not compatible with the API. To fix, please [downgrade 
+your version of signet](https://github.com/googleapis/google-api-ruby-client/issues/833) before installing the gem. 
+
 ### Showing All Legislators in a Zip Code
 
 The gem comes equipped with some vague example documentation. The documentation is also


### PR DESCRIPTION
Modern ruby versions use a signet version not compatible with the Google API. Posted the small fix.

This is a PR template. If you are adding a solution link to the curriculum, leave this as is. If not, delete it and write the message you wish.

Thank you,

The Odin Project team.
