### PR TITLE
Typo in "all?" section

### DIFF
--- a/ruby_programming/basic_ruby/predicate_enumerable_methods.md
+++ b/ruby_programming/basic_ruby/predicate_enumerable_methods.md
@@ -161,7 +161,7 @@ fruits.all? { |fruit| fruit.length > 6 }
 #=> false
 ~~~
 
-Special note to keep in mind while debugging: `#all?` will return `true` be default unless the block returns `false` or `nil`. So if you call `#all?` on an empty array or hash (i.e., there are no elements  for the block to evaluate), it will return `true`.
+Special note to keep in mind while debugging: `#all?` will return `true` by default unless the block returns `false` or `nil`. So if you call `#all?` on an empty array or hash (i.e., there are no elements  for the block to evaluate), it will return `true`.
 
 ### The none? Method
 As you might expect, `#none?` performs the opposite function of `#all?`. It returns `true` only if the condition in the block matches *none* of the elements in your array or hash; otherwise, it returns `false`.


### PR DESCRIPTION
I believe it was intended to say "by default" instead of "be default"