### PR TITLE
Tweak ES6 import note in testing-practice.md

### DIFF
--- a/javascript/testing/testing-practice.md
+++ b/javascript/testing/testing-practice.md
@@ -35,7 +35,7 @@ Write tests for the following functions, and then make the tests pass!
 
 ### Special Note on using ES6 import statements with Jest
 
-The current version of Jest as it is does not recognize the import statement. In order for you to be able to use ES6 modules for this project you may do the following:
+By default, the current version of Jest will not recognize ES6 import statements. In order for you to be able to use ES6 modules for this project you may do the following:
 
 1. Install the @babel/preset-env package
 


### PR DESCRIPTION
Currently the first sentence of the 'Special Note on ES6 import statements with Jest' section in testing-practice.md doesn't read very well (it took me a few goes to understand what it was saying - I initially thought there were some words missing). 

I have proposed an amended version which is easier to read.
