### PR TITLE
Re-points broken link to new URLfor Git Basics.

### DIFF
--- a/foundations/the_front_end/project_html_css.md
+++ b/foundations/the_front_end/project_html_css.md
@@ -21,7 +21,7 @@ These skills will be helpful for you when you start building. Either try them yo
 
 As mentioned in the [introduction to Git](/courses/foundations/lessons/introduction-to-git), you'll want to organize all your projects like a portfolio and link them to GitHub so it can be seen by others.
 
-If you do not know how to set up a repository, follow the instructions found in [Project: Git Basics](/courses/foundations/lessons/practicing-git-basics) to learn how.
+If you do not know how to set up a repository, follow the instructions found in [Git Basics](/courses/foundations/lessons/git-basics) to learn how.
 
 1. If you haven't already, create a folder on your computer called `the_odin_project` and `cd` into it. This folder will house all the projects you do at Odin.
 2. Create a new repo for this project on GitHub.com and call it `google-homepage` (instead of `git-test`).


### PR DESCRIPTION
Closes #22465 

This issue was introduced when the Git Basics lesson was moved. The URL will now point to the new URL.
