### PR TITLE
Describe how to link to external JS file in DOM manipulation lesson

### DIFF
--- a/foundations/javascript_basics/DOM-manipulation.md
+++ b/foundations/javascript_basics/DOM-manipulation.md
@@ -214,6 +214,14 @@ Keep in mind that the JavaScript does _not_ alter your HTML, but the DOM - your 
 > **Important note:**
 > Your JavaScript, for the most part, is run whenever the JS file is run, or when the script tag is encountered in the HTML. If you are including your JavaScript at the top of your file, many of these DOM manipulation methods will not work because the JS code is being run *before* the nodes are created in the DOM. The simplest way to fix this is to include your JavaScript at the bottom of your HTML file so that it gets run after the DOM nodes are parsed and created.
 
+> Alternatively, you can link the JavaScript file in the `<head>` of your HTML document. Use the `<script>` tag with the `src` attribute containing the path to the JS file, and include the `defer` keyword to load the file *after* the HTML is parsed, as such:
+
+~~~html
+<head>
+  <script src="js-file.js" defer></script>
+</head>
+~~~
+
 ### Exercise
 
 Copy the example above into files on your own computer.  To make it work you'll need to supply the rest of the HTML skeleton and either link your javascript file, or put the javascript into a script tag on the page.  Make sure everything is working before moving on!

--- a/foundations/javascript_basics/DOM-manipulation.md
+++ b/foundations/javascript_basics/DOM-manipulation.md
@@ -222,6 +222,8 @@ Keep in mind that the JavaScript does _not_ alter your HTML, but the DOM - your 
 </head>
 ~~~
 
+> Read the second bullet point in [this MDN article](https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML#applying_css_and_javascript_to_html) for more information, which also includes a link to additional script loading strategies.
+
 ### Exercise
 
 Copy the example above into files on your own computer.  To make it work you'll need to supply the rest of the HTML skeleton and either link your javascript file, or put the javascript into a script tag on the page.  Make sure everything is working before moving on!


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

After discussing this in the contributions suggestions channel from Discord, I decided learners could benefit greatly from learning how to link to external JS files from an HTML page as soon as makes sense.

I added a few sentences describing where and how to put the script tag, src attr and defer keyword. 
Additionally, I linked to a relevant portion of an MDN article that goes more in-depth regarding script loading strategies.

I initially only wanted to link to the MDN article, but believe it would be very helpful to have a reference readily available within the lesson.