### PR TITLE
Fix a minor typo: missing period at end of sentence

### DIFF
--- a/javascript/react-js/hooks.md
+++ b/javascript/react-js/hooks.md
@@ -4,7 +4,7 @@ As mentioned in the previous lesson, the lifecycle methods such as `componentDid
 
 **Hooks allow functional components to also have a lifecycle as well as a state.**
 
-Other than the basic hooks you will encounter in this section, there are many other hooks such as `useRef` or `useContext`, just to name two. React also provides the ability to write your own custom hooks. This changes the game between functional vs. class components. Functional components are no longer considered “dumb” components. Many programmers have increasingly begun to prefer functional components over class components. For more information have a look [here](https://dev.to/danielleye/react-class-component-vs-function-component-with-hooks-13dg)
+Other than the basic hooks you will encounter in this section, there are many other hooks such as `useRef` or `useContext`, just to name two. React also provides the ability to write your own custom hooks. This changes the game between functional vs. class components. Functional components are no longer considered “dumb” components. Many programmers have increasingly begun to prefer functional components over class components. For more information have a look [here](https://dev.to/danielleye/react-class-component-vs-function-component-with-hooks-13dg).
 
 Now we will discuss the most basic hooks.  Create a `create-react-app` and use the App.js file for the following examples. This won't actually create a lot of functionality, but when coding along you will remember everything better thanks to muscle memory.
 


### PR DESCRIPTION
This commit fixes a small typo, a missing period at end of sentence. See this issue:  #22513.