### PR TITLE
Remove irrelevant links from Additional Resources

### DIFF
--- a/ruby_programming/object_oriented_programming_basics/project_mastermind.md
+++ b/ruby_programming/object_oriented_programming_basics/project_mastermind.md
@@ -20,5 +20,3 @@ Build a Mastermind game from the command line where you have 12 turns to guess t
 This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something.
 
 * Not directly helpful, but here are some [Ruby game libraries](https://www.ruby-toolbox.com/categories/game_libraries) for fun.
-* A [walkthrough of how to build Tic Tac Toe in Ruby](http://codequizzes.wordpress.com/2013/10/25/creating-a-tic-tac-toe-game-with-ruby/) from the codequizzes blog.
-* An [example solution on RosettaCode.org](http://rosettacode.org/wiki/Tic-tac-toe#Ruby)


### PR DESCRIPTION
The Additional Resources section of Ruby Programming's Mastermind project is identical to that of the Tic Tac Toe project. Since the last two links are more relevant to the Tic Tac Toe project, suggesting removal of the links from the Mastermind page for clarity/avoid redundancy. Hope that makes sense. Cheers.