### PR TITLE
clarify instructions for learn.co tutorial

### DIFF
--- a/ruby_programming/basic_ruby/debugging.md
+++ b/ruby_programming/basic_ruby/debugging.md
@@ -167,7 +167,7 @@ Obviously, if available, the stack trace is the first place you should look when
 
 1. Go through the Ruby Guides [Ruby Debugging](https://www.rubyguides.com/2015/07/ruby-debugging/) tutorial, which covers everything about debugging in more depth.
 2. Read through the [Exceptions and Stack Traces](https://launchschool.com/books/ruby/read/more_stuff#readingstacktraces) section of Launch School's online book *Introduction to Programming with Ruby*.
-3. Follow along with [this Pry tutorial](https://learn.co/lessons/debugging-with-pry) using [this repo](https://github.com/learn-co-students/debugging-with-pry-v-000) by Learn.co. During Part II, use `rspec spec/pry_debugging_spec.rb` instead of 'learn' to see the failing test.
+3. Follow along with [this Pry tutorial](https://learn.co/lessons/debugging-with-pry) using [this repository](https://github.com/learn-co-students/debugging-with-pry-v-000) by Learn.co. During Part II, use `rspec spec/pry_debugging_spec.rb` instead of `learn` to see the failing test.
 </div>
 
 ### Additional Resources

--- a/ruby_programming/basic_ruby/debugging.md
+++ b/ruby_programming/basic_ruby/debugging.md
@@ -167,7 +167,7 @@ Obviously, if available, the stack trace is the first place you should look when
 
 1. Go through the Ruby Guides [Ruby Debugging](https://www.rubyguides.com/2015/07/ruby-debugging/) tutorial, which covers everything about debugging in more depth.
 2. Read through the [Exceptions and Stack Traces](https://launchschool.com/books/ruby/read/more_stuff#readingstacktraces) section of Launch School's online book *Introduction to Programming with Ruby*.
-3. Follow along with [this Pry tutorial](https://learn.co/lessons/debugging-with-pry) by Learn.co.
+3. Follow along with [this Pry tutorial](https://learn.co/lessons/debugging-with-pry) using [this repo](https://github.com/learn-co-students/debugging-with-pry-v-000) by Learn.co. During Part II, use `rspec spec/pry_debugging_spec.rb` instead of 'learn' to see the failing test.
 </div>
 
 ### Additional Resources


### PR DESCRIPTION
17 days ago I did this lesson & found that there was a "missing" link in the tutorial. I asked about it in Discord & got the link to the repo. It was suggested that I do a PR directly to learn.co to add this link to their repo, so I did. However, it is still sitting there as an open PR. 

After I did submitted the PR to learn.co, I did this tutorial, and I ran into another problem. The directions instruct you to "run `learn`  to see the failing test". Unless, I am missing something, `learn` does nothing (I think it might be a special command that learn.co includes in their set-up material). Instead, I found that I needed to run `rspec spec/pry_debugging_spec.rb` to run the test. 

Please, know that there is a chance that I am missing something from the previous lessons. I was partially through the Ruby material before it was recently updated. So, I only skimmed through the changed material.
