### PR TITLE
Add additional content to Private Events instructions

### DIFF
--- a/rails_programming/advanced_forms_and_activerecord/project_associations.md
+++ b/rails_programming/advanced_forms_and_activerecord/project_associations.md
@@ -44,7 +44,7 @@ We've gotten quite far here, so these tasks will only lay out the high level ove
 
 1. Add the association between the event attendee (also a User) and the event. Call this user the "attendee". Call the event the "attended_event". You'll again need to juggle specially named foreign keys and classes and sources.
 2. Create and migrate all necessary tables and foreign keys. This will require a "through" table since an Event can have many Attendees and a single User (Attendee) can attend many Events... many-to-many.
-3. Create a Controller and corresponding routes for the "through" table that will allow a user to become an "attendee" of an event.
+3. Create a Controller and corresponding routes for the "through" table that will allow a user to become an "attendee" of an event. This will also require creating some sort of interface in the view(s) where the user can indicate that they want to attend an event.
 4. Update the Event's Show page to display a list of attendees.
 5. Add to the User's Show page a list of their "attended_events".
 6. Separate this list of "attended_events" into either events that have occurred in the past or events that will occur in the future. You'll get some good practice building [queries](https://guides.rubyonrails.org/active_record_querying.html#array-conditions) and working with dates. Keep this logic in the view and do not put separate method calls in the controller.


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

Add one line to the Private Events instructions indicating that allowing a user to become an event attendee will not only require a controller and corresponding routes, but also an interface in the view(s) for the user to indicate that they want to attend an event.

I think that this line was a bit of a missing piece, and that adding it adds more specificity to the instructions while hopefully not giving too much away still.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

Not related to any open issues