### PR TITLE
Remove ZenGarden, broken website, links and styles not working

### DIFF
--- a/foundations/the_front_end/project_html_css.md
+++ b/foundations/the_front_end/project_html_css.md
@@ -93,6 +93,6 @@ This section contains helpful links to other content. It isn't required, so cons
 
 If you still feel shaky on your understanding of HTML and CSS, that's okay! You don't need to be an expert by any means yet. These resources should help if you want to shore up your understanding of things:
 
-- If you want to see the art of CSS, check out the [CSS Zen Garden](http://www.csszengarden.com/) and [Style Page](https://stylestage.dev/), where they collect submissions that use identical HTML and modify only the CSS to create wildly different (and beautiful) sites.
+- If you want to see the art of CSS, check out the [Style Page](https://stylestage.dev/), which collects submissions that use identical HTML and modify only the CSS to create wildly different (and beautiful) sites.
 - Read through [Shay Howe's HTML&CSS Tutorial](http://learn.shayhowe.com/html-css/terminology-syntax-intro). Lesson 1 gives a solid overview and you can do the whole thing for a more in-depth understanding.
 - Learn more about GitHub using [this tutorial](https://try.github.io) or read more in [this article](http://readwrite.com/2013/09/30/understanding-github-a-journey-for-beginners-part-1).


### PR DESCRIPTION
<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [ ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

ZenGarden link in additional resources appears to be an old/not maintained/broken (links and CSS list not working).

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX


https://www.theodinproject.com/courses/web-development-101/lessons/html-css#additional-resources