### PR TITLE
Update event_manager project.

### DIFF
--- a/ruby_programming/intermediate_ruby/project_event_manager.md
+++ b/ruby_programming/intermediate_ruby/project_event_manager.md
@@ -1497,7 +1497,7 @@ Using the registration date and time we want to find out what the peak registrat
 * [DateTime#strftime](http://rubydoc.info/stdlib/date/DateTime#strftime-instance_method) is a good reference on the
   characters necessary to match the specified date-time format.
 
-* Use [Date#hour](http://rubydoc.info/stdlib/date/Date#hour-instance_method) to find out the hour of the day.
+* Use [DateTime#hour](https://rubydoc.info/stdlib/date/DateTime#hour-instance_method) to find out the hour of the day.
 
 ## Iteration: Day of the Week Targeting
 


### PR DESCRIPTION
The class Date doesn't have a #hour method, the #hour method it's from the DateTime class https://rubydoc.info/stdlib/date/DateTime#hour-instance_method. And here it says #hour to DateTime too: https://ruby-doc.org/stdlib-2.7.1/libdoc/date/rdoc/index.html.