### PR TITLE
Small edit - 'master' to 'main'

### DIFF
--- a/foundations/git_basics/git_basics.md
+++ b/foundations/git_basics/git_basics.md
@@ -22,6 +22,8 @@ By the end of this lesson, you should be able to do the following:
 ### Cheatsheet
 This is a reference list of the most commonly used Git commands. (You might consider bookmarking this handy page.) Try to familiarize yourself with the commands so that you can eventually remember them all:
 
+Note: Starting October 1st, 2020, all new Git repositories will create a default branch named 'main' instead of 'master'. (Visit [this article](https://www.theserverside.com/feature/Why-GitHub-renamed-its-master-branch-to-main) by Carolyn Heinze if you wish to understand the reasons behind the change.)
+
 * Commands related to a remote repository:
   * `git clone git@github.com:USER-NAME/REPOSITORY-NAME.git`
   or

--- a/foundations/git_basics/git_basics.md
+++ b/foundations/git_basics/git_basics.md
@@ -24,8 +24,6 @@ Note: As of October 1st, 2020, all new Git repositories will create a default br
 ### Cheatsheet
 This is a reference list of the most commonly used Git commands. (You might consider bookmarking this handy page.) Try to familiarize yourself with the commands so that you can eventually remember them all:
 
-
-
 * Commands related to a remote repository:
   * `git clone git@github.com:USER-NAME/REPOSITORY-NAME.git`
   or

--- a/foundations/git_basics/git_basics.md
+++ b/foundations/git_basics/git_basics.md
@@ -13,6 +13,8 @@ By the end of this lesson, you should be able to do the following:
 
 ### Assignment
 
+Note: As of October 1st, 2020, all new Git repositories will create a default branch named 'main' instead of 'master'. (Visit [this article](https://www.theserverside.com/feature/Why-GitHub-renamed-its-master-branch-to-main) by Carolyn Heinze if you wish to understand the reasons behind the change.)
+
 <div class="lesson-content__panel" markdown="1">
 
   1. Watch [this video](https://www.youtube.com/watch?v=HVsySz-h9r4) by Corey Schafer for a great overview of some basic Git commands.
@@ -22,7 +24,7 @@ By the end of this lesson, you should be able to do the following:
 ### Cheatsheet
 This is a reference list of the most commonly used Git commands. (You might consider bookmarking this handy page.) Try to familiarize yourself with the commands so that you can eventually remember them all:
 
-Note: Starting October 1st, 2020, all new Git repositories will create a default branch named 'main' instead of 'master'. (Visit [this article](https://www.theserverside.com/feature/Why-GitHub-renamed-its-master-branch-to-main) by Carolyn Heinze if you wish to understand the reasons behind the change.)
+
 
 * Commands related to a remote repository:
   * `git clone git@github.com:USER-NAME/REPOSITORY-NAME.git`

--- a/foundations/git_basics/git_basics.md
+++ b/foundations/git_basics/git_basics.md
@@ -13,7 +13,7 @@ By the end of this lesson, you should be able to do the following:
 
 ### Assignment
 
-Note: As of October 1st, 2020, all new Git repositories will create a default branch named 'main' instead of 'master'. (Visit [this article](https://www.theserverside.com/feature/Why-GitHub-renamed-its-master-branch-to-main) by Carolyn Heinze if you wish to understand the reasons behind the change.)
+Note: As of October 1st, 2020, all new Git repositories will create a default branch named 'main' instead of 'master'.
 
 <div class="lesson-content__panel" markdown="1">
 


### PR DESCRIPTION
This edit acknowledges that the assignment video still refers to the default branch as 'master' instead of 'main', while the cheat sheet provided assignment assumes the updated practice of Git, which is creating the default 'main' branch.

<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [ ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

...your text here

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
