### PR TITLE
Trying to fix formatting issues

### DIFF
--- a/foundations/introduction/join_the_odin_community.md
+++ b/foundations/introduction/join_the_odin_community.md
@@ -90,18 +90,18 @@ Your Colorful Code
 
   2. In a moment we're going to ask you to join the Discord community, here are some guidelines before you dive in: 
   
-   * **Ping (@user) With a Purpose:** Only @ another user when it is necessary. Include your question or comment in the message. Wait until they reply before pinging again.	
-   * **Don't 'Bomb' Chats:** Dont send multiple messages in a row, type out your whole message, then push send.	
-   * **Don't Exclude Anyone:**	These are public chats, if someone joins in on a conversation, include them!		
-   * **Don't Disappear Right After Asking for Help on Code:** If you're posting a question, make sure you have time to stick around and discuss it with those trying to help!
-   * **Remember the Human:** Behind every username there is a person with feelings! Be kind! If you don't have anything nice to say, don't say anything at all. 
-   * **If You Wouldn't Say It Out Loud Don't Type It:** Plain and simple.
-   * **Read the Rules:** Upon joining, you will find yourself in the "#Rules" channel. Please read the rules!
+     * **Ping (@user) With a Purpose:** Only @ another user when it is necessary. Include your question or comment in the message. Wait until they reply before pinging again.	
+     * **Don't 'Bomb' Chats:** Dont send multiple messages in a row, type out your whole message, then push send.	
+     * **Don't Exclude Anyone:**	These are public chats, if someone joins in on a conversation, include them!		
+     * **Don't Disappear Right After Asking for Help on Code:** If you're posting a question, make sure you have time to stick around and discuss it with those trying to help!
+     * **Remember the Human:** Behind every username there is a person with feelings! Be kind! If you don't have anything nice to say, don't say anything at all. 
+     * **If You Wouldn't Say It Out Loud Don't Type It:** Plain and simple.
+     * **Read the Rules:** Upon joining, you will find yourself in the "#Rules" channel. Please read the rules!
 
   3. Finally, sign in to our [Discord server](https://discord.gg/hvqVr6d). Pop in and say hello! We've created an introductions-and-checkins room which is a great place to introduce yourself and we're always happy to welcome new community members. We have chat rooms for every development topic covered by Odin and beyond. Log into the chat and start exploring!
 
-   **Link your GitHub to your Discord profile:** So others can see what you're working on and vice versa!
+     **Link your GitHub to your Discord profile:** So others can see what you're working on and vice versa!
 
-   * Discord Settings > Connections > Click GitHub icon > Allow Access > Make sure "Display on profile" is toggled on.
+     * Discord Settings > Connections > Click GitHub icon > Allow Access > Make sure "Display on profile" is toggled on.
 
 </div>


### PR DESCRIPTION
On the webiste #3 is showing as #1 and the info on linking github was not in line. I tried to set it so all the bullets for 2. are indented, and then indented the github info at the bottom. This *seems* to make it render correctly in the https://www.theodinproject.com/lessons/preview. Previously the GitHub render looked correct, but wasn't once actually on the site

![Screen Shot 2020-12-22 at 9 39 19 PM](https://user-images.githubusercontent.com/59713017/102952999-5cf4ca00-449e-11eb-9817-60ab3b814e6b.png)


I *think* this should fix it. 

<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [ ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

...your text here

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
