### PR TITLE
JavaScript does have real actual classes v2

### DIFF
--- a/javascript/organizing-js/classes.md
+++ b/javascript/organizing-js/classes.md
@@ -1,7 +1,7 @@
 ### Introduction
-JavaScript does _not_ have classes in the same sense as other Object Oriented languages like Java or Ruby. ES6, however, _did_ introduce a syntax for object creation that uses the `class` keyword. It is basically a new syntax that does the _exact_ same thing as the object constructors and prototypes we learned about in the constructor lesson.
+ES6 introduced a syntax for object creation that uses the `class` keyword. It is basically a new syntax that does the _exact_ same thing as the object constructors and prototypes we learned about in the constructor lesson.
 
-There is a bit of controversy about using the class syntax, however. Opponents argue that `class` is basically just _syntactic sugar_ over the existing prototype-based constructors and that it's dangerous and/or misleading to obscure what's _really_ going on with these objects. Despite the controversy, classes are beginning to crop up in real code bases that you are almost certainly going to encounter such as frameworks like React.
+There is a bit of controversy about using the class syntax, however. Opponents argue that `class` is basically just _syntactic sugar_ over the existing prototype-based constructors and that it's dangerous and/or misleading to obscure what's _really_ going on with these objects. Proponents argue that `class` is implemented similar to Python or Ruby, where classes are mutable runtime objects and inheritance is delegation, and JavaScript's `class` is just as safe and clear as it is in those other languages. Despite the controversy, classes are beginning to crop up in real code bases that you are almost certainly going to encounter such as frameworks like React.
 
 Since we've already gone fairly in-depth with Constructors, you don't have too much left to learn here beyond the new syntax. If you choose to use classes in your code (that's fine!) you can use them much the same way as object constructors.
 


### PR DESCRIPTION
This is a continuation of #20031. I was explicitly told, "If you'd like to see this change, please make a new PR and we'll re-review it."

This PR removes, "JavaScript does not have classes."

The reasoning is:

- ECMAScript spec editors have explicitly said JavaScript *does* have classes.
- Under-the-hood implementation details matter, but implementing a feature differently than Java does not make it fake. If it did, then JavaScript's objects, arrays, functions, and much more would all also be fake. Those are all implemented differently than in Java too.
- JavaScript is not the only language to implement classes and inheritance differently than in Java. Python, Ruby, and even Smalltalk classes are implemented differently than in Java. In fact, classes in JavaScript, Python, and Ruby are strikingly similar. They are all runtime mutable objects that inherit at runtime via a delegation chain (aka objects linked to other objects).
- Repeated for emphasis: - ECMAScript spec editors have explicitly said JavaScript *does* have classes.