### PR TITLE
Name updated on CWJobs

### DIFF
--- a/getting_hired/collect_leads.md
+++ b/getting_hired/collect_leads.md
@@ -19,7 +19,7 @@ Try checking out these links for job boards.  The more technically-focused, the 
 
 * [Authentic Jobs](http://www.authenticjobs.com)
 * [StackOverflow Jobs](https://stackoverflow.com/jobs)
-* [CWJobs](http://cwjobs.co.uk)
+* [CWJobs](http://cwjobs.co.uk) jobs just for uk
 * [Github Jobs](https://jobs.github.com/)
 * [White Truffle -- Weighted towards startups right now](http://www.whitetruffle.com)
 * [Dice.com](http://www.dice.com)


### PR DESCRIPTION
We should add an update to the name, because from what I saw they had no remote jobs, and all were just for UK

