### PR TITLE
Google API Client Install Error (Repull)

### DIFF
--- a/ruby_programming/intermediate_ruby/project_event_manager.md
+++ b/ruby_programming/intermediate_ruby/project_event_manager.md
@@ -735,8 +735,7 @@ Successfully installed google-api-client-0.15.0
 1 gem installed
 ~~~
 
-
-If you recieve a signet error when installing the Google API gem, it is due to modern Ruby updates requiring an updated version of signet that is not compatible with the API. To fix, please [downgrade your version of signet(https://github.com/googleapis/google-api-ruby-client/issues/833) before installing the gem. 
+If you recieve a signet error when installing the Google API gem, it is due to modern Ruby updates requiring an updated version of signet that is not compatible with the API. To fix, please [downgrade your version of signet](https://github.com/googleapis/google-api-ruby-client/issues/833) before installing the gem. 
 
 ### Showing All Legislators in a Zip Code
 

--- a/ruby_programming/intermediate_ruby/project_event_manager.md
+++ b/ruby_programming/intermediate_ruby/project_event_manager.md
@@ -735,6 +735,9 @@ Successfully installed google-api-client-0.15.0
 1 gem installed
 ~~~
 
+
+If you recieve a signet error when installing the Google API gem, it is due to modern Ruby updates requiring an updated version of signet that is not compatible with the API. To fix, please [downgrade your version of signet(https://github.com/googleapis/google-api-ruby-client/issues/833) before installing the gem. 
+
 ### Showing All Legislators in a Zip Code
 
 The gem comes equipped with some vague example documentation. The documentation is also


### PR DESCRIPTION
Modern ruby versions use a signet version not compatible with the Google API. Posted a small fix, and moved content to one line. Started a new pull because I deleted the last repo, still figuring stuff out :). 
