### PR TITLE
Fix small typos

### DIFF
--- a/rails_programming/databases_and_activerecord/active_record_basics.md
+++ b/rails_programming/databases_and_activerecord/active_record_basics.md
@@ -67,7 +67,7 @@ The best part is that Rails knows that you want to do this and has given you a h
   create      spec/models/testmodel_spec.rb
 ~~~
 
-The model file that the generator creates is just a bare-bones model file in the `app/models` directory (which you could easily have created yourself).  The other main file is the migration file in the `db/migrate` folder, which starts with a complicated looking timestamp like `20130924230504_create_users.rb`. The number is simply the time that the migration was created so that rails can keep track of different migration files.
+The model file that the generator creates is just a bare-bones model file in the `app/models` directory (which you could easily have created yourself).  The other main file is the migration file in the `db/migrate` folder, which starts with a complicated looking timestamp like `20130924230504_create_users.rb`. The number is simply the time that the migration was created so that Rails can keep track of different migration files.
 
 If you dive into that file, you'll see that there's not much in it except another bare-bones Ruby class that inherits from `ActiveRecord::Migration` and some timestamps. The timestamps just create `created_at` and `updated_at` columns for you so you can track when your database records were created or modified. These two columns are just helpful enough that they are included as standard practice.
 
@@ -152,7 +152,7 @@ That was really just a teaser about what Active Record can do. In the reading be
 1. Read the [Rails Guides Validations chapter](http://guides.rubyonrails.org/active_record_validations.html)
     * Section 2 on helpers can be skimmed -- these help you get more specific with your validations and you'll run into them later
     * You can skim section 6 about custom validators
-    * Section 8 will likely only be interesting if you've seen ERB in rails views before... we'll get there.
+    * Section 8 will likely only be interesting if you've seen ERB in Rails views before... we'll get there.
 
 #### Associations
 1. Read the beginning of the [Rails Guides Associations Chapter](http://guides.rubyonrails.org/association_basics.html), just up until section 2.7.  Everything after that we can save for later... the important thing is that you've seen the relationships and how they're set up.


### PR DESCRIPTION
Change 'rails' to 'Rails'. To my knowledge rails is used when we talk about the command, but in these cases they refer to the Rails framework.

