### PR TITLE
replaced require 'pry' with require 'pry-byebug'

### DIFF
--- a/ruby_programming/basic_ruby/debugging.md
+++ b/ruby_programming/basic_ruby/debugging.md
@@ -106,12 +106,12 @@ p []
 ### Debugging with Pry-byebug
 [Pry](https://github.com/pry/pry) is a Ruby gem that provides you with an interactive [REPL](https://www.rubyguides.com/2018/12/what-is-a-repl-in-ruby/) while your program is running. The REPL provided by Pry is very similar to IRB but has added functionality. The recommended Ruby gem for debugging is [Pry-byebug](https://github.com/deivid-rodriguez/pry-byebug) and it includes Pry as a dependency. Pry-byebug adds step-by-step debugging and stack navigation.  
 
-To use Pry-byebug, you'll first need to install it in your terminal by running `gem install pry-byebug`. You can then make it available in your program by requiring it at the top of your file with `require 'pry'`. Finally, to use Pry-byebug, you just need to call `binding.pry` at any point in your program.
+To use Pry-byebug, you'll first need to install it in your terminal by running `gem install pry-byebug`. You can then make it available in your program by requiring it at the top of your file with `require 'pry-byebug'`. Finally, to use Pry-byebug, you just need to call `binding.pry` at any point in your program.
 
 To follow along with these examples save the code into a Ruby file (e.g., `script.rb`) and then run the file in your terminal (e.g., `ruby script.rb`)
 
 ~~~ruby
-require 'pry'
+require 'pry-byebug'
 
 def double_words_in_phrase(string)
   string_array = string.split(' ')
@@ -130,7 +130,7 @@ When your code executes and gets to `binding.pry`, it will open an IRB-like sess
 To see this point in action, try running the following:
 
 ~~~ruby
-require 'pry'
+require 'pry-byebug'
 
 def yell_greeting(string)
   name = string


### PR DESCRIPTION
with 'pry' alone I couldn't use the `next` command which is included in the same section.

<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

replaced require 'pry' with require 'pry-byebug' because with 'pry' alone I couldn't use the `next` command which is included in the same section.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
