### PR TITLE
Renaming curriculum Tracks to Paths.

### DIFF
--- a/javascript/js-rails/rails_backend.md
+++ b/javascript/js-rails/rails_backend.md
@@ -6,19 +6,19 @@ While Local Storage is great, it's not ideal: it only stores data on the compute
 
 ### OK, so ... now what? 
 
-Where you go from here will depend in part on what you've learned so far. If you are on the [full-stack Ruby on Rails track](https://www.theodinproject.com/tracks/full-stack-ruby-on-rails), hooray: you already have all of the tools you need to build your own full-fledged web app from scratch! 
+Where you go from here will depend in part on what you've learned so far. If you are on the [full-stack Ruby on Rails path](https://www.theodinproject.com/paths/full-stack-ruby-on-rails), hooray: you already have all of the tools you need to build your own full-fledged web app from scratch! 
 
 If not, never fear: you can learn how to build a back-end later using [Node.js](https://www.theodinproject.com/courses/nodejs) ... or you may decide to learn Ruby on Rails after all. For now, you can outsource your backend functionality to a Backend-as-a-Service (BaaS) company like [Firebase](https://www.firebase.com/) or [Apigee](http://apigee.com/). 
 
 #### Building your own backend with Ruby on Rails
 
-For those of you who are on the [full-stack Ruby on Rails track](https://www.theodinproject.com/tracks/full-stack-ruby-on-rails), the next step is obvious: you get to build your own backend with Rails! In preparation, reread the [Rails lesson on building an API](/courses/ruby-on-rails/lessons/apis-and-building-your-own) to refresh how to set up a Rails backend that can handle JSON requests.
+For those of you who are on the [full-stack Ruby on Rails path](https://www.theodinproject.com/paths/full-stack-ruby-on-rails), the next step is obvious: you get to build your own backend with Rails! In preparation, reread the [Rails lesson on building an API](/courses/ruby-on-rails/lessons/apis-and-building-your-own) to refresh how to set up a Rails backend that can handle JSON requests.
 
 Are you done? Good. Next, it's time to practice allowing your front end Javascript to talk to your Rails backend using AJAX.  We'll cover some best practices for how to pass data from one to another, but otherwise it's up to you: you've got everything you need to put together those final pieces of the web development puzzle.
 
 #### Outsourcing your backend to Firebase
 
-If you skipped Ruby and/or Ruby on Rails and are on the [Full Stack JavaScript](https://www.theodinproject.com/tracks/full-stack-javascript) or [Front End Only](https://www.theodinproject.com/tracks/front-end-only) track, you're not quite ready to build an entire web app from scratch. The good news: you don't have to! We will provide you with resources that guide you through setting up your backend on [Firebase](https://firebase.google.com). 
+If you skipped Ruby and/or Ruby on Rails and are on the [Full Stack JavaScript](https://www.theodinproject.com/paths/full-stack-javascript) or [Front End Only](https://www.theodinproject.com/paths/front-end-only) path, you're not quite ready to build an entire web app from scratch. The good news: you don't have to! We will provide you with resources that guide you through setting up your backend on [Firebase](https://firebase.google.com). 
 
 ### Learning Outcomes
 

--- a/rails_programming/README.md
+++ b/rails_programming/README.md
@@ -2,7 +2,7 @@ Take Ruby to the next level with the Ruby on Rails framework! Learn how to fully
 
 ## The Outline
 
-- The Track ahead: How this Course Will Work - [lesson](introduction.md)
+- The Path ahead: How this Course Will Work - [lesson](introduction.md)
 - Sinatra
   - Sinatra Basics - [lesson](sinatra/sinatra.md)
   - [Project: Sinatra Project](sinatra/project_sinatra.md)


### PR DESCRIPTION
This PR renames all references of Tracks in the curriculum to "Paths". This is in relation to this [corresponding PR for the site](https://github.com/TheOdinProject/theodinproject/pull/1404). This PR cannot be merged until the one to `theodinproject` is merged.

While working on this, I noticed that the `readme.md` for the `rails_programming` directory is wildly outdated. I will update it and have a push up tonight.