### PR TITLE
Update link in ### Practice

### DIFF
--- a/web_development_101/javascript_basics/fundamentals-2.md
+++ b/web_development_101/javascript_basics/fundamentals-2.md
@@ -46,7 +46,7 @@ Now it's time for the fun stuff...  So far we haven't done much with our program
 
 To give you a good bit of practice, we have created an online classroom on repl.it. In general, we believe that it's best to practice programming on your _own_ computer rather than in an online environment, but we'll get to that soon enough.
 
-- The classroom and lessons can be found [here](https://repl.it/community/classrooms/34425). Sign up or login to repl.it to see the lessons, and be sure to do the lessons in order. In order to do the lessons, first click on "Take and Learn", and then go to [Student](https://repl.it/student) and click on the Classroom. You can submit your answers to check them, and a couple of the lessons include 'model solutions'.
+- The classroom and lessons can be found <i>[here](https://repl.it/community/classrooms/34425)</i>. Sign up or login to repl.it to see the lessons, and be sure to do the lessons in order. In order to do the lessons, first click on "Take and Learn", and then go to [Student](https://repl.it/student) and click on the Classroom. You can submit your answers to check them, and a couple of the lessons include 'model solutions'.
 
 ### Additional Resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something.


### PR DESCRIPTION
The url (https://repl.it/community/classrooms/34425) in section ### Practice keeps redirecting to https://repl.it/talk/all. Need to find an updated link to classroom or delete this section? Admins, please advise.

-Michael 