### PR TITLE
Removes references to Windows, WSL

### DIFF
--- a/foundations/installations/prerequisites.md
+++ b/foundations/installations/prerequisites.md
@@ -1,14 +1,8 @@
 ### Introduction
 
-If you are already using **MacOS** or **Ubuntu**, you can skip this section. Otherwise, click on the small arrow to the left of the method you would like to use below to expand that section, and then follow the installation instructions.
+If you are already using **MacOS**, **Ubuntu**, or [an official flavor of Ubuntu](https://wiki.ubuntu.com/UbuntuFlavors), you can skip this section. Otherwise, click on the small arrow to the left of the method you would like to use below to expand that section, and then follow the installation instructions.
 
-Before we can continue, we must first stress one detail of importance:
-
-**We can only support what is provided within the scope of our curriculum.** This statement means that **we do not support native Windows or any version of Windows Subsystem for Linux (WSL) as a development environment.** However, we do support using a Virtual Machine (instructions enclosed below), which does not affect your Windows installation at all and can be easily removed or transfered. Please give using a Virtual Machine a shot, because it is the easiest and fastest way to get started.
-
-Using Windows and WSL has been discussed many times and it is not feasible to do so at this time. There are free alternatives described below, which are industry standard, or mimic those standards as closely as possible. Please do not ask us to support Windows, and please **do not bring it up in the Discord**. We are constantly evaluating our curriculum to keep content as fresh and accessible as possible, and Windows/WSL [has not proven to be a path of low resistance.](https://github.com/microsoft/WSL/issues)
-
-With that out of the way, we need to set up an appropriate development environment!
+**Please Note**: We can only support the operating systems indicated above. Our instructions have been tested with MacOS, Ubuntu, and official flavors of Ubuntu. We do not recommend installing an OS that is based on Ubuntu.
 
 ### Setup
 
@@ -208,9 +202,3 @@ Once you have successfully met both of these requirements, you should be able to
 Currently there is a bug preventing CloudReady v83.4 from successfully installing Linux (Beta). This was resolved in version 85.2.
 
 </details>
-  
-**A note to those who are wondering why they're being asked to install an entire new operating system**
-
-Why is everyone who comes to The Odin Project 'forced' to switch to Linux or macOS for development? Are there *no* web developers out there who use Windows as their main operating system? 
-
-The answer to that question is: [well, not that many](https://onezero.medium.com/microsoft-failed-developers-and-now-it-has-a-plan-to-win-them-back-ecdafde5b20). One of the reasons is that Ruby (on Rails) and Node.js, popular backend technologies taught by The Odin Project and widely used in the larger web development community, are open source projects that explicitly *expect* to run on an open-source (UNIX-based) platform. And while Apple's operating systems have all included the XNU kernel, originally based on the [FreeBSD flavor of UNIX](https://www.freebsd.org/) since the transition from System 9 to Mac OS X in 2001, Microsoft has only recently committed to embracing open source and providing more support for the way people approach web development today.   


### PR DESCRIPTION
This page feels like it should focus on the actual installations. We discourage Windows in the lesson prior. I'm also going to expand the language there so it feels repetitive to address it again here.

Also made a minor change about what OS we recommend. Added remarks about also support official flavors of Ubuntu but not distros that are based on Ubuntu.