### PR TITLE
Update routing with proper order of verbose routes

### DIFF
--- a/rails_programming/rails_basics/routing.md
+++ b/rails_programming/rails_basics/routing.md
@@ -48,8 +48,8 @@ Each of these represents a "RESTful" route, and so it makes sense that you'll ne
 
 ~~~ruby
   get "/posts", to: "posts#index"
-  get "/posts/:id", to: "posts#show"
   get "/posts/new", to: "posts#new"
+  get "/posts/:id", to: "posts#show"
   post "/posts", to: "posts#create"  # usually a submitted form
   get "/posts/:id/edit", to: "posts#edit"
   put "/posts/:id", to: "posts#update" # usually a submitted form


### PR DESCRIPTION
`get "/posts/new"` needs to be before `get "/posts/:id"` for this to be working as expected. Otherwise, id would simply be assigned 'new'.

<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

I have merely changed the order of the routes

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
