### PR TITLE
removed IRB for pry-byebug examples

### DIFF
--- a/ruby_programming/basic_ruby/debugging.md
+++ b/ruby_programming/basic_ruby/debugging.md
@@ -108,9 +108,7 @@ p []
 
 To use Pry-byebug, you'll first need to install it in your terminal by running `gem install pry-byebug`. You can then make it available in your program by requiring it at the top of your file with `require 'pry'`. Finally, to use Pry-byebug, you just need to call `binding.pry` at any point in your program.
 
-To follow along with the Pry-byebug examples here, you have two options:
- 1. You can open up a new IRB session and type all of the code in there. When the code hits the `binding.pry` statement, it will essentially open an IRB session inside of your current IRB session.
- 2. You can save the code into a Ruby file (e.g., `script.rb`) and then run the file in your terminal (e.g., `ruby script.rb`). When the code hits the `binding.pry` statement, a new IRB-like session will open inside the terminal.
+To follow along with these examples save the code into a Ruby file (e.g., `script.rb`) and then run the file in your terminal (e.g., `ruby script.rb`). When the code hits the `binding.pry` statement, a new IRB-like session will open inside the terminal.
 
 ~~~ruby
 require 'pry'


### PR DESCRIPTION
Lesson: https://www.theodinproject.com/courses/ruby-programming/lessons/debugging

Removed suggestion to do pry-bye-bug during an IRB session, because it does not work.
