### PR TITLE
Fix find pattern code in last example

### DIFF
--- a/ruby_programming/advanced_ruby/pattern_matching.md
+++ b/ruby_programming/advanced_ruby/pattern_matching.md
@@ -630,7 +630,7 @@ age = 32
 job_title = 'leet coder'
 
 case data
-in [*, { name: ^name, age: ^age, first_language: first_language, job_title: ^job_title }]
+in [*, { name: ^name, age: ^age, first_language: first_language, job_title: ^job_title }, *]
 else
   first_language = nil
 end


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

Change line 6 of last example's code in Ruby's Pattern Lesson from 
```ruby
in [*, { name: ^name, age: ^age, first_language: first_language, job_title: ^job_title }]
```
into 
```
in [*, { name: ^name, age: ^age, first_language: first_language, job_title: ^job_title }, *]
```

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#22605
