### PR TITLE
add info about rubocop for new users

### DIFF
--- a/ruby_programming/intermediate_ruby/lesson_oop.md
+++ b/ruby_programming/intermediate_ruby/lesson_oop.md
@@ -71,7 +71,7 @@ Look through these now and then use them to test yourself after doing the assign
   7. Glance over the [Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide) so you have an idea of how to make your code look more professional. It is recommended to install [rubocop](https://docs.rubocop.org/rubocop/installation.html), a static code analyzer (linter) and formatter, which is based on this style guide. 
     1. Read the [basic usage](https://docs.rubocop.org/rubocop/usage/basic_usage.html) of rubocop in the terminal. 
     2. Your code editor may have extensions that will utilize rubocop. For example, VSCode has two extensions: 'VSCode Ruby' and 'Ruby'. The 'Ruby' extension allows a rubocop dropdown option for a setting called, Ruby: Format.
-    3. As you begin to use rubocop, you will be inundated with multiple offenses that seem minor. At this point in your ruby knowledge, make the recommended adjustments and trust the wisdom of the Ruby community that developed this style guide. Research the offenses that you do not understand. If you feel strongly that you should ignore a particular rule, you can research ways to disable a particular rule or even ignore an entire file. 
+    3. As you begin to use rubocop, you will be inundated with multiple offenses that seem minor. At this point in your Ruby knowledge, make the recommended adjustments and trust the wisdom of the Ruby community that developed this style guide. Research the offenses that you do not understand. If you feel strongly that you should ignore a particular rule, you can research ways to disable a particular rule or even ignore an entire file. 
 </div>
 
 ### Test Yourself

--- a/ruby_programming/intermediate_ruby/lesson_oop.md
+++ b/ruby_programming/intermediate_ruby/lesson_oop.md
@@ -68,7 +68,10 @@ Look through these now and then use them to test yourself after doing the assign
       2. [Ruby Explained: Inheritance and Scope](http://www.eriktrautman.com/posts/ruby-explained-inheritance-and-scope)
   5. Read the article [Object Relationships in Basic Ruby](https://medium.com/@marcellamaki/object-relationships-in-basic-ruby-1af5773fff48) to see an example of how two classes can interact.
   6. Read the [Bastard's Chapter on Error Handling](http://ruby.bastardsbook.com/chapters/exception-handling/) to reinforce your understanding of dealing with errors.
-  7. Glance over the [Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide) so you have an idea of how to make your code look more professional. It is recommended to install [rubocop](https://docs.rubocop.org/rubocop/installation.html), a static code analyzer (linter) and formatter, which is based on this style guide.
+  7. Glance over the [Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide) so you have an idea of how to make your code look more professional. It is recommended to install [rubocop](https://docs.rubocop.org/rubocop/installation.html), a static code analyzer (linter) and formatter, which is based on this style guide. 
+    1. Read the [basic usage](https://docs.rubocop.org/rubocop/usage/basic_usage.html) of rubocop in the terminal. 
+    2. Your code editor may have extensions that will utilize rubocop. For example, VSCode has two extensions: 'VSCode Ruby' and 'Ruby'. The 'Ruby' extension allows a rubocop dropdown option for a setting called, Ruby: Format.
+    3. As you begin to use rubocop, you will be inundated with multiple offenses that seem minor. At this point in your ruby knowledge, make the recommended adjustments and trust the wisdom of the Ruby community that developed this style guide. Research the offenses that you do not understand. If you feel strongly that you should ignore a particular rule, you can research ways to disable a particular rule or even ignore an entire file. 
 </div>
 
 ### Test Yourself


### PR DESCRIPTION
lesson: https://www.theodinproject.com/courses/ruby-programming/lessons/object-oriented-programming

After adding the recommendation for users to install rubocop, it become apparent that users needed a bit more information to use it (from questions that I've seen on discord). I've seen people not know that you run it in terminal and that you can install extensions to use in your code editor. In addition, I wanted to add that new users should research the reasons behind any confusing rubocop rules because there has been some discussion about them too.

I was not sure the 'best' way to add this new information, so I kept with the current format of adding new numbers. However, I originally was thinking it would be in more paragraph form. Feel free to edit and update it as you see fit for this lesson.


