### PR TITLE
Add explanation that addEventListener uses callbacks

### DIFF
--- a/web_development_101/javascript_basics/DOM-manipulation.md
+++ b/web_development_101/javascript_basics/DOM-manipulation.md
@@ -407,7 +407,7 @@ btn.addEventListener('click', function (e) {
   console.log(e);
 });
 ~~~
-#### Note that e is a callback from addEventListener. Further explanation of callbacks can be found [HERE](https://briggs.dev/blog/understanding-callbacks)
+#### Note that function (e) is a callback from addEventListener. Further explanation of callbacks can be found [HERE](https://briggs.dev/blog/understanding-callbacks)
 
 The `e` in that function is an object that references the __event__ itself.  Within that object you have access to many useful properties and functions such as which mouse button or key was pressed, or information about the event's __target__ - the DOM node that was clicked.
 

--- a/web_development_101/javascript_basics/DOM-manipulation.md
+++ b/web_development_101/javascript_basics/DOM-manipulation.md
@@ -407,6 +407,7 @@ btn.addEventListener('click', function (e) {
   console.log(e);
 });
 ~~~
+#### Note that e is a callback from addEventListener. Further explanation of callbacks can be found [HERE](https://briggs.dev/blog/understanding-callbacks)
 
 The `e` in that function is an object that references the __event__ itself.  Within that object you have access to many useful properties and functions such as which mouse button or key was pressed, or information about the event's __target__ - the DOM node that was clicked.
 

--- a/web_development_101/javascript_basics/DOM-manipulation.md
+++ b/web_development_101/javascript_basics/DOM-manipulation.md
@@ -407,7 +407,7 @@ btn.addEventListener('click', function (e) {
   console.log(e);
 });
 ~~~
-#### Note that function (e) is a callback from addEventListener. Further explanation of callbacks can be found [HERE](https://briggs.dev/blog/understanding-callbacks)
+#### Note that function (e) is a callback from addEventListener. Further explanation of callbacks can be found [HERE.](https://briggs.dev/blog/understanding-callbacks)
 
 The `e` in that function is an object that references the __event__ itself.  Within that object you have access to many useful properties and functions such as which mouse button or key was pressed, or information about the event's __target__ - the DOM node that was clicked.
 


### PR DESCRIPTION
I was super confused when I saw that function(e) just worked somehow, and wondered where e was passed in. I got it explained to me on discord that e was passed in by addEventListener because it was defined to try to pass in arguments to the second input. Just seeing this without explanation made me confused, so I think something along these lines should be added.