### PR TITLE
Keeping in-line with ruby convention

### DIFF
--- a/ruby_programming/testing_with_rspec/project_testing_your_ruby_code.md
+++ b/ruby_programming/testing_with_rspec/project_testing_your_ruby_code.md
@@ -9,7 +9,7 @@ You still may feel shaky on RSpec at this point (which is totally normal), so le
 <div class="lesson-content__panel" markdown="1">
   1. Go back to the [Caesar Cipher Project](/courses/ruby-programming/lessons/caesar-cipher) and write tests for your code.  It shouldn't take more than a half-dozen tests to cover all the possible cases.
   2. Write tests for your [Tic Tac Toe project](/courses/ruby-programming/lessons/oop).  In this situation, it's not quite as simple as just coming up with inputs and making sure the method returns the correct thing.  You'll need to make the tests determine victory or loss conditions are correctly assessed.
-      1. Start by writing tests to make sure players win when they should, e.g. when the board reads X X X across the top row, your `#game-over` method (or its equivalent) should trigger.
+      1. Start by writing tests to make sure players win when they should, e.g. when the board reads X X X across the top row, your `#game_over` method (or its equivalent) should trigger.
       2. Test each of your critical methods to make sure they function properly and handle edge cases.
       3. Try using mocks/doubles to isolate methods and make sure that they're sending back the right outputs.
 </div>


### PR DESCRIPTION
Words in Ruby method names can't be separated by a hyphen. Updated it to follow the convention of using an underscore.
