### PR TITLE
Change: Exercise to use specific book example

### DIFF
--- a/javascript/organizing-js/objects-constructors.md
+++ b/javascript/organizing-js/objects-constructors.md
@@ -132,12 +132,12 @@ player2.sayName() // logs 'also steve'
 
 ### Exercise
 
-Write a constructor for making "book" objects. We will revisit this in the project at the end of this lesson. Your book objects should have the book's `title`, `author`, the number of `pages`, and whether or not you have `read` the book
+Write a constructor for making "Book" objects. We will revisit this in the project at the end of this lesson. Your book objects should have the book's `title`, `author`, the number of `pages`, and whether or not you have `read` the book
 
-Put a function into the constructor that can report the book info like so
+Put a function into the constructor that can report the book info like so:
 
 ~~~javascript
-book.info() // "The Hobbit by J.R.R. Tolkien, 295 pages, not read yet"
+theHobbit.info() // "The Hobbit by J.R.R. Tolkien, 295 pages, not read yet"
 ~~~
 
 note: it is almost _always_ best to `return` things rather than putting `console.log()` directly into the function. In this case, return the `info` string and log it after the function has been called:


### PR DESCRIPTION
The current exercise example for "Objects and Constructors" lesson uses a non-specific example for the first code block, causing student confusion.

This change makes the examples between both blocks consistent and specific.