### PR TITLE
Step missing an "a" to match the one above

### DIFF
--- a/ruby_programming/intermediate_ruby/project_event_manager.md
+++ b/ruby_programming/intermediate_ruby/project_event_manager.md
@@ -1391,7 +1391,7 @@ already exist.
 Dir.mkdir("output") unless Dir.exists? "output"
 ~~~
 
-* Save each form letter to file based on the id of the attendee
+* Save each form letter to a file based on the id of the attendee
 
 [File#open](http://rubydoc.info/stdlib/core/File#open-class_method) allows us
 to open a file for reading and writing. The first parameter is the name of the


### PR DESCRIPTION
The list of steps for this section above has an "a" in it. Adding it here to keep consistency.