### PR TITLE
MacOS note about security warning regarding VSCode

### DIFF
--- a/web_development_101/installations/text_editors.md
+++ b/web_development_101/installations/text_editors.md
@@ -23,6 +23,10 @@ On Windows and Linux, you can open VSCode from the command line by typing `code`
 
 MacOS can do this too, but you need to set it up. After installing VSCode, launch it any way you're comfortable with. Once it's running, open the Command palette with `CMD + Shift + P`. In the little dialog that appears, type `shell command`. One of the choices that appears will be `Shell Command: Install 'code' command in PATH`. Select that option, and restart the terminal if you have it open.
 
+##### Regarding Security Warning:
+
+A message may show, warning the user that VSCode is not trusted software. This is an expected message. VSCode can be trusted, therefore it is safe to ignore this warning.
+
 #### WSL Users:
 
 Although you just installed Ubuntu on your computer, you should still install the Windows version of the code editor you choose. You will edit the files in your Projects directory with the code editor, and WSL will be able to read these files. If you are using VSCode, be sure to install the *"Remote - WSL"* extension when prompted. This extension will allow you to directly access your Linux files. Once installed, select the green icon in the lower left corner to connect to WSL.


### PR DESCRIPTION
Trying again. Added linebreak and modified header to be smaller to fit within the MacOS section.