### PR TITLE
Spelling mistake in hashes.md

### DIFF
--- a/ruby_programming/basic_ruby/hashes.md
+++ b/ruby_programming/basic_ruby/hashes.md
@@ -66,7 +66,7 @@ If you try to access a key that doesn't exist in the hash, it will return `nil`:
 shoes["hiking"]   #=> nil
 ~~~
 
-Sometimes, this behavior can be problematic for you if silently returning a `nil` value could potentially wreck havoc in your program. Luckily, hashes have a `fetch` method that will raise an error when you try to access a key that is not in your hash. 
+Sometimes, this behavior can be problematic for you if silently returning a `nil` value could potentially wreak havoc in your program. Luckily, hashes have a `fetch` method that will raise an error when you try to access a key that is not in your hash. 
 
 ~~~ruby
 shoes.fetch("hiking")   #=> KeyError: key not found: "hiking"


### PR DESCRIPTION
Found a slight spelling mistake in the Accessing Values section where it says "wreck havoc" instead of "wreak havoc".

<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [ ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

...your text here

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
