### PR TITLE
Express messageboard project -- correct app.[method]s to router.[method]s

### DIFF
--- a/nodeJS/express-basics/Express-Mini-Message-Board.md
+++ b/nodeJS/express-basics/Express-Mini-Message-Board.md
@@ -24,7 +24,7 @@ Let's take a quick break from the main Express tutorial to practice what we've a
      ~~~
 
 4.   Next, in your index template (in the `"views"` folder) loop through the messages array using which ever templating language you selected and for each one, display the user, text and the date the message was added. Don't forget to make your messages available to your template by including it in the res.render 'locals' object (e.g. `res.render('index', { title: "Mini Messageboard", messages: messages })`.
-5.   Next lets set up the new message form.  In the router add an `app.get()` for the `"/new"` route and point it to a template named `"form"`. In the views directory create your `form` template. Add a heading, 2 inputs (one for the author's name and one for the message text) and a submit button. To make the form actually  make a network request you will need to define it with both a method and an action like so:
+5.   Next lets set up the new message form.  In the router add an `router.get()` for the `"/new"` route and point it to a template named `"form"`. In the views directory create your `form` template. Add a heading, 2 inputs (one for the author's name and one for the message text) and a submit button. To make the form actually  make a network request you will need to define it with both a method and an action like so:
 
      ~~~html
      <form method="POST" action="/new">
@@ -32,15 +32,15 @@ Let's take a quick break from the main Express tutorial to practice what we've a
      </form>
      ~~~
 
-6.   With your form set up like this, when you click on the submit button it should send a POST request to the url specified by the action attribute, so go back to your index router and add an `app.post()` for `"/new"`.
-7.   To actually get and use the data from your form you should be able to access the contents of your form inside `app.post()` as an object called `req.body`. The individual fields inside the body object are named according to the `name` attribute on your inputs (the value of `<input name="messageText">` will show up as `req.body.messageText` inside the `app.post` function).
-8.   In your `app.post()` take the contents of the form submission and push them into the messages array as an object that looks something like this:
+6.   With your form set up like this, when you click on the submit button it should send a POST request to the url specified by the action attribute, so go back to your index router and add an `router.post()` for `"/new"`.
+7.   To actually get and use the data from your form you should be able to access the contents of your form inside `router.post()` as an object called `req.body`. The individual fields inside the body object are named according to the `name` attribute on your inputs (the value of `<input name="messageText">` will show up as `req.body.messageText` inside the `router.post` function).
+8.   In your `router.post()` take the contents of the form submission and push them into the messages array as an object that looks something like this:
 
      ~~~javascript
      messages.push({text: messageText, user: messageUser, added: new Date()});
      ~~~
 
-9.   At the end of the `app.post()` function use `res.redirect('/')` to send users back to the index page after submitting a new message.
+9.   At the end of the `router.post()` function use `res.redirect('/')` to send users back to the index page after submitting a new message.
 10.  At this point, you should be able to visit `/new` (it might be a good idea to add a link to that route on your index page), fill out the form, submit it and then see it show up on the index page!
 11.  Now you're almost ready to deploy your application on Heroku, but before doing that you need to specify a couple of things, just to make life easier for your deployment. First, you need to specify the exact version of Node that you're using in your `package.json` file; if you don't remember the version number, just find it using `node -v`. Then, add it to your `package.json` file, so that it will look similar to this:
 


### PR DESCRIPTION
Per conversation [here](https://discordapp.com/channels/505093832157691914/597796701650026517/702163935385878588). If you're wondering what took so long, I was waiting for my earlier formatting pr to go through first, since they seemed like issues that should be addressed separately. Suffice it to say, I didn't anticipate how drawn out the earlier pr would be.

Repl.it you can play with [here](https://repl.it/@ScottBowles/Express-Mini-Messageboard). Use this rather than the repl.it I linked in the discord conversation, as this has the whole app uploaded.

In the routes/index.js file, it currently says to use app.get() and app.post(). Unless I'm missing something, it should be router.get() and router.post().

When I was going through the project, I had to make this change to make it work. I looked at a number of other student solutions and they all seem to do the same.