### PR TITLE
remove redundant learnco tutorial

### DIFF
--- a/ruby_programming/basic_ruby/debugging.md
+++ b/ruby_programming/basic_ruby/debugging.md
@@ -191,7 +191,6 @@ Obviously, if available, the stack trace is the first place you should look when
 
 1. Go through the Ruby Guides [Ruby Debugging](https://www.rubyguides.com/2015/07/ruby-debugging/) tutorial, which covers everything about debugging in more depth.
 2. Read through the [Exceptions and Stack Traces](https://launchschool.com/books/ruby/read/more_stuff#readingstacktraces) section of Launch School's online book *Introduction to Programming with Ruby*.
-3. Download [this repository](https://github.com/learn-co-students/debugging-with-pry-v-000) and follow along with **Part I** of the [Debugging with Pry tutorial](https://learn.co/lessons/debugging-with-pry). Keep this repository, because Part II will be completed during the ruby testing section.
 </div>
 
 ### Additional Resources

--- a/ruby_programming/testing_with_rspec/introduction_to_rspec.md
+++ b/ruby_programming/testing_with_rspec/introduction_to_rspec.md
@@ -233,8 +233,6 @@ end
 2. Write a test for a new `Calculator` method (`#multiply`, `#subtract`, or `#divide`) using a new `describe` block. Include at least one `it` block with an appropriate expectation clause. Get it to pass, and refactor if necessary.
 3. In the terminal, try running your failing or passing tests with `rspec --format documentation`. What's different?
 4. RSpec reads command line configurations from `.rspec`, one of the two files generated when RSpec is initialized in a project. If you liked the output you got with `--format documentation`, you can use the `.rspec` file to hold that flag. In doing so, you won't have to type it in every time you run your test suite. Open the file in your text editor and, on a new line, add `--format documentation`. For more information on configuring RSpec, see the docs [here](https://relishapp.com/rspec/rspec-core/v/3-7/docs/configuration).
-5. Let's switch gears back to the [Debugging with Pry tutorial](https://learn.co/lessons/debugging-with-pry) that was used in a previous lesson. In the terminal, navigate to the project directory of [this repository](https://github.com/learn-co-students/debugging-with-pry-v-000). Follow along with Part II of the tutorial for an example of using Pry during testing. Note: use `rspec` (instead of `learn`) from the directory root, to run the test.
-
 </div>
 
 ### Additional Resources


### PR DESCRIPTION
Lessons: 
https://www.theodinproject.com/courses/ruby-programming/lessons/debugging
https://www.theodinproject.com/courses/ruby-programming/lessons/introduction-to-rspec

This learnco tutorial is redundant and confuses most people, who do not read the instructions (telling them to only complete Part I during the debugging lesson). Without having rspec installed, people have errors with Part II. Now that the instructions for Pry-byebug have expanded, this tutorial is not longer needed.
