### PR TITLE
Update arrays.md

### DIFF
--- a/ruby_programming/basic_ruby/arrays.md
+++ b/ruby_programming/basic_ruby/arrays.md
@@ -73,8 +73,8 @@ The methods `#shift` and `#unshift` are used to add and remove elements at the b
 ~~~ruby
 num_array = [2, 3, 4]
 
-num_array.unshift(1)   #=> [1, 2, 3, 4]
-num_array.shift           #=> [1]
+num_array.unshift(1)      #=> [1, 2, 3, 4]
+num_array.shift           #=> 1
 num_array                 #=> [2, 3, 4]
 ~~~
 


### PR DESCRIPTION
If `num_array = [1, 2, 3, 4]`, then calling `num_array.shift` will return `1`, not `[1]`.

The `#shift` method would only return `[1]` in this context if invoked as `num_array.shift(1)`.

Source: [https://ruby-doc.org/core-2.5.0/Array.html#method-i-shift](https://ruby-doc.org/core-2.5.0/Array.html#method-i-shift)