### PR TITLE
JavaScript does have real actual classes

### DIFF
--- a/javascript/organizing-js/classes.md
+++ b/javascript/organizing-js/classes.md
@@ -1,7 +1,7 @@
 ### Introduction
-JavaScript does _not_ have classes in the same sense as other Object Oriented languages like Java or Ruby. ES6, however, _did_ introduce a syntax for object creation that uses the `class` keyword. It is basically a new syntax that does the _exact_ same thing as the object constructors and prototypes we learned about in the constructor lesson.
+ES6 introduced a syntax for object creation that uses the `class` keyword. It is basically a new syntax that does the _exact_ same thing as the object constructors and prototypes we learned about in the constructor lesson.
 
-There is a bit of controversy about using the class syntax, however. Opponents argue that `class` is basically just _syntactic sugar_ over the existing prototype-based constructors and that it's dangerous and/or misleading to obscure what's _really_ going on with these objects. Despite the controversy, classes are beginning to crop up in real code bases that you are almost certainly going to encounter such as frameworks like React.
+There is a bit of controversy about using the class syntax, however. Opponents argue that `class` is basically just _syntactic sugar_ over the existing prototype-based constructors and that it's dangerous and/or misleading to obscure what's _really_ going on with these objects. Proponents argue that `class` is implemented similar to Python or Ruby, where classes are mutable runtime objects and inheritance is delegation, and JavaScript's `class` is just as safe and clear as it is in those other languages. Despite the controversy, classes are beginning to crop up in real code bases that you are almost certainly going to encounter such as frameworks like React.
 
 Since we've already gone fairly in-depth with Constructors, you don't have too much left to learn here beyond the new syntax. If you choose to use classes in your code (that's fine!) you can use them much the same way as object constructors.
 


### PR DESCRIPTION
ECMAScript editors have explicitly said JS classes are real. Brian Terlson, for one example, was/is spec editor from ES7-present (you'll find his name in the spec for those editions). He occasionally comments on reddit, including [this comment](https://www.reddit.com/r/javascript/comments/4bmiqj/using_classes_in_javascript_es6_best_practice/d1avktu/). "It is not at all helpful for beginners to constantly be exposed to the notion that JS classes are 'fake'," he says, "They are not."

JS classes actually behave the same as classes in Python, Ruby, or Smalltalk, among others. If you write `instance.foo` in Python, for example, then it searches "instance" for a property named "foo". If it doesn't find it, then it follows a special link to another object and searches that other object for "foo". If it doesn't find it, then it follows that object's special link to another object, and so on until it finds a "foo" property or until the chain of object links ends. Here's a look at [JavaScript and Python classes side-by-side](https://i.imgur.com/p9Kw815.png).