### PR TITLE
Move the chromebook git install instructions

### DIFF
--- a/foundations/installations/prerequisites.md
+++ b/foundations/installations/prerequisites.md
@@ -200,8 +200,6 @@ Once you have successfully met both of these requirements, you should be able to
 
 **Note for CloudReady users**
 
-Chrome OS/CloudReady users will need to install Git from source by following the instructions at this [Digital Ocean tutorial](https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10#installing-git-from-source).
-
 Currently there is a bug preventing CloudReady v83.4 from successfully installing Linux (Beta). This was resolved in version 85.2.
 
 </details>

--- a/foundations/installations/setting_up_git.md
+++ b/foundations/installations/setting_up_git.md
@@ -81,6 +81,14 @@ If the version number is less than 2.28, follow the instructions again. If you a
 
 </details>
 
+<details markdown="block">
+<summary class="dropDown-header">Chrome OS/CloudReady
+</summary>
+
+You will need to install Git from source by following the instructions at this [Digital Ocean tutorial](https://www.digitalocean.com/community/tutorials/how-to-install-git-on-debian-10#installing-git-from-source).
+
+</details>
+
 ### Step 2: Configure Git and GitHub
 
 #### Step 2.1: Setup Git


### PR DESCRIPTION
Git install instructions for chromebook users are currently in the
prerequisites lesson, this commit moves them to the setting_up_git
lesson under a new dropdown for chromebook/cloudready.

<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

Move the chromebook git install instructions to the setting up git lesson rather than the prerequisites lesson.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
