### PR TITLE
Fix: React.js Section code block formatting

### DIFF
--- a/javascript/react-js/hooks.md
+++ b/javascript/react-js/hooks.md
@@ -12,7 +12,7 @@ Now we will discuss the most basic hooks.  Create a `create-react-app` and use t
 
 So finally, as already mentioned in an earlier section, we will be coming back here to discuss how to use state in functional components. The `useState` hook makes it possible to declare a state in functional components. Here is an example on how to use it:
 
-```javascript
+~~~javascript
 import React, { useState } from "react";
 
 const App = () => {
@@ -31,7 +31,7 @@ const App = () => {
 };
 
 export default App;
-```
+~~~
 
 Go try this out in the browser.
 
@@ -45,7 +45,7 @@ Afterwards we are declaring a function, which right now just sets a new count. I
 
 Well, we don't have any lifecycle methods such as `componentDidMount`, `componentDidUpdate` or `componentDidUnmount`, but we do have something better. We have `useEffect`, which can actually do everything the above mentioned lifecycle methods can do. Let's have a closer look.
 
-```javascript
+~~~javascript
 import React, { useState, useEffect } from "react";
 
 const App = () => {
@@ -88,7 +88,7 @@ const App = () => {
 };
 
 export default App;
-```
+~~~
 Try it out to get an idea of what is happening. 
  
 Once you've done that, let's go through it in all detail.
@@ -105,41 +105,41 @@ In the curly brackets you can write the code that will be executed. The dependen
 
 1. Leave it empty. If you leave it empty the useEffect hook would look something like this:
 
-```javascript
+~~~javascript
 useEffect(() => {
   // Do something
 }, []);
-```
+~~~
 
 This option is equal to a `componentDidMount` lifecycle method, meaning the hook runs **one time** when the component mounts (is inserted in the DOM tree)
 
 2. Add a dependency to the array. Like we did it in our example code.
 
-```javascript
+~~~javascript
 useEffect(() => {
   // Do something
 }, [color]);
-```
+~~~
 
 This way, the useEffect hook will re-run anytime the dependency (color) changes. This is similar to a `componentDidUpdate` method, with the only difference that it only runs when a certain condition has changed.
 
 3. Leave out the dependency array.
 
-```javascript
+~~~javascript
 useEffect(() => {
   // Do something
 });
-```
+~~~
 
 You can also completely leave out the dependency array. This way, the useEffect hook runs anytime the component is updated, **AND** right after the initial render. This is the difference compared to the `componentDidUpdate` lifecycle method, because it also runs after the initial render. This way it would be equal to a `componentDidMount` and `componenDidUpdate` method combined.
 
 The return statement we are adding to our useEffect is acually equal to a `componentWillUnmount` method. 
 
-```javascript
+~~~javascript
 return () => {
   document.removeEventListener("click", changeColorOnClick);
 };
-```
+~~~
 
 If you write a return statement like the above in a useEffect, it will do the same as a `componentWillUnmount` method. As you can see, there is a lot to the useEffect hook.  You can also create your own custom hooks if desired. However, with the above mentioned hooks `useState` and `useEffect` you will be fine in most of your smaller projects. 
 

--- a/javascript/react-js/inputs-and-lists.md
+++ b/javascript/react-js/inputs-and-lists.md
@@ -28,7 +28,7 @@ Our application will be made of two components, `App` and `Overview`. Your appli
 
 3. Open your `App.js` file in your `src` directory and make sure it looks like this.
 
-```javascript
+~~~javascript
 // App.js
 
 import React, { Component } from "react";
@@ -40,11 +40,11 @@ class App extends Component {
 }
 
 export default App;
-```
+~~~
 
 1. Make sure to clean the `index.js` as well. It should look something similar to this:
 
-```javascript
+~~~javascript
 // Index.js
 
 import React from "react";
@@ -57,14 +57,14 @@ ReactDOM.render(
   </React.StrictMode>,
   document.getElementById("root")
 );
-```
+~~~
 
 4. For our solution, we chose to style the application and will use Bootstrap to make our application look a little bit nicer. For those who don't know how Bootstrap works, in short: It is a CSS Framework, that helps us style our HTML easily. You add the styling through classNames. If you are following along with this and do not wish to style the application, you can skip to the next step and ignore any code concerning `className`. As for us, let's include it in our code. Get the bootstrap CDN from their website [here](https://getbootstrap.com/docs/4.3/getting-started/introduction/). Just copy the link element under the CSS section, it should be the first. Then, go to your `public` folder in your `task-app` and open the `index.html` file. Ignore the code in there for now, just paste the link you just copied **above** the `title` element and save the changes.
 
 5.Go back to your `src` directory and create a new folder called components with a file named`Overview.js`. This and our `App.js` file will be the main parts of the project. In `Overview.js`, we will display all our tasks, while the App component in `App.js` will contain all the logic and manage state. Don't forget to capitalize the names of your components. It doesn't change their functionality, but it is a widely accepted "best practice".
 t 6. Finally, let's write some code. To begin, in out`App.js` file, our class component should look like this.
 
-```javascript
+~~~javascript
 // App.js
 
 import React, { Component } from "react";
@@ -101,16 +101,16 @@ class App extends Component {
 }
 
 export default App;
-```
+~~~
 
 We created the skeleton of our component. First, we imported `React` and `Component` from "react", then we initialized the constructor. In the constructor, we defined state with:
 
-```javascript
+~~~javascript
 this.state = {
   task: "",
   tasks: [],
 };
-```
+~~~
 
 We assigned `task` to an empty string, this will be the state handling what we type in our input field. And `tasks` will initially be set to an empty array. Later, we will include all of our tasks here.
 Also, inside the render function, we destructured our state in order to make our code look cleaner when using it.
@@ -121,7 +121,7 @@ Now, let's have a look at what our application. looks like. Run `npm start` in y
 
 Let's add some functionality to it. Go back to your `App.js` component and add the following two functions. Make sure to add those functions between your constructor and the render method.
 
-```javascript
+~~~javascript
 handleChange = (e) => {
   this.setState({
     task: e.target.value,
@@ -135,7 +135,7 @@ onSubmitTask = (e) => {
     task: "",
   });
 };
-```
+~~~
 
 Naturally, if we do not invoke those functions nothing will change in our application. So let's call them. The `handleChange` function will be our `onChange` handler for our input field. It sets the current `task` in state to whatever we type in our input field. The `onSubmitTask` function will be our `onSubmit` handler for our `form` element. The `onSubmit` handler of the form should be invoked by a clicking the button.
 
@@ -143,9 +143,9 @@ In the `onSubmitTask` function, we first call `e.preventDefault()` because we do
 
 The following line does the magic.
 
-```javascript
+~~~javascript
 tasks: this.state.tasks.concat(this.state.task),
-```
+~~~
 
 It adds the task (whatever is in our input field by the time we submit the form) to our `tasks` array. Later we can map over this array to display all the tasks we submitted. Make sure that you **DON'T** directly assign state. That is also the reason we don't use the `push` method here. It would give us an error.
 After that, we just set our current task in state to an empty string because we want our input field to be empty, in order to add another task.
@@ -153,7 +153,7 @@ After that, we just set our current task in state to an empty string because we 
 We still haven't invoked those functions yet, so let's do that.
 In your `App.js` component in your render method, add an onChange handler to your input element like so:
 
-```javascript
+~~~javascript
 <input
   onChange={this.handleChange}
   value={this.state.task}
@@ -161,17 +161,17 @@ In your `App.js` component in your render method, add an onChange handler to you
   id="taskInput"
   className="form-control"
 />
-```
+~~~
 
 Notice that we also have to specify the `value` attribute for React input elements. In this case we want the value of the input field to be what we saved in our `task` state.
 And also add the `onSubmitTask` function to our form element like so:
 
-```javascript
+~~~javascript
 <form onSubmit={this.onSubmitTask}>
   {/* Leave all your code. Just add the onSubmit handler to the form element, or
   as an onClick handler to the submit button, as you prefere */}
 </form>
-```
+~~~
 
 If you add an onSubmit handler to the form, your button must be of `type="submit"`, otherwise it won't work. Alternatively, you can add an `onClick` event to the button which calls the `onSubmitTask` function
 
@@ -179,7 +179,7 @@ Great, if you run your application now with `npm start` (or refresh the browser 
 
 Go to your `Overview.js` file in the components folder and add the following code:
 
-```javascript
+~~~javascript
 // Overview.js
 
 import React from "react";
@@ -197,12 +197,12 @@ const Overview = (props) => {
 };
 
 export default Overview;
-```
+~~~
 
 It takes the `tasks` from the `props` and maps over it. For each task it will then display a `li` element with the content of tasks. When checking out the application in the browser we can see we received an error message which says that a unique key is required. React always requires you to add a unique key to each element when you `map` over a list. In real world projects you often use database ids as unique keys, however in this project we are not using a database, so let's install a package that provides us with unique ids.
 Run `npm install uniqid` in your project folder. Uniqid is a package which creates unique ids based on the current time, the process and the machine name. Once this is done, we just have to include it like this:
 
-```javascript
+~~~javascript
 // Overview.js
 
 import React from "react";
@@ -222,27 +222,27 @@ const Overview = (props) => {
 };
 
 export default Overview;
-```
+~~~
 
 Almost done, the only thing we need to do is importour `Overview` component to our `App.js` file and add it in our render method, as well as passing down the `tasks` array as props.
 
 Add this line to the top of your `App.js` file, right below where we import React.
 
-```javascript
+~~~javascript
 import Overview from "./components/Overview";
-```
+~~~
 
 And then add the Overview component to your render method in `App.js`. Add this line of code right before the last closing `div`, and right after the closing `form` tag in `App.js`.
 
-```javascript
+~~~javascript
 <Overview tasks={tasks} />
-```
+~~~
 
 Here we go, run `npm start` (or refresh) one last time. If you've done everything right, you should now be able to type a task into the input field and click submit to display it right below the input field. Feel free to play around a little bit and maybe change or style it as you like.
 
 Your finished files should look like this:
 
-```javascript
+~~~javascript
 // App.js
 
 import React, { Component } from "react";
@@ -302,9 +302,9 @@ class App extends Component {
 }
 
 export default App;
-```
+~~~
 
-```javascript
+~~~javascript
 // Overview.js
 
 import React from "react";
@@ -323,7 +323,7 @@ const Overview = (props) => {
 };
 
 export default Overview;
-```
+~~~
 
 ### Optional Tasks / Ideas to play around
 

--- a/javascript/react-js/react-introduction.md
+++ b/javascript/react-js/react-introduction.md
@@ -42,7 +42,7 @@ In the beginning, it might be a little bit difficult to figure out the best comp
 
 To give you an example of a basic component, see the following code:
 
-```javascript
+~~~javascript
 import React, { Component } from 'react'
 
 class App extends Component {
@@ -62,39 +62,39 @@ class App extends Component {
 }
 
 export default App
-```
+~~~
 
 Don't get overwhelmed. It isn't as difficult as it might look at the beginning. Let's walk through it step by step.
 
-```javascript
+~~~javascript
 import React, { Component } from "react";
-```
+~~~
 
 With the above `import` statement, we are importing React and the Components module from the React library, which allows us to create a class component. If you are wondering why we have to wrap `Component` into curly brackets and `React` not, this is due to the way they are exported from the `react` module. Default exports are imported without curly brackets; everything else must be wrapped in curly brackets. Don't worry about this too much as we will get plenty of exposure to import and export statements soon.
 
-```javascript
+~~~javascript
 class App extends Component {
     {/* Some logic we haven't yet talked about. */}
 }
-```
+~~~
 
 Secondly, we are declaring the class component, which is just a JavaScript class that extends the Component class we imported earlier. One thing to notice is that React components should always be declared with a capital letter at the beginning. This is a naming convention used by most developers and recommended by the React core team at Facebook.
 
-```javascript
+~~~javascript
 constructor() {
     super()
 }
-```
+~~~
 
 Next is the constructor. A constructor is not obligatory in a class component, but you will most likely encounter one because it becomes important when concepts like inheritance and state are involved. To get used to seeing it, it has been included here. You will usually see developers passing `props` as an argument to the constructor and also to the `super()` call, which must be called in any constructor. However, you will not learn about props here. This concept will be discussed further in the next lesson. The idea here is to expose you to the terminology that we will be using in the future.
 
-```javascript
+~~~javascript
 {/* Some logic we haven't yet talked about. */}
-```
+~~~
 
 This syntax may look weird at first, but it is nothing more than a simple comment. In React, you write comments within curly brackets and quotes.
 
-```javascript
+~~~javascript
 render() {
     return (
         <div className="App">
@@ -102,15 +102,15 @@ render() {
         </div>
     )
 }
-```
+~~~
 
 The most unfamiliar code is likely the render function, which returns something that looks like HTML, but is actually JSX. One of the primary characteristics and features of React is the ability to combine JavaScript and JSX. **JSX** is an HTML-like syntax that will be transpiled into JavaScript so a browser will be able to process it. One thing you should know about JSX is that you can't use the HTML protected words, such as `class` or `onchange`. Instead of `class` you write `className` and instead of `onchange` you write `onChange`. In general, all attributes in JSX are written in camelCase. You should be fairly familiar with that naming convention from the naming of variables in JavaScript. The render function you see is the most used React lifecycle function (more to that in another section). The only thing you should know for now is that every React class component needs a render function, which returns _one_ JSX element. So whatever you want to return needs to be wrapped in a single element.
 
 Finally, to be able to reuse this `App`component we created in other files of our project, we have to export the component. In our example, we export the component as the file's default export:
 
-```javascript
+~~~javascript
 export default App;
-```
+~~~
 
 If you have multiple components in one file, you could export each component separately by adding the `export` keyword before the declaration of the component. However, if you export a component as a default, you can import it without wrapping curly brackets around it. If you export multiple components, you have to import them inside of curly brackets.
 
@@ -118,7 +118,7 @@ So far, so good! We have already learned a lot about components in React, and le
 
 A basic functional component looks like the following
 
-```javascript
+~~~javascript
 import React from "react";
 
 const App = () => {
@@ -126,7 +126,7 @@ const App = () => {
 };
 
 export default App;
-```
+~~~
 
 As you can see, there are a couple of differences between functional and class based components.
 

--- a/javascript/react-js/router.md
+++ b/javascript/react-js/router.md
@@ -6,7 +6,7 @@ Let's go through it step by step. First of all, create a new project using `crea
 
 Once you've done that, let's create a new file called `Profile.js` inside the src directory, and add a basic functional component to it, which just contains an `h1` element.
 
-```javascript
+~~~javascript
 import React from "react";
 
 const Profile = () => {
@@ -18,11 +18,11 @@ const Profile = () => {
 };
 
 export default Profile;
-```
+~~~
 
 And also make sure your `App.js` file looks like this:
 
-```javascript
+~~~javascript
 import React from "react";
 
 const App = () => {
@@ -34,14 +34,14 @@ const App = () => {
 };
 
 export default App;
-```
+~~~
 
 Once you have this, install the package. Open a terminal and run `npm i react-router-dom`. This is going to install all the dependencies for us.
 While this is happening we can already create a new file called `Routes.js`, which is going to be the file that handles all of our routes.
 
 Once the package is finished installing, you can add this code to your Routes.js file.
 
-```javascript
+~~~javascript
 import React from "react";
 import { BrowserRouter, Switch, Route } from "react-router-dom";
 import App from "./App";
@@ -59,7 +59,7 @@ const Routes = () => {
 };
 
 export default Routes;
-```
+~~~
 
 So what is happening here? First we are importing React, our two components; Profile and App, as well as a couple of things from the package we just installed.
 
@@ -71,7 +71,7 @@ So what is happening here? First we are importing React, our two components; Pro
 
 Let us check this behavior in the Browser for better understanding. However, before we can do that we have to do one more thing. We have to change our `index.js` file. This is because we don't want our `App.js` file to be the first file to be called when our applications runs. Instead, we want our `Routes.js` to be the first. Your `index.js` should look something like this:
 
-```javascript
+~~~javascript
 import React from "react";
 import ReactDOM from "react-dom";
 import Routes from "./Routes";
@@ -82,7 +82,7 @@ ReactDOM.render(
   </React.StrictMode>,
   document.getElementById("root")
 );
-```
+~~~
 
 Once this is done, go ahead and run `npm start` and then check out both routes; the home route "/" and the profile route "/profile".
 In both cases, the "Hello from App" from our App component is displayed.
@@ -93,11 +93,11 @@ Now there are two solutions to this problem.
 
 2. Add the `exact` keyword to your routes. So make them look like this:
 
-```javascript
+~~~javascript
 <Route exact path="/" component={App} />
 <Route exact path="/profile" component={Profile} />
 
-```
+~~~
 
 As you can see, this also works. The exact keyword just specifies that the routes path has to match exactly the URL path.
 

--- a/javascript/react-js/state-and-props.md
+++ b/javascript/react-js/state-and-props.md
@@ -10,7 +10,7 @@ In the previous lesson, you learned a lot about components and how to structure 
 
 Let's take the following example:
 
-```javascript
+~~~javascript
 // MyComponent.js
 
 import React, { Component } from "react";
@@ -30,9 +30,9 @@ class MyComponent extends Component {
 }
 
 export default MyComponent;
-```
+~~~
 
-```javascript
+~~~javascript
 // App.js
 
 import React, { Component } from "react";
@@ -53,14 +53,14 @@ class App extends Component {
 }
 
 export default App;
-```
+~~~
 
 Let's take a look at what is happening here. Above, there are two components, `MyComponent` and `App`. As you can see, `MyComponent` is a child component of `App`, which passes down a property called `title`. In this specific example, the title is set to "React". In `MyComponent`, we can access the title (React) that has been passed down with the syntax `this.props.title`. The curly brackets around it are always needed when you write JavaScript in React.
 _IMPORTANT_: Make sure you pass `props` to the constructor of the child component (MyComponent) as well as the `super()` method, otherwise you will not be able to access `this.props.title` in `MyComponent`.
 
 Now you might be wondering how this works with functions. Believe it or not, it works the same!
 
-```javascript
+~~~javascript
 // MyComponent.js
 
 import React, { Component } from "react";
@@ -81,9 +81,9 @@ class MyComponent extends Component {
 }
 
 export default MyComponent;
-```
+~~~
 
-```javascript
+~~~javascript
 // App.js
 
 import React, { Component } from "react";
@@ -110,13 +110,13 @@ class App extends Component {
 }
 
 export default App;
-```
+~~~
 
 Ok, there is a little bit more going on here, but in the end, it works exactly as in the example before. First, there is the `MyComponent`, which is essentially the same. The only thing we added is the `{ this.props.onButtonClicked }` as an `onClick` event to the component. You should already be familiar with this syntax. Now to the `App` component. First, we defined the function `onClickBtn` above the `render` method. After that, we passed this function down to our `MyComponent` as a property, which we named `onButtonClicked` (Of course, you could also name it `onClickBtn`, and then use the function in `MyComponent.js` by the name of `onClickBtn`, but we wanted to emphasize that you can rename the functions when passing them around as props). We do that the same way we passed the title value previously. Now the only thing we have to do is bind the method to `this`; we do that in the constructor method at the top of our component but below the `super()` call. The reason we have to bind the `this` keyword when passing a function to another component is that it needs to stay in the same context. So remember, you have to bind `this` for all functions in all **class components** when passing them to other components.
 
 As you can see when you are passing many properties or functions to a component, it can get quite exhausting to always refer to them with `this.props.someProperty`. Destructuring to the rescue! We can alternatively write the above as follows:
 
-```javascript
+~~~javascript
 // MyComponent.js
 
 import React, { Component } from "react";
@@ -139,7 +139,7 @@ class MyComponent extends Component {
 }
 
 export default MyComponent;
-```
+~~~
 
 Here, we are destructuring `title` and `onButtonClicked` from `this.props`, which lets us refer to them with just their names. Make sure to destructure within the render method when using class components. In functional components (more on those later!), you would destructure outside of the return statement.
 
@@ -151,7 +151,7 @@ Another very important concept in React is "state". In short, all values that ca
 
 The following example shows how to define `state` in React:
 
-```javascript
+~~~javascript
 import React, { Components } from "react";
 
 class App extends Component {
@@ -178,7 +178,7 @@ class App extends Component {
     );
   }
 }
-```
+~~~
 
 In the above component, we declared a piece of state. You **always* declare state in the constructor of a class component. Keep in mind that this will work differently when we cover functional components later. The `setState` method we call sets the state to a new value. In React, state is **immutable**. This means you should **never** change state directly because it can lead to unexpected behavior or bugs. What exactly does that mean? Never do something like this: `this.state.count = 3`, instead always use the [setState](https://reactjs.org/docs/react-component.html#setstate) method React provides built-in to modify the state. Keep this in mind, it can save you a lot of debugging when you are getting started with React. Take a look at [this article](https://lorenstewart.me/2017/01/22/javascript-array-methods-mutating-vs-non-mutating/), which does a great job in analyzing many popular JavaScript methods concerning mutability.
 
@@ -188,7 +188,7 @@ As you have also seen in the `render` method, we access the current state throug
 
 As you have learned, React provides the ability to create functional components. They work a little bit differently than the class components we've discussed thus far. The concept of props works mostly the same, with the only difference being that you don't pass `props` as an argument to the constructor, instead you pass it as an argument to the component itself. Another major difference between functional and class components concerning props is the way you call the props. You learned that in a class component, the props that have been passed down from the parent component will be called like so: `this.props.someFunction`, however in functional components, we don't need to call `this`, so we access `props` like so: `props.someFunction`. That's the main difference with `props` between class and functional components. Let me give you a quick example to emphasize this.
 
-```javascript
+~~~javascript
 // MyComponent.js
 
 import React from "react";
@@ -198,9 +198,9 @@ const MyComponent = (props) => {
 };
 
 export default MyComponent;
-```
+~~~
 
-```javascript
+~~~javascript
 // App.js
 
 import React from "react";
@@ -215,7 +215,7 @@ const App = () => {
 };
 
 export default App;
-```
+~~~
 
 Of course, we can also destructure from props here. By adding this line `const {title} = props` above the return statement in `MyComponent.js` we can just refer to the title using `{title}`.
 


### PR DESCRIPTION
The website's markdown parser requires the use of three tildes, as opposed to back-ticks, to properly display blocks of code.

This pull request updates all code blocks to use the appropriate symbols.