### PR TITLE
Replace link at line 147

### DIFF
--- a/rails_programming/apis/api_basics.md
+++ b/rails_programming/apis/api_basics.md
@@ -144,7 +144,7 @@ Sometimes you just want to send out an HTTP error code without any response body
 
 #### Creating Dynamic Error Pages
 
-You can create your own error pages. See [this blog post](https://pooreffort.com/blog/custom-rails-error-pages).
+You can create your own error pages. See [this post](https://web-crunch.com/posts/custom-error-page-ruby-on-rails).
 
 Sometimes Heroku can require additional steps to properly display your error pages.  See [their error page docs here](https://devcenter.heroku.com/articles/error-pages).  You might need to delete the static pages in the `app/public` directory first.
 


### PR DESCRIPTION
Link https://pooreffort.com/blog/custom-rails-error-pages redirects to https://phawk.co.uk/blog/custom-rails-error-pages, which then throws a "The page you were looking for doesn't exist." error. I added another that I found googling,but of course feel free to change it.

<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [ x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

Removed the non-existent blog post referenced at line 147. Replaced it with a webcrunch post on the same issue.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
