### PR TITLE
Fix: Link to Wrong Lesson for Installing Git

### DIFF
--- a/web_development_101/git_basics/project_practicing_git_basics.md
+++ b/web_development_101/git_basics/project_practicing_git_basics.md
@@ -16,11 +16,11 @@ By the end of this lesson, you should be able to do the following:
  - Explain how to look at the history of your previous commits from the command line.
 
 ### Assignment
-In this project, we'll walk through the basic Git workflow that you will use in all your projects. 
+In this project, we'll walk through the basic Git workflow that you will use in all your projects.
 
 #### Create the Repository
 
-1. You should have already created a GitHub account in [Project: Your First Rails App](https://www.theodinproject.com/courses/web-development-101/lessons/your-first-rails-application). If you haven't done that yet, you can sign up [here](https://github.com/).
+1. You should have already created a GitHub account in the [Setting up Git](https://www.theodinproject.com/courses/web-development-101/lessons/setting-up-git) lesson. If you haven't done that yet, you can sign up [here](https://github.com/).
 
 2. Create a new repository by clicking the button shown in the screenshot below.
   <a href="https://imgur.com/LURPUjP"><img class="tutorial-img" src="https://i.imgur.com/LURPUjP.png" title="source: imgur.com" /></a>


### PR DESCRIPTION
Because:
* The old link pointed at a lesson that no longer exists.

This is a PR template. If you are adding a solution link to the curriculum, leave this as is. If not, delete it and write the message you wish.

Thank you,

The Odin Project team.
