### PR TITLE
Update conditional_logic.md

### DIFF
--- a/ruby_programming/basic_ruby/conditional_logic.md
+++ b/ruby_programming/basic_ruby/conditional_logic.md
@@ -241,7 +241,7 @@ grade = 'F'
 case grade
 when 'A'
   puts "You're a genius"
-  future_bank_account_balance += 5000000
+  future_bank_account_balance = 5_000_000
 when 'D'
   puts "Better luck next time"
   can_i_retire_soon = false

--- a/ruby_programming/basic_ruby/conditional_logic.md
+++ b/ruby_programming/basic_ruby/conditional_logic.md
@@ -241,7 +241,7 @@ grade = 'F'
 case grade
 when 'A'
   puts "You're a genius"
-  future_bank_account_balance += 5,000,000
+  future_bank_account_balance += 5000000
 when 'D'
   puts "Better luck next time"
   can_i_retire_soon = false


### PR DESCRIPTION
Although the code at issue is clearly just an example demonstrating a `case` statement, I do not think we should permit it to contain code that is syntactically incorrect. Here, the example shows that an integer is allowed to contain commas. This is not true, and would result in the following error if attempted:

```ruby
> foo = 0
> foo += 50,000

# SyntaxError (syntax error, unexpected ',', expecting end-of-input)
# foo += 50,000
#          ^
```