### PR TITLE
changed snake-case to snake_case

### DIFF
--- a/ruby_programming/intermediate_ruby/project_event_manager.md
+++ b/ruby_programming/intermediate_ruby/project_event_manager.md
@@ -46,7 +46,7 @@ file within the 'lib' directory.
 
 Ruby source file names are often times written all in lower-case characters and
 instead of camel-casing multiple words together they are instead separated by an
-underscore (often called *snake-case*).
+underscore (often called *snake_case*).
 
 Open `lib/event_manager.rb` in your text editor and add the line:
 


### PR DESCRIPTION
it says that words are separated by underscore but instead, it uses minus sign. it is definitely trivial but I thought I'd propose to fix it.


