### PR TITLE
add emphasis to part I

### DIFF
--- a/ruby_programming/basic_ruby/debugging.md
+++ b/ruby_programming/basic_ruby/debugging.md
@@ -167,7 +167,7 @@ Obviously, if available, the stack trace is the first place you should look when
 
 1. Go through the Ruby Guides [Ruby Debugging](https://www.rubyguides.com/2015/07/ruby-debugging/) tutorial, which covers everything about debugging in more depth.
 2. Read through the [Exceptions and Stack Traces](https://launchschool.com/books/ruby/read/more_stuff#readingstacktraces) section of Launch School's online book *Introduction to Programming with Ruby*.
-3. Download [this repository](https://github.com/learn-co-students/debugging-with-pry-v-000) and follow along with Part I of the [Debugging with Pry tutorial](https://learn.co/lessons/debugging-with-pry). Keep this repository, because Part II will be completed during the ruby testing section.
+3. Download [this repository](https://github.com/learn-co-students/debugging-with-pry-v-000) and follow along with **Part I** of the [Debugging with Pry tutorial](https://learn.co/lessons/debugging-with-pry). Keep this repository, because Part II will be completed during the ruby testing section.
 </div>
 
 ### Additional Resources


### PR DESCRIPTION
Lesson: https://www.theodinproject.com/courses/ruby-programming/lessons/debugging

Adding emphasis to the words 'Part I' so that students will hopefully only do this first part of the tutorial. 
