### PR TITLE
Fix Svelte URL

### DIFF
--- a/javascript/frameworks/frameworks-introduction.md
+++ b/javascript/frameworks/frameworks-introduction.md
@@ -33,7 +33,7 @@ It's no secret that there are a _ton_ of Front-end frameworks in the world... so
 - [Angular](https://angular.io/)
 - [Vue](https://vuejs.org/)
 - [Preact](https://preactjs.com/)
-- [Svelte](https://svelte.technology/guide)
+- [Svelte](https://svelte.dev/)
 - [Inferno](https://infernojs.org/)
 - [Ember](https://www.emberjs.com/)
 - [HyperApp](https://github.com/hyperapp)


### PR DESCRIPTION
The existing Svelte link (which tried to link to an old tutorial page) was dead - replaced it with a link to the project's homepage, which is consistent with the other framework links.

svelte.technology now routes to svelte.dev

This is a PR template. If you are adding a solution link to the curriculum, leave this as is. If not, delete it and write the message you wish.

Thank you,

The Odin Project team.
