### PR TITLE
Remove Github Jobs as it is deprecated with no new jobs

### DIFF
--- a/getting_hired/collect_leads.md
+++ b/getting_hired/collect_leads.md
@@ -20,7 +20,6 @@ Try checking out these links for job boards.  The more technically-focused, the 
 * [Authentic Jobs](http://www.authenticjobs.com)
 * [StackOverflow Jobs](https://stackoverflow.com/jobs)
 * [CWJobs](http://cwjobs.co.uk)
-* [GitHub Jobs](https://jobs.github.com/)
 * [White Truffle -- Weighted towards startups right now](http://www.whitetruffle.com)
 * [Dice.com](http://www.dice.com)
 * [Coderwall.com](http://coderwall.com) lets you display your engineering prowess and they can come to you.


### PR DESCRIPTION
 - Github Jobs is deprecated and no new jobs are to be added after
   19th May 2021 and entirely shutdown by August 19th 2021.
   - https://jobs.github.com/

<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [X] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

I have removed a jobs board, Github Jobs, that has already stopped taking new jobs and will be entirely removed by mid August. [The announcement.](https://github.blog/changelog/2021-04-19-deprecation-notice-github-jobs-site/). [Github jobs with all jobs at least 16 days ago.
](https://jobs.github.com/positions)

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

No
