### PR TITLE
adds redundant instructions to use VM only

### DIFF
--- a/web_development_101/installations/prerequisites.md
+++ b/web_development_101/installations/prerequisites.md
@@ -14,6 +14,10 @@ Installing a Virtual Machine (VM) is the easiest and most reliable way to get st
 
 Installing a VM is a simple process. This guide uses Oracle's VirtualBox program to create and run the VM. This program is open-source, free, and simple. What more can you ask for? Now, let's make sure we have everything downloaded and ready for installation.
 
+**IMPORTANT**
+  
+Once you have completed these instructions, **you are expected to work entirely in the VM.** Maximize the window, add more virtual monitors if you have them, fire up the Internet Browser in the **Whisker Menu** <img src="https://i.imgur.com/EjSLkCZ.png" style="width:25px" title="The Whisker Menu Icon" alt="Whisker Menu Icon"> on the top left of the desktop. You should not be using anything outside of the VM while working on The Odin Project. If you feel like you have a good understanding after using the VM for a while, and or want to improve your experience, we recommend dual-booting Ubuntu, which there are instructions for below.
+
 #### Step 1.1: Download VirtualBox
 
 [Click here](https://www.virtualbox.org/wiki/Downloads "VirtualBox Downloads") and download VirtualBox for Windows hosts.


### PR DESCRIPTION
Users still come on and ask why they cannot download VSCode and show screenshots of their desktop with a tiny VM in the background.
This PR adds the statement that they will only use the VM when they want to work on TOP, and should upgrade to dual-booting in the future.