### PR TITLE
remove double 'that'

### DIFF
--- a/rails_programming/mailers_advanced_topics/websockets_and_actioncable.md
+++ b/rails_programming/mailers_advanced_topics/websockets_and_actioncable.md
@@ -274,7 +274,7 @@ consumer.subscriptions.create("RoomChannel", {
 
 Note it imports our consumer from the consumer.js file we discussed earlier. Then it calls `subscriptions.create` on the consumer. We don't need to really dive into how this works under the hood but we just need to understand a couple of key points.
 
-The first is that that the first argument is given as a string. This would try to connect to the `RoomChannel` channel on the server. It doesn't have to be a string though. Remember those parameters we discussed earlier, this is where you can pass them. Instead of a string you can instead pass an object. The first key-value pair must be in the format `channel: 'ChannelName'`, and then afterwards you can pass in any number of key-value pairs which becomes the parameters sent to the server to establish a connection. Let's say we want to send the id of a room to our RoomChannel. We could write that first line as follows
+The first is that the first argument is given as a string. This would try to connect to the `RoomChannel` channel on the server. It doesn't have to be a string though. Remember those parameters we discussed earlier, this is where you can pass them. Instead of a string you can instead pass an object. The first key-value pair must be in the format `channel: 'ChannelName'`, and then afterwards you can pass in any number of key-value pairs which becomes the parameters sent to the server to establish a connection. Let's say we want to send the id of a room to our RoomChannel. We could write that first line as follows
 
 ~~~javascript
 consumer.subscriptions.create({channel: 'RoomChannel', room: 1}, {


### PR DESCRIPTION
change "that that" to "that"

<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

Changed "that that" to "that"

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
