### PR TITLE
Fix a capitalization error

### DIFF
--- a/foundations/html_css/html-foundations/html-boilerplate.md
+++ b/foundations/html_css/html-foundations/html-boilerplate.md
@@ -103,7 +103,7 @@ To complete the boilerplate, add a body element to the `index.html` file. The bo
 
 ### Viewing HTML Files in the Browser
 
-The HTML boilerplate in the `index.html` file is complete at this point, but how do you view it in the browser?  there are a couple of different options:
+The HTML boilerplate in the `index.html` file is complete at this point, but how do you view it in the browser?  There are a couple of different options:
 
 1. You can drag and drop an HTML file from your text editor into the address bar of your favorite browser.
 2. You can find the HTML file in your file system and then double click it. This will open up the file in the default browser your system uses.


### PR DESCRIPTION
Lesson Foundations -> HTML Boilerplate. Under heading "Viewing HTML Files in the Browser".

<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [ ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

Fix a simple capitalization error in lesson "HTML Boilerplate" under heading "Viewing HTML Files in the Browser"

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
