### PR TITLE
fix 404 scrapmaker page in firefox

### DIFF
--- a/ruby_programming/files_and_serialization/project_file_io.md
+++ b/ruby_programming/files_and_serialization/project_file_io.md
@@ -6,7 +6,7 @@ Files are a great way to save and reload a game, so we'll give it a shot here by
 You will be building a simple command line Hangman game where one player plays against the computer, but a bit more advanced.  If you're unfamiliar with how Hangman works, see <a href="http://en.wikipedia.org/wiki/Hangman_(game)">Wikipedia</a>.
 
 <div class="lesson-content__panel" markdown="1">
-  1. Download the `5desk.txt` dictionary file from [http://scrapmaker.com/](http://scrapmaker.com/view/twelve-dicts/5desk.txt).
+  1. Download the `5desk.txt` dictionary file from [http://scrapmaker.com/](http://www.scrapmaker.com/view/twelve-dicts/5desk.txt).
   2. When a new game is started, your script should load in the dictionary and randomly select a word between 5 and 12 characters long for the secret word.
   3. You don't need to draw an actual stick figure (though you can if you want to!), but do display some sort of count so the player knows how many more incorrect guesses he/she has before the game ends.  You should also display which correct letters have already been chosen (and their position in the word, e.g. `_ r o g r a _ _ i n g`) and which incorrect letters have already been chosen.
   2. Every turn, allow the player to make a guess of a letter.  It should be case insensitive.  Update the display to reflect whether the letter was correct or incorrect.  If out of guesses, the player should lose.


### PR DESCRIPTION
Scrapmaker link shows 404 in firefox without the "www". Works fine on chromium.

<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

...your text here

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
