### PR TITLE
Remove DateTime and change documentation links

### DIFF
--- a/ruby_programming/files_and_serialization/project_event_manager.md
+++ b/ruby_programming/files_and_serialization/project_event_manager.md
@@ -1547,16 +1547,11 @@ Interesting!
 
 Using the registration date and time we want to find out what the peak registration hours are.
 
-* Ruby has a [Date](http://rubydoc.info/stdlib/date/frames) library which contains classes for
-  [Date](http://rubydoc.info/stdlib/date/Date) and [DateTime](http://rubydoc.info/stdlib/date/DateTime).
+* Ruby has [Date](https://rubyapi.org/2.7/o/date) and [Time](https://rubyapi.org/2.7/o/time) classes that will be very useful for this task.
 
-* [DateTime#strptime](http://rubydoc.info/stdlib/date/DateTime#strptime-class_method) is a method that allows us to
-  parse date-time strings and convert them into Ruby objects.
+* For a quick overview, check out this [Ruby Guides](https://www.rubyguides.com/2015/12/ruby-time/) article. 
 
-* [DateTime#strftime](http://rubydoc.info/stdlib/date/DateTime#strftime-instance_method) is a good reference on the
-  characters necessary to match the specified date-time format.
-
-* Use [DateTime#hour](https://rubydoc.info/stdlib/date/DateTime#hour-instance_method) to find out the hour of the day.
+* Explore the documentation to become familiar with the available methods, especially `#strptime`, `#strftime`, and `#hour`.
 
 ## Assignment: Day of the Week Targeting
 
@@ -1565,4 +1560,4 @@ looks like there are some hours that are clearly more important than others.
 But now, tantalized, she wants to know "What days of the week did most people
 register?"
 
-* Use [Date#wday](http://rubydoc.info/stdlib/date/Date#wday-instance_method) to find out the day of the week.
+* Use [Date#wday](https://rubyapi.org/2.7/o/date#method-i-wday) to find out the day of the week.


### PR DESCRIPTION
<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

The Rubocop Style Guide suggests using `Date` instead of `DateTime`. Therefore I have removed reference to it from this lesson. 

I have added an article that I found to be quite helpful to understand how to use Ruby's `Date` and `Time` classes.

In addition, I changed the documentation to rubyapi.org because I found it to be more user-friendly, especially the best search functionality. Therefore, I removed the direct links to the specific methods, which seems a little bit like spoon-feeding. 
