### PR TITLE
Make phone numbers instruction more clear

### DIFF
--- a/ruby_programming/files_and_serialization/project_event_manager.md
+++ b/ruby_programming/files_and_serialization/project_event_manager.md
@@ -1534,7 +1534,7 @@ and well-formed.
 
 * If the phone number is less than 10 digits, assume that it is a bad number
 * If the phone number is 10 digits, assume that it is good
-* If the phone number is 11 digits and the first number is 1, trim the 1 and use the first 10 digits
+* If the phone number is 11 digits and the first number is 1, trim the 1 and use the remaining 10 digits
 * If the phone number is 11 digits and the first number is not 1, then it is a bad number
 * If the phone number is more than 11 digits, assume that it is a bad number
 


### PR DESCRIPTION
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

Ruby Programming - Event Manager - Clean Phone numbers instruction 3 is not clear.

If the phone number is less than 10 digits, assume that it is a bad number
If the phone number is 10 digits, assume that it is good
**If the phone number is 11 digits and the first number is 1, trim the 1 and use the first 10 digits**
If the phone number is 11 digits and the first number is not 1, then it is a bad number
If the phone number is more than 11 digits, assume that it is a bad number

**Problem:** If the phone number is 11 digits and the first number is 1, trim the 1 and use **the first** 10 digits

It's a bit unclear, if it look like this it will be more clear I think, 
**Solution:** If the phone number is 11 digits and the first number is 1, trim the 1 and use **the remaining** 10 digits.

So What I understood from this sentence is this, If we were given the number like this with the length of 11 =>  1234-334-2333 we need to trim the 1 first. So we will get 234-334-2333 So here we have remaining 10 digits always. So that **first 10 digits** wording make it unclear.  This is what I understood. 

So This is a PR to make it clear. If my assumption is right.