### PR TITLE
Switches broken Skillcrush resource to FCC resource & removes dead link.

### DIFF
--- a/rails_programming/apis/api_basics.md
+++ b/rails_programming/apis/api_basics.md
@@ -128,7 +128,7 @@ See the [as_json documentation](https://api.rubyonrails.org/classes/ActiveModel/
 
 #### Rendering Nothing or Errors
 
-Sometimes you just want to send out an HTTP error code without any response body.  The web is conflicted about the best practices for doing so (see [This older blog](http://www.intridea.com/blog/2008/7/23/using-http-status-codes-for-rails-ajax-error-handling) for one approach or [this SO answer](http://stackoverflow.com/questions/9130191/how-to-return-correct-http-error-codes-from-ruby-on-rails-application) for another set of answers) .  Here's a simple example (again we are just rendering the error in all cases):
+Sometimes you just want to send out an HTTP error code without any response body.  The web is conflicted about the best practices for doing so (see [this SO answer](http://stackoverflow.com/questions/9130191/how-to-return-correct-http-error-codes-from-ruby-on-rails-application) for a set of answers) .  Here's a simple example (again we are just rendering the error in all cases):
 
 ~~~ruby
   # app/controllers/users_controller.rb

--- a/rails_programming/apis/api_basics.md
+++ b/rails_programming/apis/api_basics.md
@@ -128,7 +128,7 @@ See the [as_json documentation](https://api.rubyonrails.org/classes/ActiveModel/
 
 #### Rendering Nothing or Errors
 
-Sometimes you just want to send out an HTTP error code without any response body.  The web is conflicted about the best practices for doing so (see [this SO answer](http://stackoverflow.com/questions/9130191/how-to-return-correct-http-error-codes-from-ruby-on-rails-application) for a set of answers) .  Here's a simple example (again we are just rendering the error in all cases):
+Sometimes you just want to send out an HTTP error code without any response body.  The web is conflicted about the best practices for doing so (see [this blog](https://web.archive.org/web/20201128082344/https://www.mobomo.com/2008/07/using-http-status-codes-for-rails-ajax-error-handling/) for one view and [this SO answer](http://stackoverflow.com/questions/9130191/how-to-return-correct-http-error-codes-from-ruby-on-rails-application) for a set of answers) .  Here's a simple example (again we are just rendering the error in all cases):
 
 ~~~ruby
   # app/controllers/users_controller.rb

--- a/rails_programming/apis/api_basics.md
+++ b/rails_programming/apis/api_basics.md
@@ -2,7 +2,7 @@
 
 Working with APIs is awesome and frustrating at the same time.  On the one hand, interfacing with other applications out there can greatly improve the reach and "cool factor" of your own app.  On the other, it involves lots of reading through documentation, figuring out authentication strategies, and parsing bad (or nonexistent) error messages.
 
-Backing up, if you're still unclear on what an API (Application Programming Interface) basically is, [read the Skillcrush explanation](https://skillcrush.com/2012/04/16/api/1346413073000/) and then [read the first bit of this article](http://money.howstuffworks.com/business-communications/how-to-leverage-an-api-for-conferencing1.htm) to catch up.
+Backing up, if you're still unclear on what an API (Application Programming Interface) basically is, [read this FCC explanation](https://www.freecodecamp.org/news/what-is-an-api-in-english-please-b880a3214a82/) and then [read the first bit of this article](http://money.howstuffworks.com/business-communications/how-to-leverage-an-api-for-conferencing1.htm) to catch up.
 
 "API" is an incredibly broad concept -- any time your application talks to another application, that's via some sort of API.  The components within your own application, e.g. the different pieces of Rails, also talk to each other via APIs... they are more or less independent sub-applications that pass along the data they each need to complete their particular task.  Everything's an API in application-land!
 


### PR DESCRIPTION
### Changes

Removes the dead link to a Skillcrush resource and replaces it with an FCC resource.

This is the new resource: https://www.freecodecamp.org/news/what-is-an-api-in-english-please-b880a3214a82/

Also removes a dead link to an older blog post for rendering errors. Thankfully, the section in the lesson called out this older content and an additional SO resource, so I think we can just remove the broken link. Despite the fact the lesson says there's different opinions, there's no indication what the broken link's opinions were; so we don't know what content we need to find to replace this.

Closes #22453 
Closes #22477 
