### PR TITLE
added 'Extras' section referencing Ruby extensions

### DIFF
--- a/ruby_programming/introduction/installing_ruby.md
+++ b/ruby_programming/introduction/installing_ruby.md
@@ -259,4 +259,13 @@ If you don't see the output above, log off and log back on, then try again.
 
 Well done! Pat yourself on the back! The hard part is done, and it's time to move on to the next lesson!
 
+#### Extras
+
+If you are using Visual Studio Code as your IDE, you can install the "Ruby" extension which will provide you with semantic highlighting and formatting support (RuboCop). This is optional, but it is a quick install; go to the "Extensions" tab in VSC (Ctrl+Shift+X), search "Ruby", and click install on the first one. Congratulations, the extension is now installed (you can also uninstall the extension from here).
+
+If you are using a different IDE, a quick Google search such as "Ruby programming extensions for (your IDE here)" should provide you with the resources to get started. Free support extensions can help make your programming go more smoothly, and there are tons of extensions for all languages (not just Ruby). 
+
+
+
+
 </details>


### PR DESCRIPTION
I was not using extensions and after Fensus showed me them, we both decided they are important and he suggested I make a pull request adding them in.

This request adds an "Extras" section including how to install the "Ruby" extension for VSC, and general information for finding extensions online.