### PR TITLE
Word "the" appearing an extra time incorrectly.

### DIFF
--- a/javascript/organizing-js/es6-modules.md
+++ b/javascript/organizing-js/es6-modules.md
@@ -47,7 +47,7 @@ Webpack _is_ a very powerful tool, and with that power comes a decent amount of 
 
 To get us started we are going to refer to the official documentation.
 
-1. Code along with the all of the steps of [this tutorial](https://webpack.js.org/guides/getting-started/) ("Basic Setup" through "Conclusion")
+1. Code along with all of the steps of [this tutorial](https://webpack.js.org/guides/getting-started/) ("Basic Setup" through "Conclusion")
 
 Let's discuss what's going on there. After installing webpack using npm we set up a simple project that required an external library (lodash - check it out [here](https://lodash.com/) if it's new to you) using a simple `script` tag. The site lists a few reasons why this is probably _not_ ideal and then steps through using webpack to accomplish the same thing.
 


### PR DESCRIPTION
"Code along with the all of the steps of [this tutorial] " changed to " Code along with all of the steps of [this tutorial]"

<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [ ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

Word "the" appearing an extra time incorrectly.

"Code along with the all of the steps of [this tutorial] " 
>>

"Code along with all of the steps of [this tutorial]"

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
