### PR TITLE
Added direct link to readMe for Jasmine + rephrase

### DIFF
--- a/foundations/javascript_basics/fundamentals-4.md
+++ b/foundations/javascript_basics/fundamentals-4.md
@@ -21,10 +21,21 @@ Test Driven Development \(TDD\) is a phrase you often hear in the dev world.  It
 In many ways TDD is much more productive than writing code without tests.  If we didn't have the test for the adding function above, we would have to run the code ourselves over and over, plugging in different numbers until we were sure that it was working... not a big deal for a simple `add(2, 2)`, but imagine having to do that for more complicated functions, like checking whether or not someone has won a game of tic tac toe: \(`game_win(["o", null,"x",null,"x",null,"x", "o", "o"])`) If you didn't do TDD then you might actually have to play multiple games against yourself just to test if the function was working correctly!
 
 We will teach you the art of actually writing these tests later in the course.  The following exercises have the tests already written out for you. All you have to do is read the specs and write the code that makes them pass!  The very first exercise \(`01-helloWorld`\) is intentionally very simple and walks you through the process of running the tests and making them pass.  
+<<<<<<< HEAD
  
 ### Good Luck!
 
+<<<<<<<< HEAD:foundations/javascript_basics/fundamentals-4.md
 Check out our exercises repository [here](https://github.com/TheOdinProject/javascript-exercises) and follow the directions in the [README] (https://github.com/TheOdinProject/javascript-exercises#how-to-use-these-exercises) for setting up Jasmine.  Solutions for the exercises can be found on the 'solutions' branch of that repo.      
+========
+Check out our exercises repository [here](https://github.com/TheOdinProject/javascript-exercises) and follow the directions in the [README] (https://github.com/TheOdinProject/javascript-exercises#how-to-use-these-exercises) for setting up Jasmine.  Solutions for the exercises can be found on the 'solutions' branch of that repo.
+>>>>>>>> 1e40b0ced80b43cbbc336ee2e6da48521b99194d:web_development_101/javascript_basics/fundamentals-4.md
+=======
+
+### Good Luck!
+
+Check out our exercises repository [here](https://github.com/TheOdinProject/javascript-exercises) and follow the directions in the [README](https://github.com/TheOdinProject/javascript-exercises#how-to-use-these-exercises) for setting up Jasmine.  Solutions for the exercises can be found on the 'solutions' branch of that repo. 
+>>>>>>> 1e40b0ced80b43cbbc336ee2e6da48521b99194d
 
 Complete the following exercises:
 

--- a/foundations/javascript_basics/fundamentals-4.md
+++ b/foundations/javascript_basics/fundamentals-4.md
@@ -21,10 +21,10 @@ Test Driven Development \(TDD\) is a phrase you often hear in the dev world.  It
 In many ways TDD is much more productive than writing code without tests.  If we didn't have the test for the adding function above, we would have to run the code ourselves over and over, plugging in different numbers until we were sure that it was working... not a big deal for a simple `add(2, 2)`, but imagine having to do that for more complicated functions, like checking whether or not someone has won a game of tic tac toe: \(`game_win(["o", null,"x",null,"x",null,"x", "o", "o"])`) If you didn't do TDD then you might actually have to play multiple games against yourself just to test if the function was working correctly!
 
 We will teach you the art of actually writing these tests later in the course.  The following exercises have the tests already written out for you. All you have to do is read the specs and write the code that makes them pass!  The very first exercise \(`01-helloWorld`\) is intentionally very simple and walks you through the process of running the tests and making them pass.  
-
+ 
 ### Good Luck!
 
-Check out our exercises repository [here](https://github.com/TheOdinProject/javascript-exercises) and follow the directions in the README for getting set up.  Solutions for the exercises can be found on the 'solutions' branch of that repo.
+Check out our exercises repository [here](https://github.com/TheOdinProject/javascript-exercises) and follow the directions in the README for getting set up.  Solutions for the exercises can be found on the 'solutions' branch of that repo. 
 
 Complete the following exercises:
 

--- a/foundations/javascript_basics/fundamentals-4.md
+++ b/foundations/javascript_basics/fundamentals-4.md
@@ -24,7 +24,7 @@ We will teach you the art of actually writing these tests later in the course.  
  
 ### Good Luck!
 
-Check out our exercises repository [here](https://github.com/TheOdinProject/javascript-exercises) and follow the directions in the README for getting set up.  Solutions for the exercises can be found on the 'solutions' branch of that repo. 
+Check out our exercises repository [here](https://github.com/TheOdinProject/javascript-exercises) and follow the directions in the [README] (https://github.com/TheOdinProject/javascript-exercises#how-to-use-these-exercises) for setting up Jasmine.  Solutions for the exercises can be found on the 'solutions' branch of that repo. 
 
 Complete the following exercises:
 

--- a/foundations/javascript_basics/fundamentals-4.md
+++ b/foundations/javascript_basics/fundamentals-4.md
@@ -24,7 +24,7 @@ We will teach you the art of actually writing these tests later in the course.  
  
 ### Good Luck!
 
-Check out our exercises repository [here](https://github.com/TheOdinProject/javascript-exercises) and follow the directions in the [README] (https://github.com/TheOdinProject/javascript-exercises#how-to-use-these-exercises) for setting up Jasmine.  Solutions for the exercises can be found on the 'solutions' branch of that repo. 
+Check out our exercises repository [here](https://github.com/TheOdinProject/javascript-exercises) and follow the directions in the [README] (https://github.com/TheOdinProject/javascript-exercises#how-to-use-these-exercises) for setting up Jasmine.  Solutions for the exercises can be found on the 'solutions' branch of that repo.      
 
 Complete the following exercises:
 

--- a/foundations/javascript_basics/fundamentals-4.md
+++ b/foundations/javascript_basics/fundamentals-4.md
@@ -22,11 +22,22 @@ In many ways TDD is much more productive than writing code without tests.  If we
 
 We will teach you the art of actually writing these tests later in the course.  The following exercises have the tests already written out for you. All you have to do is read the specs and write the code that makes them pass!  The very first exercise \(`01-helloWorld`\) is intentionally very simple and walks you through the process of running the tests and making them pass.  
 <<<<<<< HEAD
+<<<<<<< HEAD
  
 ### Good Luck!
 
 <<<<<<<< HEAD:foundations/javascript_basics/fundamentals-4.md
 Check out our exercises repository [here](https://github.com/TheOdinProject/javascript-exercises) and follow the directions in the [README] (https://github.com/TheOdinProject/javascript-exercises#how-to-use-these-exercises) for setting up Jasmine.  Solutions for the exercises can be found on the 'solutions' branch of that repo.      
+========
+Check out our exercises repository [here](https://github.com/TheOdinProject/javascript-exercises) and follow the directions in the [README] (https://github.com/TheOdinProject/javascript-exercises#how-to-use-these-exercises) for setting up Jasmine.  Solutions for the exercises can be found on the 'solutions' branch of that repo.
+>>>>>>>> 1e40b0ced80b43cbbc336ee2e6da48521b99194d:web_development_101/javascript_basics/fundamentals-4.md
+=======
+
+### Good Luck!
+
+<<<<<<<< HEAD:foundations/javascript_basics/fundamentals-4.md
+Check out our exercises repository [here](https://github.com/TheOdinProject/javascript-exercises) and follow the directions in the [README](https://github.com/TheOdinProject/javascript-exercises#how-to-use-these-exercises) for setting up Jasmine.  Solutions for the exercises can be found on the 'solutions' branch of that repo. 
+>>>>>>> 1e40b0ced80b43cbbc336ee2e6da48521b99194d
 ========
 Check out our exercises repository [here](https://github.com/TheOdinProject/javascript-exercises) and follow the directions in the [README] (https://github.com/TheOdinProject/javascript-exercises#how-to-use-these-exercises) for setting up Jasmine.  Solutions for the exercises can be found on the 'solutions' branch of that repo.
 >>>>>>>> 1e40b0ced80b43cbbc336ee2e6da48521b99194d:web_development_101/javascript_basics/fundamentals-4.md


### PR DESCRIPTION
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:

### Describe the nature of the changes made:

I see a lot of people coming to discord asking about how to set up jasmine because they are missing the jasmine install directions because when you click this link (https://github.com/TheOdinProject/javascript-exercises) given the first thing you see is all the code files, and people don't scroll down to the readMe (even though the directions on the TOP page tell them to). So I added a direct inline link to the read me and changed the wording to specify that the readMe includes directions for how to set up jasmine.