### PR TITLE
replaced broken link with a link to ruby-basics markdown file

### DIFF
--- a/ruby_programming/basic_ruby/lesson_building_blocks.md
+++ b/ruby_programming/basic_ruby/lesson_building_blocks.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-Welcome to Ruby Building Blocks!  Since you've already done a decent chunk of Ruby in [Ruby Basics](https://www.theodinproject.com/courses/ruby-programming/lessons/ruby-basics-ruby-programming), this section will reinforce what you've already learned with *Variables, Data Types, Strings, and Methods*.  
+Welcome to Ruby Building Blocks!  Since you've already done a decent chunk of Ruby in [Ruby Basics](https://github.com/TheOdinProject/curriculum/blob/master/ruby_programming/basic_ruby/ruby_basics_lesson.md), this section will reinforce what you've already learned with *Variables, Data Types, Strings, and Methods*.  
 
 But this lesson will take you much deeper and further than you went before, so don't think you've got a free pass.  There's a whole lot of stuff to cover.  These first couple of lessons cover the broadest swathe of material of the entire Ruby course, so get stretched out and warmed up, it's time to dive in!
 


### PR DESCRIPTION
This is a temporary fix until new Ruby Basics section is released in a few days. For now at least, this will allow students to access the ruby basics material through the first link at the [building blocks lesson page. 
](https://www.theodinproject.com/courses/ruby-programming/lessons/ruby-building-blocks#introduction)