### PR TITLE
Fix/22020 html-css replaced medium links

### DIFF
--- a/html_css/backgrounds.md
+++ b/html_css/backgrounds.md
@@ -25,4 +25,4 @@ Backgrounds are usually ignored until they become a problem and then you're left
 This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something.
 
 * [CSS Backgrounds](http://www.w3schools.com/css/css_background.asp)
-* [Do you really understand CSS linear-gradients?](https://medium.com/@patrickbrosset/do-you-really-understand-css-linear-gradients-631d9a895caf#.tjka033kc)
+* [Do you really understand CSS linear-gradients?](https://patrickbrosset.com/articles/2015-03-27-do-you-really-understand-CSS-linear-gradients/)

--- a/html_css/css_frameworks.md
+++ b/html_css/css_frameworks.md
@@ -22,9 +22,9 @@ Frameworks let you focus more on building great sites and less on how they are a
 <div class="lesson-content__panel" markdown="1">
 1. Read [From A List Apart, Frameworks for Designers](http://alistapart.com/article/frameworksfordesigners)
 2. Read [From A List Apart, Building Twitter Bootstrap](http://alistapart.com/article/building-twitter-bootstrap)
-2. [Choosing Bootstrap or Foundation](https://medium.com/@davegenge/bootstrap-vs-foundation-which-front-end-framework-to-use-e85319258b88)
-3. Browse through [Getting Started with Foundation](https://get.foundation/sites/docs/) for an idea of how that framework operates.  Observe the similarities and differences between that and Bootstrap.
-4. Take a brief look at [TailwindCSS](https://tailwindcss.com/) for a more unique and modern approach to CSS frameworks.
+3. [Choosing Bootstrap or Foundation](https://medium.com/@davegenge/bootstrap-vs-foundation-which-front-end-framework-to-use-e85319258b88)
+4. Browse through [Getting Started with Foundation](https://get.foundation/sites/docs/) for an idea of how that framework operates.  Observe the similarities and differences between that and Bootstrap.
+5. Take a brief look at [TailwindCSS](https://tailwindcss.com/) for a more unique and modern approach to CSS frameworks.
 </div>
 
 ### Additional Resources


### PR DESCRIPTION
<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

For the HTML-CSS course curriculum, have replaced (where possible) medium.com links with open source versions. Also corrected a typo in relation to numbering.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#22020 
