### PR TITLE
Fix subject-verb agreement

### DIFF
--- a/web_development_101/installations/text_editors.md
+++ b/web_development_101/installations/text_editors.md
@@ -3,7 +3,7 @@ A text editor is by far the most used developer tool regardless of what type of 
 
 ### Why can't I use Microsoft Word?
 
-Rich text editors, such as Microsoft Word and Libre-Office Writer, are great for writing a paper, but the features that make them good at creating nicely formatted documents make them unsuitable for writing code. A document created with these rich text editors have more than just text embedded in their files. These files also contain information on how to display the text on the screen and data on how to display graphics embedded into the document. In contrast, plain text editors, such as VSCode and Sublime, don't save any additional information. Saving only the text allows other programs, like Ruby's interpreter, to read and execute the file as code.
+Rich text editors, such as Microsoft Word and Libre-Office Writer, are great for writing a paper, but the features that make them good at creating nicely formatted documents make them unsuitable for writing code. A document created with these rich text editors has more than just text embedded in the file. These files also contain information on how to display the text on the screen and data on how to display graphics embedded into the document. In contrast, plain text editors, such as VSCode and Sublime, don't save any additional information. Saving only the text allows other programs, like Ruby's interpreter, to read and execute the file as code.
 
 ### Code Editors
 


### PR DESCRIPTION
Use the correct conjugation of the verb 'has' to agree with the subject 'document'. Also correct the end of the sentence to match the initial subject of 'document'. The original sentence seems to have accidentally morphed the subject from 'document' to 'text editors' resulting in the error.
