### PR TITLE
Fixed inconsistency in Ruby lesson on loops

### DIFF
--- a/ruby_programming/basic_ruby/loops.md
+++ b/ruby_programming/basic_ruby/loops.md
@@ -102,7 +102,7 @@ What if we know exactly how many times we want our loop to run? Ruby lets us use
 A `for` loop is used to iterate through a collection of information such as an array or range. These loops are useful if you need to do something a given number of times while also using an iterator.
 
 ~~~ruby
-for i in 0..5
+for i in 0..5 do
   puts "#{i} zombies incoming!"
 end
 ~~~


### PR DESCRIPTION
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

In the Ruby course's lesson on loops, there are 6 code examples of various loops. 5 of them use a _do/end_ block while the for loop example does not. I did some testing and it seems like the _do_ keyword is optional in all loops. Some tutorial websites use it while others do not. I have made the for loop example use the _do_ keyword for consistency, since I was often confused about when a _do/end_ block is required as opposed to when only the _end_ keyword suffices (eg. in if/else/end). The original inconsistency in the article made me think for loops were some kind of exception, which it seems they are not.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
