### PR TITLE
Remove reference to Javascript course

### DIFF
--- a/html_css/conclusion.md
+++ b/html_css/conclusion.md
@@ -1,8 +1,8 @@
 HTML and CSS are actually surprisingly large topics, who would have thought?  If you've made it this far, though, you're more than well on your way to front end development magic.  You should be significantly more comfortable breaking down a webpage into its component pieces and then coding them with HTML and CSS.  You have the tools necessary to identify an effective visual layout and then bring it to fruition.
 
-There are still plenty of ways you can make your workflow better or improve your knowledge of best practices (so don't stop learning!), but you've got everything you need to build beautiful websites.  Now that you've finished this course, you are probably chomping at the bit for the final piece of the puzzle which will empower you to make everything dynamic... Javascript.
+There are still plenty of ways you can make your workflow better or improve your knowledge of best practices (so don't stop learning!), but you've got everything you need to build beautiful websites.  
 
-Luckily, that's the next course!  Onwaaaaaaard!!!
+Onwaaaaaaard!!!
 
 ### Additional Resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something.


### PR DESCRIPTION
This conclusion is written as if Ruby is still the only track, and the Javascript module is next, but doesn't make sense for people on the Javascript track. I've removed the offending lines in this PR.

