### PR TITLE
note not to include $ when following test key instructions in Git Setup

### DIFF
--- a/web_development_101/installations/setting_up_git.md
+++ b/web_development_101/installations/setting_up_git.md
@@ -147,6 +147,7 @@ Now, go back to GitHub in your browser window and paste the key you copied into 
 #### Step 2.5 Testing your key
 
 Follow the directions in [this article from GitHub](https://help.github.com/en/articles/testing-your-ssh-connection) to verify your SSH connection. If the output doesn't correctly match up, then try going through these steps again or come to [the Discord chat](https://discord.gg/hvqVr6d) to ask for help. 
+Note: Do not inlcude the `$` when typing in the commands given in the article. 
 
 ### Step 3: Let us know how it went!
 


### PR DESCRIPTION
I see lots of people in discord having issues because they include the `$` (the test key article shows the dollar sign). so they type it in and then it doesnt work. (section 2.5 article)


