### PR TITLE
Fix bulleted list formatting

### DIFF
--- a/web_development_101/the_front_end/introduction_to_the_front_end.md
+++ b/web_development_101/the_front_end/introduction_to_the_front_end.md
@@ -30,6 +30,7 @@ Look through these now and then use them to test yourself after doing the assign
 
 ### Additional Resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something.
+
 * Watch [this awesome video](https://www.youtube.com/watch?v=gT0Lh1eYk78) explaining the big picture of the three core web technologies: HTML, CSS and JavaScript.
 * [This video](https://www.youtube.com/watch?v=BANChTkxYYY&list=PLwqG3V3cExWpCgHOcLEKg6z-InpjHr7MB) is another great introduction to how the various front-end technologies interact.
 * [Skills of a Successful Front-End Web Developer](https://web.archive.org/web/20151110193658/https://www.drupal.org/node/1245650) from Drupal (a CMS based on PHP).


### PR DESCRIPTION
It looks like a bulleted list is intended for the list of resources at the bottom of this page, under Additional Resources: https://www.theodinproject.com/courses/web-development-101/lessons/introduction-to-the-front-end

However, the list isn't showing up formatted with bullets (see image below).

![image](https://user-images.githubusercontent.com/20115216/89750605-8f6ad100-da81-11ea-8e1c-b2c036005365.png)

