### PR TITLE
Fixed 'Git Basics' dead link

### DIFF
--- a/javascript/finishing-up/project_final_js.md
+++ b/javascript/finishing-up/project_final_js.md
@@ -9,7 +9,7 @@ Replicate your favorite website as close as possible - Pinterest, Facebook, Twit
 
 Of course, you can't replicate every feature, and the user interface will probably be a bit clunkier. However, if you can get yourself 80% of the way there, that's darn impressive!
 
-1. Set up a GitHub Repo for this project. Follow the instructions in [Git basics](/web_development_101/git_basics) if you need help.
+1. Set up a GitHub Repo for this project. Follow the instructions in [Git basics](https://www.theodinproject.com/courses/foundations/lessons/git-basics) if you need help.
 2. Think about what you need to do. It's really helpful to write your plan down on paper or whiteboard ahead of time! A few hours of thought now will save you days of coding. Try to lay it ALL out. An important part of planing is **scope**. You obviously can't build the entire website (which presumably took a full team of engineers years to produce), so you'll need to identify the site's core functionality and the "nice-to-have" stuff. **Make sure you finish the core functionality BEFORE working on the rest.** If you try to do everything at once, you'll get lost and frustrated. Trust me. Everything takes longer than you expect.
 3. Roll up your sleeves and start building!
 4. Try to test the high-level functionality using a suitable testing library, for example, Javascript with Jest or Rails with RSpec. Don't get too bogged down in testing, but try and save yourself time by adding high-level tests, so you don't need to click around 100 times every time you make a change to something that seems important.


### PR DESCRIPTION
The Git Basics link returned a 404 as the old page had changed. New Page located at - https://www.theodinproject.com/courses/foundations/lessons/git-basics.

<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

...your text here

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
