### PR TITLE
Removed link to old outdated w3.org article

### DIFF
--- a/foundations/javascript_basics/DOM-manipulation.md
+++ b/foundations/javascript_basics/DOM-manipulation.md
@@ -487,7 +487,6 @@ Manipulating web pages is the primary benefit of the JavaScript language!  These
 * [Eloquent JS - Handling Events](http://eloquentjavascript.net/14_event.html)
 * [Event Capture, Propagation and Bubbling video by Wes Bos](https://www.youtube.com/watch?v=F1anRyL37lE)
 * [DOM Enlightenment](http://domenlightenment.com/)
-* [Dynamic style - manipulating CSS with JavaScript](https://www.w3.org/wiki/Dynamic_style_-_manipulating_CSS_with_JavaScript)
 * [JavaScript30](https://JavaScript30.com)
 * [An introduction to DOM](https://leila-alderman.github.io/javascript/2018/12/05/Intro-to-the-Document-Object-Model.html)
 * [Plain JavaScript](https://plainjs.com/javascript/) is a reference of JavaScript code snippets and explanations involving the DOM, as well as other aspects of JS. If you've already learned jQuery, it will help you figure out how to do things without it.


### PR DESCRIPTION
The removed link contains missing links and outlined outdated techniques such as:
  - getElementById (modernly: querySelector)
  - sheetParent.removeChild(sheetToBeRemoved) (does not work and all example links are "Not Found")
  - insertRule (does not work and all example links are "Not Found") and,
  - className (modernly: classList).

<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

...your text here

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
