### PR TITLE
Changed = to == in websockets lesson

### DIFF
--- a/rails_programming/mailers_advanced_topics/websockets_and_actioncable.md
+++ b/rails_programming/mailers_advanced_topics/websockets_and_actioncable.md
@@ -84,7 +84,7 @@ So if you are using devise a neat way to verify a connection is to use the follo
 
 ~~~ruby
 def find_verified_user
-  if verified_user = env['warden'].user
+  if verified_user == env['warden'].user
     verified_user
   else
     reject_unauthorized_connection


### PR DESCRIPTION
<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [ ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

Just fixed a small typo under the server side concerns section of the websockets lesson. Not sure if you guys even accept user typo corrections, but at the very least, you'll be aware of it. (Unless of course I'm mistaken, which is entirely possible)

I changed 
`if verified_user = env['warden'].user`

to 

`if verified_user == env['warden'].user`

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
