### PR TITLE
Typo Error

### DIFF
--- a/foundations/html_css/html-foundations/links-and-images.md
+++ b/foundations/html_css/html-foundations/links-and-images.md
@@ -57,7 +57,7 @@ Generally, there are two kinds of links we will create:
 
 #### Absolute Links
 
-Links to pages op other websites on the internet are called absolute links. A typical absolute link will be made up of the following parts: `protocol://domain/path`. An absolute link will always contain the protocol and domain of the destination.
+Links to pages on other websites on the internet are called absolute links. A typical absolute link will be made up of the following parts: `protocol://domain/path`. An absolute link will always contain the protocol and domain of the destination.
 
 We've already seen an absolute link in action. The link we created to The Odin Projects about page earlier was an absolute link as it contains the protocol and domain.
 


### PR DESCRIPTION
I fixed a typo. in the absolute links section, it says "Links to pages op other websites on the..." op is not a word. I changed it too "on" other websites

<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

typo fix. i changed "op" to "on"

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
