### PR TITLE
Models inherit from ApplicationRecord

### DIFF
--- a/rails_programming/databases_and_activerecord/active_record_basics.md
+++ b/rails_programming/databases_and_activerecord/active_record_basics.md
@@ -139,7 +139,7 @@ That was really just a teaser about what Active Record can do. In the reading be
 
 1. Read the [Active Record Basics](http://guides.rubyonrails.org/active_record_basics.html) section of the Rails Guides.
     * We'll go more into Migrations and Validations in the next section and in the lesson on Callbacks later in the course.
-    * Model files in Rails live in the `app/models` folder and are just normal .rb files.  The key points are that the file and the class name is named after the table in your database (but singular), and that class inherits from ActiveRecord::Base to get its super powers.
+    * Model files in Rails live in the `app/models` folder and are just normal .rb files.  The key points are that the file and the class name is named after the table in your database (but singular), and that class inherits from ApplicationRecord to get its super powers.
 
 #### Migrations
 1. Read the [Migrations chapter of Rails Guides](http://edgeguides.rubyonrails.org/active_record_migrations.html).


### PR DESCRIPTION
Rails 5 made the change that models inherit from `ApplicationRecord`. For reference: https://bigbinary.com/blog/application-record-in-rails-5.