### PR TITLE
replace broken resumerepublic.com link

### DIFF
--- a/getting_hired/project_resume.md
+++ b/getting_hired/project_resume.md
@@ -12,7 +12,7 @@ Knowing that perspective, how can you play to it?  It's difficult if you're brea
 
 Remember: ONE PAGE.
 
-* [ResumeRepublic.com has a free tier with sample online resumes](https://www.resumerepublic.com/)
+* [This Career Tool Belt article lists 6 free resume builder websites](https://www.careertoolbelt.com/5-best-free-resume-builder-websites/)
 * [Novorésumé also has a free tier with templates available, as an alternate resource](https://novoresume.com/)
 * [Formatting could use some work, but here's an example resume from CareerCup.com](http://www.careercup.com/resume)
 


### PR DESCRIPTION
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

I clicked on the resumerepublic.com link and it leads nowhere, I don't think they exist anymore. I found an article on Career Tool Belt that lists 6 free resume builder website which I included instead