### PR TITLE
spaceship operator in ruby conditional logic section

### DIFF
--- a/ruby_programming/basic_ruby/conditional_logic.md
+++ b/ruby_programming/basic_ruby/conditional_logic.md
@@ -155,9 +155,10 @@ This happens because computers can't store strings in the same efficient way the
 In addition to the above operators, Ruby has a special operator that is affectionately referred to as the **spaceship operator**. Unlike the other comparison operators, which all return `true` or `false`, the spaceship operator returns one of three numerical values.
 
 `<=>` (spaceship operator) returns the following:
- `-1` if the value on the left is less than the value on the right;
- `0` if the value on the left is equal to the value on the right; and
- `1` if the value on the left is greater than the value on the right.
+
+- `-1` if the value on the left is less than the value on the right;
+- `0` if the value on the left is equal to the value on the right; and
+- `1` if the value on the left is greater than the value on the right.
 
 ~~~ruby
 5 <=> 10    #=> -1

--- a/ruby_programming/basic_ruby/conditional_logic.md
+++ b/ruby_programming/basic_ruby/conditional_logic.md
@@ -155,9 +155,9 @@ This happens because computers can't store strings in the same efficient way the
 In addition to the above operators, Ruby has a special operator that is affectionately referred to as the **spaceship operator**. Unlike the other comparison operators, which all return `true` or `false`, the spaceship operator returns one of three numerical values.
 
 `<=>` (spaceship operator) returns the following:
- - `-1` if the value on the left is less than the value on the right;
- - `0` if the value on the left is equal to the value on the right; and
- - `1` if the value on the left is greater than the value on the right.
+ `-1` if the value on the left is less than the value on the right;
+ `0` if the value on the left is equal to the value on the right; and
+ `1` if the value on the left is greater than the value on the right.
 
 ~~~ruby
 5 <=> 10    #=> -1


### PR DESCRIPTION
removed dashes that were in front of numbers in the explanation because they show up making 0 look like - 0, and 1 look like -1.

This is a PR template. If you are adding a solution link to the curriculum, leave this as is. If not, delete it and write the message you wish.

Thank you,

The Odin Project team.
