### PR TITLE
Update sub_strings.md

### DIFF
--- a/ruby_programming/basic_ruby_projects/sub_strings.md
+++ b/ruby_programming/basic_ruby_projects/sub_strings.md
@@ -19,8 +19,10 @@ Next, make sure your method can handle multiple words:
 
 ~~~ruby
   > substrings("Howdy partner, sit down! How's it going?", dictionary)
-  => { "down" => 1, "how" => 2, "howdy" => 1,"go" => 1, "going" => 1, "it" => 2, "i" => 3, "own" => 1,"part" => 1,"partner" => 1,"sit" => 1 }
+  => { "down" => 1, "go" => 1, "going" => 1, "how" => 2, "howdy" => 1, "it" => 2, "i" => 3, "own" => 1, "part" => 1, "partner" => 1, "sit" => 1 }
 ~~~
+
+Please note the order of your keys might be different.
 
 **Quick Tips:**
 


### PR DESCRIPTION
As discussed on the #ruby-help Discord channel with user Natty, there was a slight mistake in the order of the output example here. "how" and "howdy" should come after "go" and "going" for this program if "down" was the first outputted key. This now follows the order of the Dictionary array and matches the majority of submitted student solutions. 

If a #split method was used in the program on the starting array first, then "how" and "howdy" would come first before "go" and "going", but then "down" would not have come first. I corrected the output example here as well as a couple missing spaces between the keys and double quotes that were present. 

Finally, user Igni suggested adding a line that the output order of the keys might be different, since, for example, if students use the #split method then "how" and "howdy" should be first in that case.