### PR TITLE
Update resources for html/css best-practices

### DIFF
--- a/html_css/best_practices.md
+++ b/html_css/best_practices.md
@@ -21,7 +21,7 @@ You'll also get the chance to review what was covered in previous sections by ch
 ### Additional Resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something.
 
-* [Put a box around every div on the page with this chrome extension from Pesticide.io](http://pesticide.io/).  It can help you deconstruct an existing page or debug your own layouts easier.
+* Put a box around every div on the page with [this Chrome extension](https://chrome.google.com/webstore/detail/pesticide-for-chrome/bblbgcheenepgnnajgfpiicnbbdmmooh), or [this Firefox extension](https://addons.mozilla.org/en-US/firefox/addon/open-pesticide/) by Matthew Baa.  It can help you deconstruct an existing page or debug your own layouts.
 * [CSS Style Guide](http://codeguide.co/#css) by [Mark Otto](https://github.com/mdo), one of the creators of Bootstrap.
 * [CSS Reference](http://cssreference.io/), a visual guide to CSS, by [Jeremy Thomas](https://github.com/jgthms).
 * Add some!


### PR DESCRIPTION
The link given for pesticide.io was broken. The site seems to no longer
exist. I linked instead to a replacement Chrome extension by Matthew
Baa, as well as the equivalent in Firefox.