### PR TITLE
Replace deprecated form helpers with form_with

### DIFF
--- a/rails_programming/forms_and_authentication/form_basics.md
+++ b/rails_programming/forms_and_authentication/form_basics.md
@@ -212,7 +212,7 @@ You'll probably want to display the errors so the user knows what went wrong.  R
 
 That will give the user a message telling him/her how many errors there are and then a message for each error.
 
-The best part about Rails form helpers... they handle errors automatically too!  If a form is rendered for a specific model object, like using `form_for @article` from the example above, Rails will check for errors and, if it finds any, it will automatically wrap a special `<div>` element around that field with the class `field_with_errors` so you can write whatever CSS you want to make it stand out.  Cool!
+The best part about Rails form helpers... they handle errors automatically too!  If a form is rendered for a specific model object, like using `form_with @article` from the example above, Rails will check for errors and, if it finds any, it will automatically wrap a special `<div>` element around that field with the class `field_with_errors` so you can write whatever CSS you want to make it stand out.  Cool!
 
 ### Making PATCH and DELETE Submissions
 

--- a/rails_programming/forms_and_authentication/form_basics.md
+++ b/rails_programming/forms_and_authentication/form_basics.md
@@ -218,7 +218,7 @@ The best part about Rails form helpers... they handle errors automatically too! 
 
 Forms aren't really designed to natively delete objects because browsers only support GET and POST requests.  Rails gives you a way around that by sticking a hidden field named "\_method" into your form.  It tells Rails that you actually want to do either a PATCH (aka PUT) or DELETE request (whichever you specified), and might look like `<input name="_method" type="hidden" value="patch">`.
 
-You get Rails to add this to your form by passing an option to `form_for` or `form_tag` called `:method`, e.g.:
+You get Rails to add this to your form by passing an option to `form_with` called `:method`, e.g.:
 
 ~~~ruby
   form_tag(search_path, method: "patch")

--- a/rails_programming/forms_and_authentication/form_basics.md
+++ b/rails_programming/forms_and_authentication/form_basics.md
@@ -221,7 +221,7 @@ Forms aren't really designed to natively delete objects because browsers only su
 You get Rails to add this to your form by passing an option to `form_with` called `:method`, e.g.:
 
 ~~~ruby
-  form_tag(search_path, method: "patch")
+  form_with(search_path, method: "patch")
 ~~~
 
 ### Controller-Side Refresher


### PR DESCRIPTION
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

Replace references to deprecated form helpers (`form_for`, `form_tag`) with `form_with`.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
