### PR TITLE
 Fix incorrect controller action name in refresher

### DIFF
--- a/rails_programming/rails_basics/web_refresher.md
+++ b/rails_programming/rails_basics/web_refresher.md
@@ -22,7 +22,7 @@ REST (short for Representational state transfer) is a term that you'll see comin
 5. POST the data you just filled out for a new post back to the server so it can create that post (aka **"create"** the post)
 4. GET the page that lets you edit an existing post (aka view the **"edit"** post page)
 5. PUT (or PATCH) the data you just filled out for editing the post back to the server so it can actually perform the update (aka **"update"** the post)
-6. DELETE one specific post by sending a delete request to the server (aka **"delete"** the post)
+6. DELETE one specific post by sending a delete request to the server (aka **"destroy"** the post)
 
 The highlighted words correspond to standard Rails controller actions!
 


### PR DESCRIPTION
<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

The [web refresher](https://www.theodinproject.com/courses/ruby-on-rails/lessons/a-railsy-web-refresher#rest) should say `destroy` rather than `delete` when listing the Rails controller actions. 
#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
