### PR TITLE
added fix for mongoose connection deprecation warning

### DIFF
--- a/nodeJS/authentication/Authentication.md
+++ b/nodeJS/authentication/Authentication.md
@@ -28,7 +28,7 @@ const mongoose = require("mongoose");
 const Schema = mongoose.Schema;
 
 const mongoDb = "YOUR MONGO URL HERE";
-mongoose.connect(mongoDb, { useNewUrlParser: true });
+mongoose.connect(mongoDb, { useUnifiedTopology: true, useNewUrlParser: true });
 const db = mongoose.connection;
 db.on("error", console.error.bind(console, "mongo connection error"));
 


### PR DESCRIPTION
Hello,

I faced an issue with the tutorial on this page. There was the deprecation warning: "current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor." It's fixed with the change.

Cheers,

Kris
