### PR TITLE
Add note that devtools resources are for chrome

### DIFF
--- a/foundations/javascript_basics/developer_tools_2.md
+++ b/foundations/javascript_basics/developer_tools_2.md
@@ -15,6 +15,8 @@ There are three ways to open the Developer Tools menu:
 
 <div class="lesson-content__panel" markdown="1">
 
+**The following resources are meant to be done in Chrome browser unless stated otherwise.**
+
 1. Head to the [Chrome DevTools Documentation](https://developers.google.com/web/tools/chrome-devtools/) by Google. The following subsections cover what you'll be using the Developer Tools for 95% of the time.  Feel free to skip the elements you are already familiar with:
     - Open DevTools
     - CSS

--- a/foundations/the_front_end/developer_tools.md
+++ b/foundations/the_front_end/developer_tools.md
@@ -33,6 +33,9 @@ Make sure you can do each of the following once you have finished the assignment
 ### Assignment
 <div class="lesson-content__panel" markdown="1">
 
+
+**The following resources are meant to be done in Chrome browser unless stated otherwise.**
+
   1. Watch [this 10-minute video](https://www.youtube.com/watch?v=wcFnnxfA70g) that goes over the most useful features of the Chrome DevTools in some detail.
   2. Watch this [awesome tutorial](https://www.youtube.com/watch?v=Z3HGJsNLQ1E) from LearnCode.academy on how to use developer tools effectively when working with your CSS.  It talks a bit about Bootstrap, which you may not know about yet.  Don't worry about it at this point; just check out the stuff he's doing to CSS in the DevTools.  In particular, editing CSS *in the browser* in real time is a serious productivity booster compared to using your text editor and continuously refreshing to see the changes.
   3. Skim through the [official Chrome DevTools docs](https://developers.google.com/web/tools/chrome-devtools/) [(or Firefox's!)](https://developer.mozilla.org/en-US/docs/Tools). Chrome and Firefox are constantly enhancing and updating their developer tools.  The basic functionality is going to be the same of course, but it's not unusual for things to move around or change appearance as the tools evolve.  These docs should be your up-to-date resource.  If your version of DevTools doesn't look like the videos above, reference these docs to find out where everything went.


### PR DESCRIPTION
Students seem to be trying to follow chrome tutorials in FireFox devtools. Added a note saying resources are to be followed in Chrome DevTools.