### PR TITLE
Fix link to contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Odin Project depends on open-source contributions to improve, grow, and thri
 ### Lessons/Courses in Development
 We are constantly making improvements to the curriculum, and new lessons are always in the works. However, writing new lessons is very time consuming and is done for free. If you would like to know specifics about work on new lessons, ask in the [Discord chat](https://discord.gg/hvqVr6d), or keep an eye on this repo.
 
-If you would like to help us develop any lessons, please read our [contributing guide](https://www.theodinproject.com/contributing) to find out how you can contribute.
+If you would like to help us develop any lessons, please read our [contributing guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md) to find out how you can contribute.
 
 #### A non-exhaustive list of what you can contribute to help us:
 * correcting typos and other grammar errors,
@@ -27,7 +27,7 @@ If you would like to help us develop any lessons, please read our [contributing 
 * adding new resource links you think would make a lesson better, and
 * working on new lessons and projects. You can choose to work on parts of a lesson that are outlined in the progress list on [lesson plans](https://github.com/TheOdinProject/curriculum/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3A%22new%20lesson%22%20) or you can work on completing an entire lesson yourself.
 
-To find out more about how you can contribute, please read our [contributing guide](https://www.theodinproject.com/contributing).
+To find out more about how you can contribute, please read our [contributing guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).
 
 ## Other helpful links
 


### PR DESCRIPTION
<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [ Yes] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

Corrected the links in the README.md file to the contributing guide FROM https://www.theodinproject.com/contributing TO https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md

###### Rationale:
In attempting to find out how to contribute to The Odin Project, I found myself in a loop as the README file 'contributing guide' link goes to a page on TOP website with general contributing info that then links back to the repo README instructions rather than linking to the actual dedicated contributing guide (which contains the more detailed info of _how_ to contribute).

_This is my first time forking or contributing to a project, thank you for your patience._

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
