### PR TITLE
Remove explicit reference to 'render()' fn

### DIFF
--- a/javascript/organizing-js/library-project.md
+++ b/javascript/organizing-js/library-project.md
@@ -21,7 +21,7 @@ Let's extend the 'Book' example from the previous lesson and turn it into a smal
    }
    ~~~
 
-3. Hook the array up to your HTML with a `render()` function that loops through the array and displays each book on the page. You can display them in some sort of table, or each on their own "card". It might help for now to manually add a few books to your array so you can see the display.
+3. Write a function that loops through the array and displays each book on the page. You can display them in some sort of table, or each on their own "card". It might help for now to manually add a few books to your array so you can see the display.
 4. Add a "NEW BOOK" button that brings up a form allowing users to input the details for the new book: author, title, number of pages, whether it's been read and anything else you might want.
 5. Add a button on each book's display to remove the book from the library.
    1. You will need to associate your DOM elements with the actual book objects in some way. One easy solution is giving them a data-attribute that corresponds to the index of the library array.


### PR DESCRIPTION
This lesson has faced a high volume of questions concerning the `render()` function named within the instructions. The name often misleads students in numerous ways and as a result has been generalized.