### PR TITLE
Change `RSpec.describe` to just `describe` in RSpec intro for consistency.

### DIFF
--- a/ruby_programming/testing_with_rspec/introduction_to_rspec.md
+++ b/ruby_programming/testing_with_rspec/introduction_to_rspec.md
@@ -68,7 +68,7 @@ Let's add our first test. Let's say we want to create a calculator with a few me
 ~~~ruby
 #spec/calculator_spec.rb
 
-RSpec.describe Calculator do
+describe Calculator do
   describe "#add" do
     it "returns the sum of two numbers" do
       calculator = Calculator.new


### PR DESCRIPTION
Change `RSpec.describe` to just `describe` in RSpec intro for consistency.

None of the other spec files provided by the curriculum use this prefix, and it
is inconsistent with the next block that repeats the "describe Calculator do"
line.
