### PR TITLE
Removed mention of partner contribution

### DIFF
--- a/ruby_programming/testing_with_rspec/project_testing_your_ruby_code.md
+++ b/ruby_programming/testing_with_rspec/project_testing_your_ruby_code.md
@@ -163,7 +163,7 @@ Only write exactly enough code to make your test pass.  Oftentimes, you'll end u
 </div>
 
 ### Student Solutions
-Send us your solution so we can show others! Submit a link to the GitHub repo with your files in it here using any of the methods listed on the [contributing page](http://github.com/TheOdinProject/curriculum/blob/master/contributing.md).  Please include your partner's github handle somewhere in the description if they would like attribution.
+Send us your solution so we can show others! Submit a link to the GitHub repo with your files in it here using any of the methods listed on the [contributing page](http://github.com/TheOdinProject/curriculum/blob/master/contributing.md).
 
 <details markdown="block">
   <summary> Show Student Solutions </summary>


### PR DESCRIPTION
In the student solution section of the TDD connect 4 project, it mentions to link your partners GitHub to share project creds. I made this PR because there are no partners associated with this project.

Thanks,
Henry