### PR TITLE
modify language of step 9 to accurately represent definition of node …

### DIFF
--- a/ruby_programming/computer_science/project_data_structures_algorithms.md
+++ b/ruby_programming/computer_science/project_data_structures_algorithms.md
@@ -25,7 +25,7 @@ You'll build a balanced BST in this assignment. Do not use duplicate values beca
 
   8. Write a `#height` method which accepts a node and returns its height. Height is defined as the number of edges in longest path from a given node to a leaf node.
 
-  9. Write a `#depth` method which accepts a node and returns the depth(number of levels) beneath the node.
+  9. Write a `#depth` method which accepts a node and returns its depth. Depth is defined as the number of edges in path from a given node to the tree's root node.
 
   10. Write a `#balanced?` method which checks if the tree is balanced. A balanced tree is one where the difference between heights of left subtree and right subtree of every node is not more than 1.
 


### PR DESCRIPTION
As noted in issue [here](https://github.com/TheOdinProject/curriculum/issues/20466), the language used to define depth (step 9) wasn't entirely accurate. This PR addresses that by using the language of _edges_ to mirror the definition of step 8 (height) above it. 