### PR TITLE
Fix "Introduction" not showing as a heading

### DIFF
--- a/web_development_101/the_front_end/project_html_css.md
+++ b/web_development_101/the_front_end/project_html_css.md
@@ -1,4 +1,4 @@
-﻿### Introduction
+### Introduction
 
 For this mini-project, you'll deconstruct an existing web page and rebuild it.  Don't worry if the links don't go anywhere and the search box doesn't do anything when you submit it. The goal is to start thinking about how elements get placed on the page and roughly how they get styled and aligned. For some of you, this may be the first time you've actually tried to "build" something in HTML (very exciting!).
 


### PR DESCRIPTION
#16404 The .md file was saved with "UTF-8 with BOM" encoding which was messing up with the heading. Saved it with "UTF-8" encoding.