### PR TITLE
Updated instructions to verify git version

### DIFF
--- a/foundations/installations/setting_up_git.md
+++ b/foundations/installations/setting_up_git.md
@@ -67,7 +67,7 @@ This will install the latest version of Git. Easy, right?
 
 #### Step 1.2: Verify version
 
-Make sure your git version is **at least** 2.28 by running this command:
+**Open a new terminal window** and then make sure your git version is **at least** 2.28 by running this command:
 
 ~~~bash
 git --version


### PR DESCRIPTION
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

In the Setting Up Git lesson in the Foundations course, on step 1.2 in the MacOS section, students are asked to use _git --version_ after installing git. I did as instructed but it still said I was using the old version that comes with the laptop. I found this [StackExchange post](https://apple.stackexchange.com/questions/93002/how-to-use-the-homebrew-installed-git-on-mac), where the second response said you have to open a new terminal window in order for _git --version_ to show changes. I have updated the lesson to reflect this.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
