### PR TITLE
Updated the "Passing Local Variables to Partials" section on the Rails Basics: Views page.

### DIFF
--- a/rails_programming/rails_basics/views.md
+++ b/rails_programming/rails_basics/views.md
@@ -113,10 +113,17 @@ There's a lot you can do with partials and we won't dive into it all here, but o
 In the example above, you most likely want to pass the `@user` variable to the partial so your code can render the right kind of form. `render` is just a regular method and it lets you pass it an [options hash](https://stackoverflow.com/questions/18407618/what-are-options-hashes).  One of those options is the `:locals` key, which will contain the variables you want to pass.  Your code might change to look like:
 
 ~~~erb
-  <%= render "shared/your_partial", :locals => { :user => user } %>
+  <%= render partial: "shared/your_partial", :locals => { :user => user } %>
 ~~~  
 
-To use the variable in your partial file, you drop the `@` and call it like a normal variable.
+To use the variable in your partial file, you drop the `@` and call it like a normal variable. Note that you should use the `:locals` option if you're calling the `render` method with a `:partial` key. 
+
+There is a `render` shortcut that allows you to simply pass in variables without the need of using the `:locals` option:
+
+~~~erb
+  <%= render "shared/your_partial", :user => user %>
+~~~
+
 
 ### Implicit Partials
 


### PR DESCRIPTION

<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [ ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

... There was outdated code in the **Passing Local Variables To Partials** section. On latest versions of rails the `:locals` option only works if you're calling render in the format of `<% render partial: "partial_name", ... %>`. 

So the following ( as shown in the TOP page ) is misleading.
~~~ruby
  <%= render "shared/your_partial", :locals => { :user => user } %>
~~~

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
