### PR TITLE
Updated rspec it string in code block

### DIFF
--- a/ruby_programming/testing_with_rspec/introduction_to_rspec.md
+++ b/ruby_programming/testing_with_rspec/introduction_to_rspec.md
@@ -176,7 +176,7 @@ Finished in 0.28565 seconds (files took 0.6273 seconds to load)
 
 Failed examples:
 
-rspec ./spec/calculator_spec.rb:5 # Calculator#add adds two numbers together
+rspec ./spec/calculator_spec.rb:5 # Calculator#add returns the sum of two numbers
 ~~~
 
 Our first failure is denoted by the `F` at the top of the output. Congratulations! You've made it to the "red" portion of the "red-green-refactor" cycle of TDD. RSpec provides a list of all the failures, with the expected vs. actual output of the method being tested. At the bottom of your output, RSpec also points to the line of the failing test, which in this case is where our `it` block started.


### PR DESCRIPTION
Rspec it string argument is "returns the sum of two numbers", but page code block says "adds two numbers together", possibly from older version.

Terminal output of files confirms the accurate form to be "returns the sum of two numbers"

<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [✓] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

Changed the it string argument in code block from:
"adds two numbers together"
to:
"returns the sum of two numbers"

to accurately reflect the it string argument in the calculator.rb file provided:

describe "#add" do
      it "returns the sum of two numbers" do

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
