### PR TITLE
fix typo in "working with text"

### DIFF
--- a/foundations/html_css/html-foundations/working-with-text.md
+++ b/foundations/html_css/html-foundations/working-with-text.md
@@ -147,7 +147,7 @@ The parent, child, and sibling relationships between elements will become much m
 
 HTML comments are not visible to the browser, they allow us to *comment* on our code so that other developers or our future selves can read them and get some context about something that might not be clear in the code.
 
-Writing a HTML comment is simple, we just put `<!-—` and `-->` at either end of the comment, for example:
+Writing an HTML comment is simple, we just put `<!--` and `-->` at either end of the comment, for example:
 
 <p class="codepen" data-height="300" data-theme-id="dark" data-default-tab="html,result" data-slug-hash="abwoyBg" data-user="TheOdinProjectExamples" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;">
   <span>See the Pen <a href="https://codepen.io/TheOdinProjectExamples/pen/abwoyBg">


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

The html comment syntax explanation used an em dash instead of a hyphen, causing issues when copy-pasting, as well as an incorrect indefinite article.

Edit: Turns out the a/an thing is mostly up to pronunciation, but an seems to be more popular.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
