### PR TITLE
Update typo of 'Dylia' to 'Lydia'

### DIFF
--- a/javascript/organizing-js/objects-constructors.md
+++ b/javascript/organizing-js/objects-constructors.md
@@ -242,4 +242,4 @@ If we had used `Object.create` in this example then we could safely edit the `Ni
 ### Additional Resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something.
 
-* [This article](https://dev.to/lydiahallie/javascript-visualized-prototypal-inheritance-47co) from Dylia Hallie and [This video](https://www.youtube.com/watch?v=sOrtAjyk4lQ) from Avelx explains the Prototype concept with graphics and simple language. Try using these resources if you want another perspective to understand the concept.
+* [This article](https://dev.to/lydiahallie/javascript-visualized-prototypal-inheritance-47co) from Lydia Hallie and [This video](https://www.youtube.com/watch?v=sOrtAjyk4lQ) from Avelx explains the Prototype concept with graphics and simple language. Try using these resources if you want another perspective to understand the concept.


### PR DESCRIPTION
There was a typo in the additional resources section of the objects constructor lesson. The authors name is `Lydia Hallie` but it was spelled `Dylia Hallie`. This change fixes the typo.