### PR TITLE
Fix Thunder Client link formatting

### DIFF
--- a/nodeJS/APIs/Blog-Project.md
+++ b/nodeJS/APIs/Blog-Project.md
@@ -28,5 +28,5 @@ Why are we setting it up like this? Because we can! If you already have a portfo
 </div>
 
 ### Additional Resources
-- As mentioned earlier, the cli-tool `curl` and [Postman](https://www.postman.com/downloads) are popular choices for testing your routes. Alernatively, the (Thunder Client)[https://marketplace.visualstudio.com/items?itemName=rangav.vscode-thunder-client] VS Code extension is another way of testing your API. 
+- As mentioned earlier, the cli-tool `curl` and [Postman](https://www.postman.com/downloads) are popular choices for testing your routes. Alernatively, the [Thunder Client](https://marketplace.visualstudio.com/items?itemName=rangav.vscode-thunder-client) VS Code extension is another way of testing your API. 
 


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

The ol' `()[]` instead of `[]()`! This made me curious, so I did a grep of the repo and I'm pretty sure this is the only link on the site that was misformatted like this. 😊

Please let me know if I've made any mistakes in how I've submitted this, this is my first GitHub contribution.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

N/A
