### PR TITLE
added a homebrew step for Silicon machines

### DIFF
--- a/foundations/installations/setting_up_git.md
+++ b/foundations/installations/setting_up_git.md
@@ -55,6 +55,10 @@ First, you'll need to install Homebrew.  Make sure you have checked the requirem
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ~~~
 
+Note: On an Apple Silicon Mac you will have an extra step to take.
+If you look at the terminal output after installing Homebrew, you will see "Installation Successful!". Further down in the terminal there will be a section called "Next steps". 
+This may all seem a bit intimidating but this is a great chance at overcoming those feelings. Follow the next steps as stated in your terminal (copy and paste the commands given) and you will make sure you will not encounter a "command not found: brew" error when doing the below Step 1.1: Update Git.
+
 #### Step 1.1: Update Git
 
 MacOS already comes with a version of Git, but you should update to the latest version. In the terminal, type
@@ -64,15 +68,6 @@ brew install git
 ~~~
 
 This will install the latest version of Git. Easy, right?
-
-Note: On an Apple Silicon Mac you might now encounter the following error: "brew command not found". This is due to Homebrew installing in a different directory than it is on an intel machine.
-To fix this issue, copy and paste the following into your terminal:
-
-~~~bash
-echo "export PATH=/opt/homebrew/bin:$PATH" >> ~/.zshrc
-~~~
-
-after reopening the terminal, the brew commands should work.
 
 #### Step 1.2: Verify version
 

--- a/foundations/installations/setting_up_git.md
+++ b/foundations/installations/setting_up_git.md
@@ -57,7 +57,7 @@ First, you'll need to install Homebrew.  Make sure you have checked the requirem
 
 Note: On an Apple Silicon Mac you will have an extra step to take.
 If you look at the terminal output after installing Homebrew, you will see "Installation Successful!". Further down in the terminal there will be a section called "Next steps". 
-This may all seem a bit intimidating but this is a great chance at overcoming those feelings. Follow the next steps as stated in your terminal (copy and paste the commands given) and you will make sure you will not encounter a "command not found: brew" error when doing the below Step 1.1: Update Git.
+Reading the terminal may seem a bit intimidating, but this is a great chance to overcome those feelings. Follow the next steps as stated in your terminal (copy and paste the commands given) to add Homebrew to your PATH, which allows you to use the `brew` command prefix. 
 
 #### Step 1.1: Update Git
 

--- a/foundations/installations/setting_up_git.md
+++ b/foundations/installations/setting_up_git.md
@@ -65,6 +65,15 @@ brew install git
 
 This will install the latest version of Git. Easy, right?
 
+Note: On an Apple Silicon Mac you might now encounter the following error: "brew command not found". This is due to Homebrew installing in a different directory than it is on an intel machine.
+To fix this issue, copy and paste the following into your terminal:
+
+~~~bash
+echo "export PATH=/opt/homebrew/bin:$PATH" >> ~/.zshrc
+~~~
+
+after reopening the terminal, the brew commands should work.
+
 #### Step 1.2: Verify version
 
 **Open a new terminal window** and then make sure your git version is **at least** 2.28 by running this command:


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [ ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

Added a command for terminal for silicon machines to avoid 'brew command not found' error.

It seems that home-brew installs in a different directory on silicon machines compared to intel machines. I haven't tried it in bash but since zsh is the default I found this fix from https://stackoverflow.com/questions/20381128/installing-homebrew-on-os-x . I also found this YouTube with a possible explanation but frankly I'm not very experienced yet and not sure if what he says is correct. https://www.youtube.com/watch?v=2St60bsdAbg

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
