### PR TITLE
Adds codespell Github Action.

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,14 @@
+name: codespell
+on: pull_request
+jobs:
+    codespell:
+        name: Check for spelling errors
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v2
+        - uses: codespell-project/actions-codespell@master
+          with:
+            check_filenames: true
+            check_hidden: true
+            skip: ./.git,*.png,*.csv,./archive,./legacy_submissions
+            only_warn: 1


### PR DESCRIPTION
#### Changes :

This PR adds a GitHub Action to `curriculum` that will run `codespell` on the repo.

- This Action will trigger on **every** PR.
- The Action ignores the archive and legacy submission folders.
- Codespell won't detect every misspelling there is.
- The check will pass every time because the `only_warn` flag is set to `1`. We will need to quickly check `Checks` to see if the student's changed files introduced any misspellings. Under the `Run codespell-project/actions-codespell@master` tab.

It would be ideal to have codespell bomb a PR if it introduced any typos, but the behavior I observed for the Codespell action was to bomb the check upon the **first** typo, meaning we wouldn't get a list of all typos. With the warning on, the check will pass but we will get our list of typos.

I think this is fine for now and discussed it with @I3uckwheat until someone can improve the job further.

If you want to play with this, I strongly recommend doing it in a forked repo so weird actions don't happen on `curriculum`.

Closes #12979 


**Edit**
I forgot to mention that you can click on this PR's `Checks` to see the Action work. Additionally, since Codespell doesn't detect every misspelling, I think it's still worth asking contributors to have a spellchecking extension in their text editors to help further mitigate this issue.