### PR TITLE
Change embarrassing to anonymous posts

### DIFF
--- a/rails_programming/forms_and_authentication/project_auth.md
+++ b/rails_programming/forms_and_authentication/project_auth.md
@@ -16,7 +16,7 @@ In this project you'll follow along to Andy Leverenz's brilliant Building a Twit
 
 ### Project: Members Only!
 
-In this project, you'll be building an exclusive clubhouse where your members can write embarrassing posts about non-members.  Inside the clubhouse, members can see who the author of a post is but, outside, they can only see the story and wonder who wrote it.
+In this project, you'll be building an exclusive clubhouse where your members can write anonymous posts. Inside the clubhouse, members can see who the author of a post is but, outside, they can only see the story and wonder who wrote it.
 
 If you want to add your own stylistic flourishes, consider it extra credit.
 


### PR DESCRIPTION
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

After discussion about this lesson, I wanted to change the wording of "embarrassing posts about non-members" to simply "anonymous posts" because the subject matter of the posts does not really matter to the project.
