### PR TITLE
Change numbering from 1. 1. 1. to 1. 2. 3.

### DIFF
--- a/javascript/react-js/hooks.md
+++ b/javascript/react-js/hooks.md
@@ -107,23 +107,23 @@ You have three different options for the dependency array:
 
 1. Leave it empty. If you leave it empty the useEffect hook would look something like this:
 
-~~~javascript
+   ~~~javascript
 useEffect(() => {
   // Do something
 }, []);
 ~~~
 
-This option is equal to a `componentDidMount` lifecycle method, meaning the hook runs **one time** when the component mounts (is inserted in the DOM tree)
+   This option is equal to a `componentDidMount` lifecycle method, meaning the hook runs **one time** when the component mounts (is inserted in the DOM tree)
 
 2. Add a dependency to the array. Like we did it in our example code.
 
-~~~javascript
+   ~~~javascript
 useEffect(() => {
   // Do something
 }, [color]);
 ~~~
 
-This way, the useEffect hook will re-run anytime the dependency (color) changes. This is similar to a `componentDidUpdate` method, with the only difference that it only runs when a certain condition has changed.
+   This way, the useEffect hook will re-run anytime the dependency (color) changes. This is similar to a `componentDidUpdate` method, with the only difference that it only runs when a certain condition has changed.
 
 3. Leave out the dependency array.
 


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

At the moment numbering doesn't work as expected. Instead of 1. 2. 3. on the page 1. 1. 1. is displayed. 
This is because how Kramdown formats stuff. In order that Kramdown formats here correctly, we need to add 3 spaces before each paragraph of a numbering section.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:
