### PR TITLE
Add a relevant link in the lesson

### DIFF
--- a/web_development_101/installations/installation_overview.md
+++ b/web_development_101/installations/installation_overview.md
@@ -14,7 +14,7 @@ In the next few lessons, we will walk through these installation steps together:
 
 * installing the [operating system](https://en.wikipedia.org/wiki/Operating_system) (OS) of your choice;
 * installing a code editor;
-* creating an SSH key (a personal "password" that will identify you to GitHub, Heroku, and many other sites you'll be using);
+* creating an [SSH key](https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys-2) (a personal "password" that will identify you to GitHub, Heroku, and many other sites you'll be using);
 
 At the end of this section, you'll be up and running with many of the tools you need to write and run code! It may seem like a lot of steps, but we'll get through it as painlessly as possible together! If anything goes wrong, remember to use these steps:
 


### PR DESCRIPTION

As I was going through the installation lesson, setting up _SSH keys_ was mentioned in brief. Naturally curious, I had to look it up because I didn't have much idea on _SSH_. 
It would be convenient to have a link to an explanation on _SSH keys_, and how to set it up thus improving the overall reading experience for students or rather mention that it would be discussed later in the future lessons if that was _the_ case. 