### PR TITLE
Added webpack-cli to instructions

### DIFF
--- a/javascript/organizing-js/restaurant-project.md
+++ b/javascript/organizing-js/restaurant-project.md
@@ -8,7 +8,7 @@ Let's use what we've learned and take a chance to continue practicing DOM manipu
 1. Start the project the same way you began the webpack tutorial project.
     1. run `npm init` in your project directory to generate a `package.json` file.
     
-    1. run `npm install --save-dev webpack` to install webpack to the node_modules directory of your project.
+    1. run `npm install webpack webpack-cli --save-dev` to install webpack to the node_modules directory of your project.
    
         - Quick tip: the `node_modules` folder can get _really_ big. It is customary to   add a `.gitignore` file to your project so that you don't have to sync the contents of `node_modules` to github. The dependencies that are stored there can be installed from your package.json by running `npm install`, so you don't need to sync them.  
       


### PR DESCRIPTION
`webpack-cli` was missing in the instructions.
It was required when I ran `webpack --watch`.
