### PR TITLE
Remove outdated TDD resource

### DIFF
--- a/ruby_programming/testing_with_rspec/test_driven_development.md
+++ b/ruby_programming/testing_with_rspec/test_driven_development.md
@@ -42,4 +42,3 @@ As usual, it depends. Still, here are some reasons we think it might be importan
 </div>
 
 ### Additional Resources
-* [Thoughtbot's Fundamentals of Testing](https://thoughtbot.com/upcase/fundamentals-of-tdd) videos offer an introduction to test driven development. But a quick warning, the TDD Spec Cleanup Exercise requires cloning an older GitHub repository that needs installations and gems not covered to this point. Many students have not been able to run it so you might want to skip that exercise.


### PR DESCRIPTION
<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

Lesson: https://www.theodinproject.com/courses/ruby-programming/lessons/test-driven-development

This resource has been under a lot of discussion lately because the repo requires installations that are not covered in our curriculum. The best part of this resource (the red-green-refactor video) is mentioned in the new ruby_testing repo. I had thought about linking this video directly on this lesson, but I think it is best seen after the following "Intro to RSpec" lesson. 
