### PR TITLE
Updated nvm install command

### DIFF
--- a/web_development_101/installations/installing_node.md
+++ b/web_development_101/installations/installing_node.md
@@ -20,7 +20,7 @@ sudo apt install curl
 Simply run this command:
 
 ~~~bash
-curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
 ~~~
 
 This will install `nvm`


### PR DESCRIPTION
The nvm install command uses an old release from January 2019, I updated it to use the latest nvm version.

Old release: https://github.com/nvm-sh/nvm/releases/tag/v0.34.0
Latest release: https://github.com/nvm-sh/nvm/releases/tag/v0.35.3
