### PR TITLE
Removing duplicate example of #split method.

### DIFF
--- a/ruby_programming/basic_ruby/basic_data_types.md
+++ b/ruby_programming/basic_ruby/basic_data_types.md
@@ -230,8 +230,6 @@ You'll read more about these methods and others in the assignment. The examples 
 
 "hello".insert(-1, " dude")     #=> "hello dude"
 
-"hello".split("")               #=> ["h", "e", "l", "l", "o"]
-
 "!".prepend("hello, ", "world") #=> "hello, world!"
 ~~~
 

--- a/ruby_programming/basic_ruby/basic_data_types.md
+++ b/ruby_programming/basic_ruby/basic_data_types.md
@@ -230,6 +230,8 @@ You'll read more about these methods and others in the assignment. The examples 
 
 "hello".insert(-1, " dude")     #=> "hello dude"
 
+"hello world".delete("l")       #=> "heo word"
+
 "!".prepend("hello, ", "world") #=> "hello, world!"
 ~~~
 


### PR DESCRIPTION
"hello".split("") is referenced first in it's own section about splits on line 215, and then again in the "other awesome ways to use string methods" section on line 233. Not necessarily hurting anything, but seems redundant to have it twice when all the other methods in the "other awesome ways you can use strings" section are new.
