### PR TITLE
Change line 100 on 'No such file or directory'

### DIFF
--- a/web_development_101/installations/setting_up_git.md
+++ b/web_development_101/installations/setting_up_git.md
@@ -97,7 +97,7 @@ First, we need to see if you have an SSH key already installed. Type this into t
 ls ~/.ssh/id_rsa.pub
 ~~~
 
-If the message in the console contains `No such file or directory`, then you don't have an SSH key, and you'll need to create one. If you do not see `No such file or directory` in the output, you already have a key; proceed to step 2.4.
+If a message appears in the console containing the text "No such file or directory", then you do not yet have an SSH key, and you will need to create one. If no message has appeared in the console output, you already have a key and can proceed to step 2.4.
 
 To create a new SSH key, run the following command inside your terminal. The `-C` flag followed by your email address ensures that GitHub knows who you are. 
 


### PR DESCRIPTION
Found that user on Discord was getting confused where "No such file or directory" was written twice. I restructured this paragraph in an attempt to make it less confusing.

