### PR TITLE
Add video instructions on enabling touchscreen

### DIFF
--- a/foundations/installations/prerequisites.md
+++ b/foundations/installations/prerequisites.md
@@ -129,6 +129,7 @@ While your VM is running, do the following steps:
 * If upon trying to start the VM you only get a black screen, close and "power off" the VM, click "Settings -> Display" and make sure "Enable 3D Acceleration" is UNCHECKED, and Video memory is set to AT LEAST 128mb. 
 * If you receive an error when trying to mount the Guest Additions CD image ("Unable to insert the virtual optical disk"), please reboot your host (Windows/OSX) operating system. Afterwards, ensure that there is no image file mounted in *both* Virtual Box as well as in the file system of the VM.
 * If you encounter the error "VirtualBox-Error: Failed to open a session for the virtual machine..." you might have to turn on 'virtualization' in your host's BIOS settings. If you are using Windows as your host OS you can follow these [instructions](https://2nwiki.2n.cz/pages/viewpage.action?pageId=75202968), otherwise just google how to turn it on for your specific OS.
+* Are you using a touchscreen? [Click here](https://www.youtube.com/watch?v=hW-iyHHoDy4) to watch a video on how to enable touchscreen controls for Virtualbox.
 
 ### Step 4: Understand Your New VM
 

--- a/foundations/installations/prerequisites.md
+++ b/foundations/installations/prerequisites.md
@@ -129,7 +129,7 @@ While your VM is running, do the following steps:
 * If upon trying to start the VM you only get a black screen, close and "power off" the VM, click "Settings -> Display" and make sure "Enable 3D Acceleration" is UNCHECKED, and Video memory is set to AT LEAST 128mb. 
 * If you receive an error when trying to mount the Guest Additions CD image ("Unable to insert the virtual optical disk"), please reboot your host (Windows/OSX) operating system. Afterwards, ensure that there is no image file mounted in *both* Virtual Box as well as in the file system of the VM.
 * If you encounter the error "VirtualBox-Error: Failed to open a session for the virtual machine..." you might have to turn on 'virtualization' in your host's BIOS settings. If you are using Windows as your host OS you can follow these [instructions](https://2nwiki.2n.cz/pages/viewpage.action?pageId=75202968), otherwise just google how to turn it on for your specific OS.
-* Are you using a touchscreen? [Click here](https://www.youtube.com/watch?v=hW-iyHHoDy4) to watch a video on how to enable touchscreen controls for Virtualbox.
+* Are you using a touchscreen? [Click here](https://www.youtube.com/watch?v=hW-iyHHoDy4) to watch a video on how to enable touchscreen controls for VirtualBox.
 
 ### Step 4: Understand Your New VM
 


### PR DESCRIPTION
Discord user confirmed these instructions are accurate for enabling touchscreen controls for Virtualbox. Can add more detailed instructions in the future. VM settings/System/Motherboard/Pointing Device/USB Tablet. Switch back to PS/2 if not using touchscreen for reference. It's the last note at the bottom of Virtualbox instructions.