### PR TITLE
Remove Codecademy HTML/CSS

### DIFF
--- a/html_css/conclusion.md
+++ b/html_css/conclusion.md
@@ -8,7 +8,6 @@ Luckily, that's the next course!  Onwaaaaaaard!!!
 This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something.
 
 * [Web Fundamentals](https://developers.google.com/web/fundamentals/)... tons of links to articles specific to your goals.
-* [Codecademy's HTML/CSS track](https://www.codecademy.com/learn/learn-html)
 * [Codecademy's Learn Sass](http://www.codecademy.com/learn/learn-sass)
 * [Shay Howe's Beginner's Guide to HTML and CSS](http://learn.shayhowe.com/html-css/)
 * [HTML5 Tutorial](http://www.html-5-tutorial.com/start-html5-tutorial.htm)


### PR DESCRIPTION
In the conclusion for HTML/CSS, within Additional Resources, Codecademy's HTML/CSS course is recommended. This is a very high level beginner resource. I've done the course and it is completely superseded by the material presented prior. THIS COURSE WOULD HAVE NO VALUE TO ANYONE WHO HAD BEEN THROUGH THE ENTIRE HTML/CSS SECTION.

https://www.theodinproject.com/courses/html5-and-css3/lessons/conclusion-html5-and-css3

This is a PR template. If you are adding a solution link to the curriculum, leave this as is. If not, delete it and write the message you wish.

Thank you,

The Odin Project team.
