### PR TITLE
Fix typo in pattern_matching.md

### DIFF
--- a/ruby_programming/advanced_ruby/pattern_matching.md
+++ b/ruby_programming/advanced_ruby/pattern_matching.md
@@ -522,7 +522,7 @@ in { a: 'ant' } => hash
   p hash
 end
 
-#=> { :a => 'apple', :b => 'ball' }
+#=> { :a => 'ant', :b => 'ball' }
 ~~~
 
 ### Ruby 3 patterns


### PR DESCRIPTION
<!-- 
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/master/CONTRIBUTING.md).

#### 1.Describe the changes made:

Fixed a typo in the last pattern example before the **Ruby 3** section in pattern_matching.md. I think it's meant to say "ant" rather than "apples", this confused me when I was learning this lesson.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
