### PR TITLE
Edited text about GitHub pages for Google Project

### DIFF
--- a/foundations/the_front_end/project_html_css.md
+++ b/foundations/the_front_end/project_html_css.md
@@ -102,7 +102,7 @@ There are a couple of ways to go about doing this, but the simplest is this:
 
 - make sure that the main HTML file of your project is called `index.html`. If it is not, you will need to rename it.
 - go to your GitHub repo on the web and click the **Settings** button
-- click on the right side bar on **Pages**
+- click on **Pages** on the left side bar
 - change the **Source** from _none_ to _main branch_ and click Save.
 - it may take a few minutes (the GitHub website says up to 10) but your project should be accessible over the web from `your-github-username.github.io/your-github-repo-name` (obviously substituting your own details in the link)
 


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

Currently in GitHub settings, when trying to publish a website on GitHub Pages, the overall settings appear on the left hand side and therefore changed the current text which refers to clicking on Pages on the right side bar.

A photo below showing the setting bar position:
![left side bar](https://i.imgur.com/YEqflMG.png)


#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
