### PR TITLE
remove references to rails installation from introduction

### DIFF
--- a/rails_programming/basic_rails/introduction.md
+++ b/rails_programming/basic_rails/introduction.md
@@ -34,19 +34,6 @@ My typical workflow for a long time went sort of like this:
 
 As you can see, I frequently relied on the main resources you'll be learning from and you'll find them to be helpful long after you've completed this course, so it makes sense to get familiar with them!
 
-### Prerequisites
-
-**If you haven't completed these, be sure to do so before getting started:**
-
-<div class="lesson-content__panel" markdown="1">
-  * Your software should be installed, as listed in the [Installfest section](/courses/web-development-101/lessons/your-first-rails-application).
-  * You should really have gone through the full [Web Development 101](/courses/web-development-101) course, but the most important parts are listed below.
-      * Read the full [Back End section](/courses/web-development-101/lessons/introduction-to-the-back-end) of the Web Development 101 section for an introduction to Ruby.
-      * Complete at least the full [Ruby Basics](/courses/web-development-101/lessons/ruby-basics) lesson (all readings and projects) to have a solid grounding in Ruby basics.
-      * Read the [Rails portion of the Web Development 101](/courses/web-development-101/lessons/ruby-on-rails-basics) section for an overview of Rails.  
-      * Build the [Rails project from the Web Dev 101 section](/courses/web-development-101/lessons/ruby-on-rails) to get your hands dirty with Rails first.
-</div>
-
 ### Additional Resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something.
 


### PR DESCRIPTION
The prerequisites for the rails course now come after the introduction so there is no need for them to be here anymore.