### PR TITLE
Practicing git basics: Change "git add ." to "git add -A"

### DIFF
--- a/web_development_101/git_basics/project_practicing_git_basics.md
+++ b/web_development_101/git_basics/project_practicing_git_basics.md
@@ -54,7 +54,7 @@ In this project, we'll walk through the basic Git workflow that you will use in 
 4. Add README.md to the staging area with `git add README.md`.
 5. Can you guess what `git status` will output now? README.md will be displayed in green text, while hello_world.txt will still be in red. This means that only README.md has been added to the staging area.
   <a href="https://imgur.com/b9tCLfT"><img class="tutorial-img" src="https://i.imgur.com/b9tCLfT.png" title="source: imgur.com" /></a>
-6. Now, add hello_world.txt to the staging area with a slightly different command: `git add .`, where the full stop means to add all files that are not staged. Then, type `git status` once more, and everything should now be in the staging area.
+6. Now, add hello_world.txt to the staging area with a slightly different command: `git add -A`, where the -A flag means to add all files that are not staged. Then, type `git status` once more, and everything should now be in the staging area.
   <a href="https://imgur.com/13jYJiV"><img class="tutorial-img" src="https://i.imgur.com/13jYJiV.png" title="source: imgur.com" /></a>
 9. Finally, let's commit all of the files that are in the staging area and add a descriptive commit message `git commit -m "Add hello_world.txt and edit README.md"`. Then, type `git status` once again, which will output "*nothing to commit*".
   <a href="https://imgur.com/9lda2lB"><img class="tutorial-img" src="https://i.imgur.com/9lda2lB.png" title="source: imgur.com" /></a>

--- a/web_development_101/git_basics/project_practicing_git_basics.md
+++ b/web_development_101/git_basics/project_practicing_git_basics.md
@@ -54,7 +54,7 @@ In this project, we'll walk through the basic Git workflow that you will use in 
 4. Add README.md to the staging area with `git add README.md`.
 5. Can you guess what `git status` will output now? README.md will be displayed in green text, while hello_world.txt will still be in red. This means that only README.md has been added to the staging area.
   <a href="https://imgur.com/b9tCLfT"><img class="tutorial-img" src="https://i.imgur.com/b9tCLfT.png" title="source: imgur.com" /></a>
-6. Now, add hello_world.txt to the staging area with a slightly different command: `git add -A`, where the -A flag means to add all files that are not staged. Then, type `git status` once more, and everything should now be in the staging area.
+6. Now, add hello_world.txt to the staging area with a slightly different command: `git add .`, where the full stop means to add all files **in the current directory** that are not staged. Then, type `git status` once more, and everything should now be in the staging area. *(Note: You can use `git add -A` to add ALL unstaged files to the staging area within the repository)*
   <a href="https://imgur.com/13jYJiV"><img class="tutorial-img" src="https://i.imgur.com/13jYJiV.png" title="source: imgur.com" /></a>
 9. Finally, let's commit all of the files that are in the staging area and add a descriptive commit message `git commit -m "Add hello_world.txt and edit README.md"`. Then, type `git status` once again, which will output "*nothing to commit*".
   <a href="https://imgur.com/9lda2lB"><img class="tutorial-img" src="https://i.imgur.com/9lda2lB.png" title="source: imgur.com" /></a>


### PR DESCRIPTION
Step 6 in the Add Another File section says that the full stop in "git add ." means to add all unstaged files, but the full stop actually means to add all unstaged files from only the current directory (and its subdirectories).

The correct command to add all unstaged files regardless of the current directory would be "git add -A". 

I propose we either change step 6 to use the "git add -A" command instead as seen in this PR, or clarify that the full stop only adds files from the current directory and its subdirectories.