### PR TITLE
Fix form_with call with url

### DIFF
--- a/rails_programming/forms_and_authentication/form_basics.md
+++ b/rails_programming/forms_and_authentication/form_basics.md
@@ -221,7 +221,7 @@ Forms aren't really designed to natively delete objects because browsers only su
 You get Rails to add this to your form by passing an option to `form_with` called `:method`, e.g.:
 
 ~~~ruby
-  form_with(search_path, method: "patch")
+  form_with(url: search_path, method: "patch")
 ~~~
 
 ### Controller-Side Refresher


### PR DESCRIPTION
Calling `form_with` with a url requires a `url` keyword arg.