### PR TITLE
Fix sentence to be more clear

### DIFF
--- a/ruby_programming/intermediate_ruby/project_event_manager.md
+++ b/ruby_programming/intermediate_ruby/project_event_manager.md
@@ -296,8 +296,8 @@ lines.each_with_index do |line,index|
 end
 ~~~
 
-This solves the problem if the header row were to change in the future. It does
-assume that the header row is the first row in the file.
+This solves the problem if the header row were to change in the future. It
+assumes that the header row is the first row in the file.
 
 
 ### Look for a Solution before Building a Solution

--- a/ruby_programming/intermediate_ruby/project_event_manager.md
+++ b/ruby_programming/intermediate_ruby/project_event_manager.md
@@ -297,7 +297,7 @@ end
 ~~~
 
 This solves the problem if the header row were to change in the future. It does
-now assume that the header row is first row within the file.
+assume that the header row is the first row in the file.
 
 
 ### Look for a Solution before Building a Solution


### PR DESCRIPTION
The original sentence did not read clearly and also had a missing word. I made it more simple using more common grammar and fixed the typo. 