### PR TITLE
Fix a broken link in JS tutorial

### DIFF
--- a/javascript/organizing-js/objects-constructors.md
+++ b/javascript/organizing-js/objects-constructors.md
@@ -143,7 +143,7 @@ Before we go much further, there's something important you need to understand ab
 
 This concept is an important one, so you've got some reading to do. Make sure you really get this before moving on!
 
-1. [This article](http://javascriptissexy.com/javascript-prototype-in-plain-detailed-language/) is a straightforward introduction and demonstration of the concept. It also covers constructors again.. good time for a review! The important bits here, once you've covered the basics are 'Prototype-based inheritance' and the 'Prototype chain'
+1. [This article](https://web.archive.org/web/20200111104600/http://javascriptissexy.com/javascript-prototype-in-plain-detailed-language/) is a straightforward introduction and demonstration of the concept. It also covers constructors again.. good time for a review! The important bits here, once you've covered the basics are 'Prototype-based inheritance' and the 'Prototype chain'
 2. To go a bit deeper into both the chain and inheritance spend some time with [this great article](http://javascript.info/prototype-inheritance). As usual, doing the exercises at the end will help cement this knowledge in your mind. Don't skip them! Important note: this article makes heavy use of `__proto__` which is not generally recommended. The concepts here are what we're looking for at the moment. We will soon learn another method or two for setting the prototype.
 
 If you've understood the concept of the prototype then this next bit about constructors will not be confusing at all!

--- a/web_development_101/javascript_basics/clean_code.md
+++ b/web_development_101/javascript_basics/clean_code.md
@@ -88,4 +88,4 @@ Read through these articles that discuss a few elements of writing good clean co
 * [A nice op-ed](https://www.martinfowler.com/bliki/CodeAsDocumentation.html)
 * THE complete guide to [self-documenting code](http://wiki.c2.com/?SelfDocumentingCode)
 * [Airbnb style guide](https://github.com/airbnb/javascript)  
-* [Chaining methods to write sentences](http://javascriptissexy.com/beautiful-javascript-easily-create-chainable-cascading-methods-for-expressiveness/)   
+* [Chaining methods to write sentences](https://web.archive.org/web/20200416025635/http://javascriptissexy.com/beautiful-javascript-easily-create-chainable-cascading-methods-for-expressiveness/)   


### PR DESCRIPTION
A fix for issue #16525 

- [x] Identify the links to the resources
- [x] Use the wayback machine to obtain the appropriate snapshot of the resource from the past
- [x] Replace the links in the curriculum files in the appropriate place.

Thanks!