### PR TITLE
Added needed hyphen to fix typo.

### DIFF
--- a/foundations/html_css/html-foundations/html-boilerplate.md
+++ b/foundations/html_css/html-foundations/html-boilerplate.md
@@ -129,7 +129,7 @@ Back in the `index.html` file lets add a heading (more on these later) to the bo
 Now if you refresh the page in the browser, you should see the changes take effect, and a heading  "Hello World!" will be displayed.
 
 ### VSCode Shortcut
-VSCode has a built in shortcut you can use for generating all the boilerplate in one go. To trigger the shortcut, delete everything in the `index.html` file and just enter `!` on the first line. This will bring up a couple of options. Press the enter key to choose the first one, and voila, you should have all the boilerplate populated for you.
+VSCode has a built-in shortcut you can use for generating all the boilerplate in one go. To trigger the shortcut, delete everything in the `index.html` file and just enter `!` on the first line. This will bring up a couple of options. Press the enter key to choose the first one, and voila, you should have all the boilerplate populated for you.
 
 But it's still good to know how to write the boilerplate yourself in case you find yourself using a text editor like notepad (heaven forbid) which doesn't have this shortcut. Try not to use the shortcut in your first few HTML projects to build some muscle memory with how to write the boilerplate code.
 


### PR DESCRIPTION
Built-in is a compound adjective needing a hyphen.

 - [X] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

Added a hyphen to fix the typo of "built in" to "built-in"

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
