### PR TITLE
Fix/node auth message

### DIFF
--- a/nodeJS/authentication/Authentication.md
+++ b/nodeJS/authentication/Authentication.md
@@ -158,10 +158,10 @@ passport.use(
         return done(err);
       };
       if (!user) {
-        return done(null, false, { msg: "Incorrect username" });
+        return done(null, false, { message: "Incorrect username" });
       }
       if (user.password !== password) {
-        return done(null, false, { msg: "Incorrect password" });
+        return done(null, false, { message: "Incorrect password" });
       }
       return done(null, user);
     });
@@ -321,7 +321,7 @@ bcrypt.compare(password, user.password, (err, res) => {
     return done(null, user)
   } else {
     // passwords do not match!
-    return done(null, false, {msg: "Incorrect password"})
+    return done(null, false, {message: "Incorrect password"})
   }
 })
 ~~~

--- a/nodeJS/authentication/Authentication.md
+++ b/nodeJS/authentication/Authentication.md
@@ -321,7 +321,7 @@ bcrypt.compare(password, user.password, (err, res) => {
     return done(null, user)
   } else {
     // passwords do not match!
-    return done(null, false, {message: "Incorrect password"})
+    return done(null, false, { message: "Incorrect password" })
   }
 })
 ~~~


### PR DESCRIPTION
Change "msg" to "message" in done function argument to make sign in errors show up as flash messages, fix formatting.