### PR TITLE
Change wording of class_variables

### DIFF
--- a/ruby_programming/basic_ruby/variables.md
+++ b/ruby_programming/basic_ruby/variables.md
@@ -108,7 +108,7 @@ This example may be hard to completely understand at this point in the lesson. T
 ### Assignment
 <div class="lesson-content__panel" markdown="1">
 
-1. Read the [Variables](https://launchschool.com/books/ruby/read/variables) chapter from LaunchSchool's brilliant *Introduction to Programming With Ruby*. As indicated in this article, remember that you should not use `$global_variables` or `@@class_variables`.
+1. Read the [Variables](https://launchschool.com/books/ruby/read/variables) chapter from LaunchSchool's brilliant *Introduction to Programming With Ruby*. As indicated in this article, remember that you should not use `$global_variables`. Additionally, `@@class_variables` are rarely needed and easily misused.
 2. Read through these short, to-the-point variable lessons by Ruby Monstas:
       * [Overview of Variables](http://ruby-for-beginners.rubymonstas.org/variables.html)
       * [Reusing Variables](http://ruby-for-beginners.rubymonstas.org/variables/reusing_names.html)


### PR DESCRIPTION
Per discussion in #ruby-help, April 28th, 2021

<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [ x ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).
 - Sorry I didn't do the branch part, I just modified the markdown on Github (hopefully that is okay for a minor change like this). I _did_ check in a local editor that I didn't mess anything up with the markdown, though.

#### 1.Describe the changes made:

Just changed the wording of line 111 to fix an inaccuracy and draw a clearer distinction between global variables (which should never be used) and class variables (which have legitimate uses, even if such cases are rare and advanced). As mentioned above, the relevant discussion is in the Discord channel #ruby-help.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

It is not.
