### PR TITLE
add Getting Started as an assignment and clarify repo instructions

### DIFF
--- a/rails_programming/rails_basics/project_blog_app.md
+++ b/rails_programming/rails_basics/project_blog_app.md
@@ -8,8 +8,8 @@ To be honest, you're kind of going into the deep end so don't worry if you don't
 
 <div class="lesson-content__panel" markdown="1">
 
-  1. Follow the instructions atop the [Google Homepage project](/courses/foundations/lessons/html-css) to set up a GitHub repository for this project (of course you'll need to change the title).
-  2. Do the [Jumpstart Lab's Blogger Tutorial](http://tutorials.jumpstartlab.com/projects/blogger.html) sections I0 through I4.  Pay attention to any error messages you get, both planned (because the tutorial walks you through a common error-guided workflow) and unplanned (likely for things like spelling errors).  You'll see all these messages again and again when you're building Rails apps, so it's helpful to start getting familiar with which portions of the message you should pay attention to (and maybe put into Google if you can't figure out what caused it).
+  1. Do the [Jumpstart Lab's Blogger Tutorial](http://tutorials.jumpstartlab.com/projects/blogger.html) sections I0 through I4. Follow the instructions at the end of the first section to set up a GitHub repository for this project.
+  2. Pay attention to any error messages you get, both planned (because the tutorial walks you through a common error-guided workflow) and unplanned (likely for things like spelling errors).  You'll see all these messages again and again when you're building Rails apps, so it's helpful to start getting familiar with which portions of the message you should pay attention to (and maybe put into Google if you can't figure out what caused it).
   3. At the end of I3: Tags when you're attempting to delete your Article tags, you'll run into an error along the lines of "FOREIGN KEY constraint failed". You can solve this by enforcing [Referential Integrity](https://en.wikipedia.org/wiki/Referential_integrity) by applying the `dependent: :destroy` option for the `has_many` method in the right model. You can learn about it in [This Entry of the Rails Guides](http://guides.rubyonrails.org/association_basics.html)
   4. Here's a [helpful gist with common Blogger problems](https://gist.github.com/burtlo/4970471) if you're running into issues with routes, deleting, partials, and `redirect_to`.
   5. If you're feeling ambitious, add in authentication in section I5.
@@ -21,5 +21,5 @@ To be honest, you're kind of going into the deep end so don't worry if you don't
 This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something.
 
 * The [official Ruby on Rails guides](http://guides.rubyonrails.org/) are an excellent resource if you want to build on your knowledge.
-* If you want, you can take a look at [The Ruby on Rails Guides: Getting Started](http://guides.rubyonrails.org/getting_started.html) from last lesson again. This will help you add some extra features to your blog such as [deleting comments](http://guides.rubyonrails.org/getting_started.html#deleting-comments).
+* If you want, you can use [The Ruby on Rails Guides: Getting Started](http://guides.rubyonrails.org/getting_started.html) to add some extra features to your blog, such as [deleting comments](http://guides.rubyonrails.org/getting_started.html#deleting-comments).
 * You can read the [Introduction to Core Ruby Tools](https://launchschool.com/books/core_ruby_tools/read/introduction) from LaunchSchool to get a better understanding of Ruby and Rails concepts such as gems, version managers, bundler, and rake.

--- a/rails_programming/rails_basics/views.md
+++ b/rails_programming/rails_basics/views.md
@@ -218,7 +218,9 @@ Rails offers several different helpers that help you create forms, and we'll go 
 Now that you've got a taste of the high-level stuff, read through the Rails Guides for a more detailed look at things.  The chapter below will actually start in the controller, where you need to let it know WHICH view file you want to render.  The second half of the chapter gets more into the view side of things.
 
 <div class="lesson-content__panel" markdown="1">
-1. Read the [Rails Guide chapter on Layouts and Rendering](http://guides.rubyonrails.org/layouts_and_rendering.html), sections 1 through 3.4.  You can certainly skim when they start going over all the many different options you can pass to a given function... it's good to know what they are and where you can find them, but you don't need to memorize all of them.  Usually you'll have something that you want to do, Google it, and find a Stack Overflow post that shows you the option you can use.
+
+  1. Read the [Rails Guide chapter on Layouts and Rendering](http://guides.rubyonrails.org/layouts_and_rendering.html), sections 1 through 3.4.  You can certainly skim when they start going over all the many different options you can pass to a given function... it's good to know what they are and where you can find them, but you don't need to memorize all of them.  Usually you'll have something that you want to do, Google it, and find a Stack Overflow post that shows you the option you can use.
+  2. Now that you are familiar with Models, Views, and Controllers, it is time put them all together by reading [Ruby on Rails Guides: Getting Started](https://guides.rubyonrails.org/getting_started.html#creating-the-blog-application), sections 3.2 through 8.1. You do not have to build this blog project because you will complete a similar tutorial in a few lessons.
 </div>
 
 ### Conclusion


### PR DESCRIPTION
<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

Currently the [Ruby on Rails Guides: Getting Started](http://guides.rubyonrails.org/getting_started.html) resource is not assigned in the Rails curriculum. This resource use to be assigned in the "Rails Basics" lesson in wd101. Right now the first mention is in [Project Blog App](https://theodinproject.com/courses/ruby-on-rails/lessons/ruby-on-rails-ruby-on-rails#additional-resources) as an additional resource and the second mention is in [Active Record](https://theodinproject.com/courses/ruby-on-rails/lessons/active-record-basics-ruby-on-rails#assignment) and it assumes that resource has been read. 

In looking at the current Rails lessons, I think a good place to include this assignment is after the students have read about Models, Views and Controllers. 

In addition, the suggestion to use the Google Homepage project to set-up this repo is unnecessary. I decided to remove this suggestion because the resource includes instructions to set up a repo. If we want to link other instructions, [Your First Rails App](https://theodinproject.com/courses/ruby-on-rails/lessons/your-first-rails-application-ruby-on-rails#step-2-initialize-git-and-push-to-github) has better instructions for a Rails project.