### PR TITLE
removed reference to webdev101 course. replaced with ruby basics.

### DIFF
--- a/ruby_programming/basic_ruby/lesson_building_blocks.md
+++ b/ruby_programming/basic_ruby/lesson_building_blocks.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-Welcome to Ruby Building Blocks!  Since you've already done a decent chunk of Ruby in the [Web Development 101 Course](https://www.theodinproject.com/courses/web-development-101/lessons/ruby-basics) (if not, go do that first!), this should start as a healthy refresher of what you've already learned with *Variables, Data Types, Strings, and Methods*.  
+Welcome to Ruby Building Blocks!  Since you've already done a decent chunk of Ruby in [Ruby Basics](https://www.theodinproject.com/courses/ruby-programming/lessons/ruby-basics-ruby-programming), this section will reinforce what you've already learned with *Variables, Data Types, Strings, and Methods*.  
 
 But this lesson will take you much deeper and further than you went before, so don't think you've got a free pass.  There's a whole lot of stuff to cover.  These first couple of lessons cover the broadest swathe of material of the entire Ruby course, so get stretched out and warmed up, it's time to dive in!
 

--- a/ruby_programming/basic_ruby/lesson_how_this_course_will_work.md
+++ b/ruby_programming/basic_ruby/lesson_how_this_course_will_work.md
@@ -28,7 +28,7 @@ Everyone is coming into this with a different goal in mind, so to accommodate th
 
 ### Our Primary "Textbooks"
 
-1. [Codecademy.com](https://www.codecademy.com/catalog/language/ruby) has a lot of great introductory content to get you ramped into the Ruby language.  You've already read [Chris Pine's Learn to Program](http://pine.fm/LearnToProgram/) in the Web Development 101 section for a good introduction, and the Codecademy stuff will overlap a bit and carry forward from there.
+1. [Codecademy.com](https://www.codecademy.com/catalog/language/ruby) has a lot of great introductory content to get you ramped into the Ruby language.  [Chris Pine's Learn to Program](http://pine.fm/LearnToProgram/) is also a good introduction. It overlaps with the Codecademy stuff a bit and will carry forward from there.
 2. Peter Cooper's [Beginning Ruby](https://www.amazon.co.uk/Beginning-Ruby-Professional-Peter-Cooper/dp/1484212797) is a solid introduction to Ruby that covers pretty much the breadth of the language as you need to understand it. It's a bit outdated but Ruby hasn't changed a whole lot since then.  The goal of this project is to move BEYOND Codecademy and other simple, free resources and get you building stuff on your own.  This book will start covering some of the more intermediate/useful stuff that you'll need to know to do that.
 
 ### The (Free) Backup "Textbooks"


### PR DESCRIPTION
Section in 'Ruby Building Blocks' references that we've worked on Ruby in Web Development 101. Since Ruby is no longer part of Web Development 101, I changed it to reference lesson three (ruby basics) and modified the text accordingly. 
