### PR TITLE
replace non-existent "componentDidUnmount"

### DIFF
--- a/javascript/react-js/hooks.md
+++ b/javascript/react-js/hooks.md
@@ -43,7 +43,7 @@ Afterwards we are declaring a function, which right now just sets a new count. I
 
 ### useEffect
 
-Well, we don't have any lifecycle methods such as `componentDidMount`, `componentDidUpdate` or `componentDidUnmount`, but we do have something better. We have `useEffect`, which can actually do everything the above mentioned lifecycle methods can do. Let's have a closer look.
+Well, we don't have any lifecycle methods such as `componentDidMount`, `componentDidUpdate` or `componentWillUnmount`, but we do have something better. We have `useEffect`, which can actually do everything the above mentioned lifecycle methods can do. Let's have a closer look.
 
 ~~~javascript
 import React, { useState, useEffect } from "react";


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [ x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

The page on react hooks mentions `componentDidUnmount` as an example of a lifecycle method. As far as I can tell, react does not have a `componentDidUnmount` lifecycle method and there seems to be no mention of it in the react docs. I assume this was meant to be `componentWillUnmount`. See also this issue on the react github: https://github.com/facebook/react/issues/6424

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:
