### PR TITLE
fix Mac/Windows Chrome DevTools shortcut

### DIFF
--- a/foundations/javascript_basics/developer_tools_2.md
+++ b/foundations/javascript_basics/developer_tools_2.md
@@ -9,7 +9,7 @@ There are three ways to open the Developer Tools menu:
     - Chrome: Select the `Chrome Menu` > `More Tools` > `Developer Tools`
     - Firefox: Select the Firefox `Menu` > `Web Developer`> `Toggle Tools`  
 2. Right-click anywhere on a webpage and select `Inspect`
-3. Use the keyboard shortcut `F12` or `CTRL + Shift + I` (`option + command + I` on Mac)
+3. Use the keyboard shortcut `F12` or `CTRL + Shift + C` (`option + command + C` on Mac)
 
 ### Assignment
 


### PR DESCRIPTION
option+CMD+i opens last panel you had open last time you closed DevTools; the correct keys are option+CMD+c (corrected for Windows too)

Source: https://developers.google.com/web/tools/chrome-devtools/open

<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

...your text here

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
