### PR TITLE
Exclude RaspberryPi as option for environment

### DIFF
--- a/foundations/installations/prerequisites.md
+++ b/foundations/installations/prerequisites.md
@@ -5,7 +5,7 @@ If you are already using **MacOS** or **Ubuntu**, you can skip this section. Oth
 
 **IMPORTANT**
 
-This curriculum only supports using a Laptop, Desktop or supported Chromebook. We cannot help you set up a developer environment on a RaspberryPi or any other device that is not a Laptop, Desktop or supported Chromebook.
+This curriculum only supports using a Laptop, Desktop or supported Chromebook. We cannot help you set up a developer environment on a RaspberryPi or any other device.
 
 
 <details markdown="block">

--- a/foundations/installations/prerequisites.md
+++ b/foundations/installations/prerequisites.md
@@ -3,6 +3,10 @@ Before we can continue, we need to set up a development environment.
 
 If you are already using **MacOS** or **Ubuntu**, you can skip this section. Otherwise, click on the small arrow to the left of the method you would like to use below to expand that section, and then follow the installation instructions.
 
+**IMPORTANT**
+
+This curriculum only supports using a Laptop, Desktop or supported Chromebook. We cannot help you set up a developer environment on a RaspberryPi or any other device that is not a Laptop, Desktop or supported Chromebook.
+
 
 <details markdown="block">
 <summary class="dropDown-header">Virtual Machine (Recommended)

--- a/foundations/installations/prerequisites.md
+++ b/foundations/installations/prerequisites.md
@@ -5,7 +5,7 @@ If you are already using **MacOS** or **Ubuntu**, you can skip this section. Oth
 
 **IMPORTANT**
 
-This curriculum only supports using a Laptop, Desktop or supported Chromebook. We cannot help you set up a developer environment on a RaspberryPi or any other device.
+This curriculum only supports using a laptop, desktop or supported Chromebook. We cannot help you set up a developer environment on a RaspberryPi or any other device.
 
 
 <details markdown="block">


### PR DESCRIPTION
Explicitly mention that only a laptop, desktop or supported chromebook is currently supported by the curriculum, and anything else (including raspberry pi) is not.
