### PR TITLE
Removed e parameter from the second code block in the Event subsection of DOM manipultaion lesson under ‘attaching listeners to groups of nodes'.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
-This is a PR template. If you are adding a solution link to the curriculum, leave this as is. If not, delete it and write the message you wish.
+Hi there,
 
-Thank you,
+I'm using The Odin Project as my primary learning for about 2 months now. I just came around a typo or I think it’s a typo in Web Development 101 JavaScript basics section. In the Event subsection of the DOM Manipulation lesson under ‘attaching listeners to groups of nodes’, there’s a second code block describing how to use forEach method on a nodelist. I think there’s no need to pass ‘e’ as a parameter to the callback function as we’re accessing the button object’s id property, not e’s. I’ve removed e parameter from the code in DOM-manipulation.md file.
 
-The Odin Project team.
+Thank you.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
-Hi there,
+This is a PR template. If you are adding a solution link to the curriculum, leave this as is. If not, delete it and write the message you wish.
 
-I'm using The Odin Project as my primary learning for about 2 months now. I just came around a typo or I think it’s a typo in Web Development 101 JavaScript basics section. In the Event subsection of the DOM Manipulation lesson under ‘attaching listeners to groups of nodes’, there’s a second code block describing how to use forEach method on a nodelist. I think there’s no need to pass ‘e’ as a parameter to the callback function as we’re accessing the button object’s id property, not e’s. I’ve removed e parameter from the code in DOM-manipulation.md file.
+Thank you,
 
-Thank you.
+The Odin Project team.

--- a/web_development_101/javascript_basics/DOM-manipulation.md
+++ b/web_development_101/javascript_basics/DOM-manipulation.md
@@ -448,7 +448,7 @@ const buttons = document.querySelectorAll('button');
 buttons.forEach((button) => {
 
   // and for each one we add a 'click' listener
-  button.addEventListener('click', (e) => {
+  button.addEventListener('click', () => {
     alert(button.id);
   });
 });


### PR DESCRIPTION
Hi there,

I'm using The Odin Project as my primary learning for about 2 months now. I just came around a typo or I think it’s a typo in Web Development 101 JavaScript basics section. In the Event subsection of the DOM Manipulation lesson under ‘attaching listeners to groups of nodes’, there’s a second code block describing how to use forEach method on a nodelist. I think there’s no need to pass ‘e’ as a parameter to the callback function as we’re accessing the button object’s id property, not e’s. I’ve removed e parameter from the code in DOM-manipulation.md file.

Thank you.