### PR TITLE
Fix typo in additional resources

### DIFF
--- a/ruby_programming/computer_science/lesson_recursion.md
+++ b/ruby_programming/computer_science/lesson_recursion.md
@@ -41,6 +41,6 @@ This section contains helpful links to other content. It isn't required, so cons
 * ["What is Ruby Recursion and How Does It Work?"](http://stackoverflow.com/questions/6418017/what-is-ruby-recursion-and-how-does-it-work) on Stack Overflow
 * [Efficient Recursion from U of Alberta](http://webdocs.cs.ualberta.ca/~holte/T26/efficient-rec.html)
 * [Natashatherobot's blog post on Recursion in Ruby](http://natashatherobot.com/recursion-factorials-fibonacci-ruby/)
-* [Functional Programming Techniquest with Ruby post](http://www.sitepoint.com/functional-programming-techniques-with-ruby-part-iii/), which covers recursion at the top
+* [Functional Programming Techniques with Ruby post](http://www.sitepoint.com/functional-programming-techniques-with-ruby-part-iii/), which covers recursion at the top
 * [CS50 explanation of recursion](https://www.youtube.com/watch?v=mz6tAJMVmfM)
 * [A breakdown of the recursive Fibonacci method](https://youtu.be/zg-ddPbzcKM) from Khan Academy


### PR DESCRIPTION
There's a "t" at the end of techniques in the resource's hyperlink