### PR TITLE
Fix small typos

### DIFF
--- a/rails_programming/databases_and_activerecord/project_ar_basics.md
+++ b/rails_programming/databases_and_activerecord/project_ar_basics.md
@@ -107,7 +107,7 @@ If any of those don't work, double check your associations.  Sometimes the error
 </div>
 
 ### Student Solutions
-Send us your solution by editing this [file](https://github.com/TheOdinProject/curriculum/blob/master/rails_programming/databases_and_activerecord/project_ar_basics.md) so we can show others! Submit a link to the Github repo with your files in it here using any of the methods listed on the [contributing page](http://github.com/TheOdinProject/curriculum/blob/master/contributing.md).  Please include your partner's github handle somewhere in the description if they would like attribution.
+Send us your solution by editing this [file](https://github.com/TheOdinProject/curriculum/blob/master/rails_programming/databases_and_activerecord/project_ar_basics.md) so we can show others!. Submit a link to the GitHub repo with your files in it here using any of the methods listed on the [contributing page](http://github.com/TheOdinProject/curriculum/blob/master/contributing.md).  Please include your partner's GitHub handle somewhere in the description if they would like attribution.
 
 <details markdown="block">
   <summary> Show Student Solutions </summary>


### PR DESCRIPTION
Add '.', change 'github' and 'Github' to 'GitHub'.
