### PR TITLE
Add missing period - Ruby - Event Manager

### DIFF
--- a/ruby_programming/files_and_serialization/project_event_manager.md
+++ b/ruby_programming/files_and_serialization/project_event_manager.md
@@ -262,7 +262,7 @@ lines.each do |line|
 end
 ~~~
 
-When this program is run, the `next if` line checks every line to see if it matches the provided string. If so, it skips that line from the rest of the loop
+When this program is run, the `next if` line checks every line to see if it matches the provided string. If so, it skips that line from the rest of the loop.
 
 A problem with this solution is that the content of our header row could change
 in the future. Additional columns could be added or the existing columns


### PR DESCRIPTION
- [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

Missing '.' has been added at the section skipping header row

