### PR TITLE
Fix off by one error in the loops lesson

### DIFF
--- a/ruby_programming/basic_ruby/loops.md
+++ b/ruby_programming/basic_ruby/loops.md
@@ -67,13 +67,13 @@ We can re-write our `while` loop examples using `until`.
 
 ~~~ruby
 i = 0
-until i > 10 do
+until i >= 10 do
  puts "i is #{i}"
  i += 1
 end
 ~~~
 
-You can see here that using `until` means that the loop will continue running until the condition i > 10 is true.
+You can see here that using `until` means that the loop will continue running until the condition i >= 10 is true.
 
 The next example shows how you can use `until` to avoid the negation `!` that the above `while` loop had to use.
 


### PR DESCRIPTION
<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

Fix off by one error in the ruby_programming/basic_ruby/loops.md until loop section so that it would match the while loop section.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#21953
