### PR TITLE
Add specific section to end tutorial due to errors

### DIFF
--- a/rails_programming/rails_basics/project_blog_app.md
+++ b/rails_programming/rails_basics/project_blog_app.md
@@ -8,7 +8,7 @@ To be honest, you're kind of going into the deep end so don't worry if you don't
 
 <div class="lesson-content__panel" markdown="1">
 
-  1. Do the [The Ruby on Rails Guides: Getting Started](http://guides.rubyonrails.org/getting_started.html) project from the Rails Guides. It gives a pretty good overview of the common commands you'll use when using Rails.
+  1. Do the [The Ruby on Rails Guides: Getting Started](http://guides.rubyonrails.org/getting_started.html) project through section 8.2, from the Rails Guides. It gives a pretty good overview of the common commands you'll use when using Rails. Section 8.3 is causing a few problems, but they should be resolved soon.
   2. You should have Rails installed already so section 3.1 might not be relevant. It still might be prudent to run the `--version` commands to check you have everything you need though.
   3. Make sure you commit to git regularly so if you run into any issues you can revert to an earlier commit without having to start over from scratch. As a rough guide look to commit at the end of each section.
   4. Pay attention to any error messages you get as you build the app, even though they'll be unplanned.  You'll see all these messages again and again when you're building Rails apps, so it's helpful to start getting familiar with which portions of the message you should pay attention to (and maybe put into Google if you can't figure out what caused it).


### PR DESCRIPTION
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

@msespos experienced a few problems in section 8.3 during this tutorial and as I looked at it closer, I realized that this section was not in the tutorial when I did it 2 months ago. So, I decided to run through this tutorial again. Not only does this section change from "hand holding" the students through creating an app to only having vague instructions.

However, the main problem is that there are 4 major exclusions from this section, that I discovered from looking at the current Edge Guides. However, even one of the current proposed changes on the Edge Guides is incorrect. 

Until this section is revised, I think it is best to have students end 8.2. I tried to skip this section, but in the following section, one of the provided code snippets uses new code from section 8.3, which will cause an uninitialized constant error.
