### PR TITLE
Add clarifying sentence with link on first step 6

### DIFF
--- a/rails_programming/advanced_forms_and_activerecord/project_associations.md
+++ b/rails_programming/advanced_forms_and_activerecord/project_associations.md
@@ -37,7 +37,7 @@ We've gotten quite far here, so these tasks will only lay out the high level ove
 3. Set up [devise](https://github.com/heartcombo/devise) to handle authentication and create your User model. Set the `root_path` to be the Event's Index page.
 4. Add the association between the event creator (a User) and the event. Call this user the "creator". Add the foreign key to the Event model as necessary. You'll need to specify your association properties carefully (e.g. `:foreign_key`, `:class_name`, and `:source`).
 5. Have the User's Show page list all the events a user has created.
-6. Update the EventsController and corresponding routes to allow you to create a new event. The `#create` action should use the `#build` [association reference method](https://guides.rubyonrails.org/association_basics.html#detailed-association-reference) to create the new event with the user's ID prepopulated. You could use Event's `::new` method and manually enter the ID but... don't.
+6. Update the EventsController and corresponding routes to allow you to create a new event. The `#create` action should use the `#build` association reference method to create the new event with the user's ID prepopulated. Find the right `#build` [association reference method](https://guides.rubyonrails.org/association_basics.html#detailed-association-reference) for the type of association you set up between your models. You could use Event's `::new` method and manually enter the ID but... don't.
 7. Make the form for creating an event.
 8. Have the Event's Show page display the details of the event.
 9. Update the Event's Index to display all of the events. You do not need to worry about editing or deleting events.


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [X] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

The link in step 6 goes to the start of Chapter 4 which immediately shows the `belongs_to` association and `#build_association` method. This method will not work and students need to go down and find the `#build` association method from the `has_many` association section. 

This fix adds another line about finding the right `#build` association method from this Rails Guide link. Along with that reminder it also moves the link to this new sentence to help students think about checking for the right method and hopefully avoid confusion. By keeping the exact same link to the start of chapter 4 instead of linking to the `has_many` section it prevents spoilers on which association students should be using for this model.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
