### PR TITLE
Added direct link to jasmine setup portion of readMe and rephrase

### DIFF
--- a/foundations/javascript_basics/fundamentals-4.md
+++ b/foundations/javascript_basics/fundamentals-4.md
@@ -24,7 +24,7 @@ We will teach you the art of actually writing these tests later in the course.  
 
 ### Good Luck!
 
-Check out our exercises repository [here](https://github.com/TheOdinProject/javascript-exercises) and follow the directions in the README for getting set up.  Solutions for the exercises can be found on the 'solutions' branch of that repo.
+Check out our exercises repository [here](https://github.com/TheOdinProject/javascript-exercises) and follow the directions in the README for getting set up.  Solutions for the exercises can be found on the 'solutions' branch of that repo. 
 
 Complete the following exercises:
 

--- a/foundations/javascript_basics/fundamentals-4.md
+++ b/foundations/javascript_basics/fundamentals-4.md
@@ -24,7 +24,7 @@ We will teach you the art of actually writing these tests later in the course.  
 
 ### Good Luck!
 
-Check out our exercises repository [here](https://github.com/TheOdinProject/javascript-exercises) and follow the directions in the README for getting set up.  Solutions for the exercises can be found on the 'solutions' branch of that repo. 
+Check out our exercises repository [here](https://github.com/TheOdinProject/javascript-exercises) and follow the directions in the [README](https://github.com/TheOdinProject/javascript-exercises#how-to-use-these-exercises) for setting up Jasmine.  Solutions for the exercises can be found on the 'solutions' branch of that repo. 
 
 Complete the following exercises:
 


### PR DESCRIPTION
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:

### Describe the nature of the changes made:

I see a lot of people coming to discord asking about how to set up jasmine because they are missing the jasmine install directions because when you click this link (https://github.com/TheOdinProject/javascript-exercises) given the first thing you see is all the code files, and people don't scroll down to the readMe (even though the directions on the TOP page tell them to). So I added a direct inline link to the read me and changed the wording to specify that the readMe includes directions for how to set up jasmine.