### PR TITLE
Remove redundant link

### DIFF
--- a/foundations/introduction/motivation_and_mindset.md
+++ b/foundations/introduction/motivation_and_mindset.md
@@ -142,5 +142,4 @@ Without further ado, let's jump in to learning web development!
 ### Additional Resources
 * [Managing inspiration and motivation](https://markmanson.net/do-something)
 * [Learning to code when it gets dark](https://medium.freecodecamp.org/learning-to-code-when-it-gets-dark-e485edfb58fd#.yjh0fehje)
-* [Why learning to code is so damn hard](https://www.vikingcodeschool.com/posts/why-learning-to-code-is-so-damn-hard)
 * [Improve your typing skills with Keybr.com](https://www.keybr.com/) Use this keyboard trainer if you find your typing speed is holding you back. We recommend to spend 5 mins everyday after you start your PC.


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [X] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:
Removes the link to Why Learning to Code is So Damn Hard (added 5 years ago), we've just read this article in the previous section's conclusion; "Foundations/Introduction/Introduction To Web Development" Line 85 found here (added 3 years ago):
https://github.com/TheOdinProject/curriculum/blob/main/foundations/introduction/introduction_to_web_development.md#conclusion

Based on the Blame dates; what was previously just an additional link on this page, is now worked into the body of the previous page. Assuming the most recent, and in-body, version is the preferred.
