### PR TITLE
Remove redudant link and slight rewording

### DIFF
--- a/foundations/introduction/join_the_odin_community.md
+++ b/foundations/introduction/join_the_odin_community.md
@@ -43,9 +43,6 @@ If the puzzle still can't be solved, push your project to GitHub or put your cod
 
 Sometimes there might be no one around to help you with your issue. That is the ideal time to get familiar with the [Discord search function](https://support.discordapp.com/hc/en-us/articles/115000468588-Using-Search). Search for specific keywords or error messages to see if anyone else had a similar issue before and how they solved it!
 
-#### An Important Read
-The article [How to be great at asking coding questions](https://medium.com/@gordon_zhu/how-to-be-great-at-asking-questions-e37be04d0603) has really great tips on how to put together an effective question. An effective question makes it easy for us to help you. The strategies outlined there invite you to think deeply about your problem. Sometimes, as a happy accident, you may even lead yourself to the answer as you reflect on the matter. But asking good questions isn't just about us helping you. Great questions make you a great teammate. A future co-worker or manager does not want to spend time poking at your code to learn about your problem. You'll be expected to bring thoughtful and fully developed questions.
-
 ### Formatting your questions
 
 Asking your questions in a readable format helps everyone debug them better. Here are some ways to go about that:
@@ -129,7 +126,7 @@ If you do not have much time to help, please let someone else answer the questio
 If the question does not reveal where they are in the curriculum, ask them so that you can adjust your expectations to their knowledge level.
 
 #### 6. Ask for clarifications
-If the question seems confusing or ambiguous, ask for more clarity, or politely link them to our bot command `/question`, which links to the [How to be great at asking coding questions](https://medium.com/@gordon_zhu/how-to-be-great-at-asking-questions-e37be04d0603) article mentioned above.
+If the question seems confusing or ambiguous, ask for more clarity, or politely link them to our bot command `/question`, which links to the [How to be great at asking coding questions](https://medium.com/@gordon_zhu/how-to-be-great-at-asking-questions-e37be04d0603) article.
 
 #### 7. Ask for live code
 If the question needs to have live code to fully understand or debug, ask them use [replit](https://replit.com) to provide it. If the problem is difficult to isolate, they should recreate the problem with isolated code.


### PR DESCRIPTION
Removes `#### An Important Read` section which links to https://medium.com/@gordon_zhu/how-to-be-great-at-asking-questions-e37be04d0603, in favour of the previous page: Asking For Help.
Also removes a reference to this section.

Closes #22462 