### PR TITLE
Fix broken Udacity link

### DIFF
--- a/getting_hired/preparing_to_interview.md
+++ b/getting_hired/preparing_to_interview.md
@@ -67,7 +67,7 @@ You'll need to read up on a variety of things that weren't focused on in the pre
 
 ### Algorithms Training:
 
-* [Udacity course on Algorithms](https://www.udacity.com/course/viewer#!/c-cs215/l-48747095/m-48691609) (asynchronous)
+* [Udacity course on Algorithms](https://www.udacity.com/course/intro-to-algorithms--cs215) (asynchronous)
 * [Coursera course on Algorithms](https://www.coursera.org/course/algo) (semi-synchronous)
 * [Visualgo](https://visualgo.net/) visualizes many common algorithms to help students better understand data structures and algorithms.
 


### PR DESCRIPTION


 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

The Udacity link did not lead anywhere, the new link leads to the "Intro to Algorithms" course
