### PR TITLE
add rspec playground as an assignment

### DIFF
--- a/ruby_programming/testing_with_rspec/project_testing_your_ruby_code.md
+++ b/ruby_programming/testing_with_rspec/project_testing_your_ruby_code.md
@@ -8,10 +8,11 @@ You still may feel shaky on RSpec at this point (which is totally normal), so le
 
 <div class="lesson-content__panel" markdown="1">
   1. Go back to the [Caesar Cipher Project](/courses/ruby-programming/lessons/caesar-cipher) and write tests for your code.  It shouldn't take more than a half-dozen tests to cover all the possible cases.
-  2. Write tests for your [Tic Tac Toe project](/courses/ruby-programming/lessons/oop).  In this situation, it's not quite as simple as just coming up with inputs and making sure the method returns the correct thing.  You'll need to make the tests determine victory or loss conditions are correctly assessed.
+  2. Download the [RSpec Playground](https://github.com/TheOdinProject) and complete the lessons in the spec folder. 
+  3. Write tests for your [Tic Tac Toe project](/courses/ruby-programming/lessons/oop).  In this situation, it's not quite as simple as just coming up with inputs and making sure the method returns the correct thing.  You'll need to make the tests determine victory or loss conditions are correctly assessed.
       1. Start by writing tests to make sure players win when they should, e.g. when the board reads X X X across the top row, your `#game_over` method (or its equivalent) should trigger.
       2. Test each of your critical methods to make sure they function properly and handle edge cases.
-      3. Try using mocks/doubles to isolate methods and make sure that they're sending back the right outputs.
+      3. Use mocks/doubles to isolate methods to make sure that they're sending back the right outputs. 
 </div>
 
 ### Student Solutions

--- a/ruby_programming/testing_with_rspec/project_testing_your_ruby_code.md
+++ b/ruby_programming/testing_with_rspec/project_testing_your_ruby_code.md
@@ -8,7 +8,7 @@ You still may feel shaky on RSpec at this point (which is totally normal), so le
 
 <div class="lesson-content__panel" markdown="1">
   1. Go back to the [Caesar Cipher Project](/courses/ruby-programming/lessons/caesar-cipher) and write tests for your code.  It shouldn't take more than a half-dozen tests to cover all the possible cases.
-  2. Download the [RSpec Playground](https://github.com/TheOdinProject) and complete the lessons in the spec folder. 
+  2. Download [this repo](https://github.com/TheOdinProject/ruby_testing) and complete the lessons in the spec folder. 
   3. Write tests for your [Tic Tac Toe project](/courses/ruby-programming/lessons/oop).  In this situation, it's not quite as simple as just coming up with inputs and making sure the method returns the correct thing.  You'll need to make the tests determine victory or loss conditions are correctly assessed.
       1. Start by writing tests to make sure players win when they should, e.g. when the board reads X X X across the top row, your `#game_over` method (or its equivalent) should trigger.
       2. Test each of your critical methods to make sure they function properly and handle edge cases.


### PR DESCRIPTION
**Lesson:** https://www.theodinproject.com/courses/ruby-programming/lessons/testing-your-ruby-code

The purpose of this resource is to provide "hands-on" examples before testing Tic-Tac-Toe and doing TDD for Connect Four. If this resource is added, the repository will need to be moved to the TOP account & the link updated. **The current repository link is https://github.com/rlmoser99/ruby_rspec_TOP**

You can read the proposal.md file for additional background on why I created this resource. In addition, the contents.md file is a rough summary of the concepts that each lesson covers.

These lessons need a thorough review to verify that the information & explanations are correct. Here is a list of particular areas that concern me:
 - These lessons may "spoon feed" more information than necessary. 
 - The first 9 lessons are very simple ones and could be more of a hindrance/annoyance to some students.
 - Lesson 11 uses a shared example for multiple classes, which is not essential to Tic-Tac-Toe or Connect Four. 
 - Lessons 13 - 16 explains a lot of different concepts like stubs, message expectations, doubles, TDD, class encapsulation, polymorphism, testing methods in module, etc. 
 - Lesson 15 & 16 explains what methods should & should not be tested for these ruby terminal games, which is slightly different than in the "real world".
