### PR TITLE
Update command_line_basics.md

### DIFF
--- a/foundations/installations/command_line_basics.md
+++ b/foundations/installations/command_line_basics.md
@@ -39,7 +39,7 @@ By the end of this lesson, you should be able to do the following:
 **Note**: Many of these resources assume you're using a Mac or Linux environment. If you did our previous installation lesson, you should already have Linux installed in dual-boot or a virtual machine. Or, you might be using MacOS. If you don't have MacOS, or any version of Linux installed, please return to the [operating system installation guide](https://www.theodinproject.com/courses/foundations/lessons/prerequisites).
 
   1. Before diving into the command line lesson, you'll want to know how to create a file. You can do so with the `touch` command. Open your terminal and enter `ls` (the `l` is a lowercase `L`). `ls` will show you the files and folders in the current directory (or will show nothing if the current directory is empty). Create a file called `test.txt` by entering this in your terminal: `touch test.txt`. Now enter `ls` once again. You should see `test.txt` listed in the output. You can also create more than one file at once using the `touch` command. Enter `touch index.html script.js style.css` and press the enter. Then enter `ls` once more. You should see the files in the output. Here is a small way that the terminal reveals its power. How long would it have taken to create all three of those files with your mouse? Thanks, terminal.
-  2. Read through [chapter 1 of Conquering the Command Line](https://webcache.googleusercontent.com/search?q=cache:7rq6J-lQX_UJ:conqueringthecommandline.com/book/basics).
+  2. Read through [chapter 1 of Conquering the Command Line](https://www.softcover.io/read/fc6c09de/unix_commands/basics).
 </div>
 
 


### PR DESCRIPTION
Under "Assignment" the link for "Chapter 1 of Conquering Command Line Basics" (linkhttps://webcache.googleusercontent.com/search?q=cache:7rq6J-lQX_UJ:conqueringthecommandline.com/book/basics) is a defunct link. Upon sufficient Google-fu'ing you can instead redirect to "https://www.softcover.io/read/fc6c09de/unix_commands/basics" for the learner to complete the assignment.

<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [ ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

Under "Assignment" the link for "Chapter 1 of Conquering Command Line Basics" (linkhttps://webcache.googleusercontent.com/search?q=cache:7rq6J-lQX_UJ:conqueringthecommandline.com/book/basics) there is a defunct link. I propose replacing the URL with a new redirect to the following "https://www.softcover.io/read/fc6c09de/unix_commands/basics" which is a working web page with the relevant information.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#22531
