### PR TITLE
Changed this.countUp to () => this.countUp() in state lesson

### DIFF
--- a/javascript/react-js/state-and-props.md
+++ b/javascript/react-js/state-and-props.md
@@ -172,7 +172,7 @@ class App extends Component {
   render() {
     return (
       <div>
-        <button onClick={this.countUp}>Click Me!</button>
+        <button onClick={() => this.countUp()}>Click Me!</button>
         <p>{this.state.count}</p>
       </div>
     );


### PR DESCRIPTION
I was having errors regarding the said function so I found out that it had to be in a arrow function and also the parenthesis. I don't know if it's a problem only for me though.

