### PR TITLE
Moved `sudo ./VBoxLinuxAdditions.run` on a new line.

### DIFF
--- a/foundations/installations/prerequisites.md
+++ b/foundations/installations/prerequisites.md
@@ -118,11 +118,12 @@ While your VM is running, do the following steps:
   10. Wait for the CD image to mount, it will show the CD on the desktop as solid, not transparent, and a window will show on the top right of the VM screen saying it was successfully mounted.
   11. If you see a File Manager window appear, then confirm the presence of a file named `VBoxLinuxAdditions.run` before proceeding to step 12. But if you do _not_ see a File Manager window appear, then navigate to the desktop by minimizing all opened windows, and then double-click on the CD icon on the VM desktop.
   12. In the new window that opens, right click on the white-space or any file/folder, and click **Open Terminal Here**.
-  13. In the newly opened terminal window, paste `sudo ./VBoxLinuxAdditions.run` and hit enter.
-  14. Once it finishes, close the terminal and the CD folder.
-  15. Right-click CD on the VM desktop and click **Eject Volume**. It will not eject if the CD folder is open.
-  16. Reboot your VM (which you can do by typing `reboot` and hitting enter in a terminal).
-  17. You can now maximize the VM window, create additional displays, and use many other useful features. These options are available on the VM toolbar under **View** and **Device**.
+  13. In the newly opened terminal window, paste 
+`sudo ./VBoxLinuxAdditions.run` and hit enter.
+  15. Once it finishes, close the terminal and the CD folder.
+  16. Right-click CD on the VM desktop and click **Eject Volume**. It will not eject if the CD folder is open.
+  17. Reboot your VM (which you can do by typing `reboot` and hitting enter in a terminal).
+  18. You can now maximize the VM window, create additional displays, and use many other useful features. These options are available on the VM toolbar under **View** and **Device**.
   
   **NOTE**: 
 


### PR DESCRIPTION
Moved `sudo ./VBoxLinuxAdditions.run` on a new line as it is written on two different lines. It is hard to recognize the space between "sudo" and "./VBoxLinuxAdditions.run" thus typing a wrong command in the terminal.

<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [ ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

Moved `sudo ./VBoxLinuxAdditions.run` (step number 13 in the "Install and Enable Guest Additions" step) on a new line as it is written on two different lines. It is hard to recognize the space between "sudo" and "./VBoxLinuxAdditions.run" thus typing a wrong command in the terminal.


#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
