### PR TITLE
fixed typo in puts 'EventManager initialized!'

### DIFF
--- a/ruby_programming/files_and_serialization/project_event_manager.md
+++ b/ruby_programming/files_and_serialization/project_event_manager.md
@@ -52,7 +52,7 @@ underscore (often called *snake_case*).
 Open `lib/event_manager.rb` in your text editor and add the line:
 
 ~~~ruby
-puts 'EventManager Initialized!'
+puts 'Event Manager Initialized!'
 ~~~
 
 Validate that ruby is installed correctly and you have created the file correctly by running it from the root of your `event_manager` directory:


### PR DESCRIPTION
This is to match the following output in bash, after:
$ ruby /lib/event_manager.rb

<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

When writing the first line in /lib/event_manager.rb there's a typo. My proposed change:

puts 'EventManager Initialized! -> puts 'Event Manager Initialized!'

This fits with the following output displayed in bash when ruby /lib/event_manager.rb

```
$ ruby lib/event_manager.rb
Event Manager Initialized!
```
