### PR TITLE
Add disclaimer to onextrapixel article

### DIFF
--- a/foundations/javascript_basics/clean_code.md
+++ b/foundations/javascript_basics/clean_code.md
@@ -80,7 +80,7 @@ There are many different opinions on what constitutes great JavaScript code.  Th
 
 Read through these articles that discuss a few elements of writing good clean code.
 
-1. [This list of clean-code tips](https://onextrapixel.com/10-principles-for-keeping-your-programming-code-clean/).
+1. [This list of clean-code tips](https://onextrapixel.com/10-principles-for-keeping-your-programming-code-clean/) (disclaimer: just be aware that the article is from 2011; today, we would recommend using semantic elements over div tags where possible).
 2. [This article](https://blog.codinghorror.com/coding-without-comments/), [and this one too](https://blog.codinghorror.com/code-tells-you-how-comments-tell-you-why/) about the role of comments in your code.
 
 ### Additional Resources


### PR DESCRIPTION
HTML5 wasn't a thing back then. Today, we would be using semantic elements. Beginners may get the wrong idea when looking at the code that's part of the article?

<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

Added a disclaimer behind the article for beginners not to misunderstand.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
