### PR TITLE
Fix code section advanced_topics.md

### DIFF
--- a/rails_programming/apis_mailers_advanced_topics/advanced_topics.md
+++ b/rails_programming/apis_mailers_advanced_topics/advanced_topics.md
@@ -55,7 +55,7 @@ The `$ rake routes` for a singular resource would only contain 6 routes (since w
 ...compared with the plural version of the same route:
 
 ~~~bash
-  edit_post  GET /posts/:id/edit(.:format)  posts#edit
+  edit_dashboard  GET /dashboards/:id/edit(.:format)  dashboards#edit
 ~~~
 
 ### Nested Routes


### PR DESCRIPTION
At line 52 there is an example of a dashboard route,  in line 55 it says 'compared with the plural version of the same route' (talking about the dashboard route) and in line 58 there is the example of a post route.

```
51  ~~~bash
52    edit_dashboard  GET /dashboard/edit(.:format)  dashboards#edit
53  ~~~
54
55  ...compared with the plural version of the same route:
56
57  ~~~bash
58    edit_post  GET /posts/:id/edit(.:format)  posts#edit
59  ~~~

```
