### PR TITLE
Fixed RuboCop installation dead link

### DIFF
--- a/ruby_programming/intermediate_ruby/lesson_oop.md
+++ b/ruby_programming/intermediate_ruby/lesson_oop.md
@@ -68,7 +68,7 @@ Look through these now and then use them to test yourself after doing the assign
       2. [Ruby Explained: Inheritance and Scope](http://www.eriktrautman.com/posts/ruby-explained-inheritance-and-scope)
   5. Read the article [Object Relationships in Basic Ruby](https://medium.com/@marcellamaki/object-relationships-in-basic-ruby-1af5773fff48) to see an example of how two classes can interact.
   6. Read the [Bastard's Chapter on Error Handling](http://ruby.bastardsbook.com/chapters/exception-handling/) to reinforce your understanding of dealing with errors.
-  7. Glance over the [Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide) so you have an idea of how to make your code look more professional. It is recommended to install [rubocop](https://docs.rubocop.org/en/stable/installation/), a static code analyzer (linter) and formatter, which is based on this style guide.
+  7. Glance over the [Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide) so you have an idea of how to make your code look more professional. It is recommended to install [rubocop](https://docs.rubocop.org/rubocop/installation.html), a static code analyzer (linter) and formatter, which is based on this style guide.
 </div>
 
 ### Test Yourself


### PR DESCRIPTION
Hi Odin Project team,

I noticed the original link for RuboCop leads to a page with a "Page Not Found" error. I found the correct link to the installation page that I hope is the same one the previous link was trying to link to.

I wasn't sure where to raise this issue, hopefully this is the right place.

Best Regards,
Sandy
