### PR TITLE
Fix capitalization and punctuation

### DIFF
--- a/foundations/html_css/flexbox/flexbox-growing-and-shrinking.md
+++ b/foundations/html_css/flexbox/flexbox-growing-and-shrinking.md
@@ -51,7 +51,7 @@ An important implication to notice here is that when you specify `flex-grow` or 
 
 `flex-basis` simply sets the initial size of a flex-item, so any sort of `flex-grow`ing or `flex-shrink`ing starts from that baseline size. The shorthand value defaults to `flex-basis: 0%`. The reason we had to change it to `auto` in the `flex-shrink` example is that with the basis set to `0`, those items would ignore the item's width, and everything would shrink evenly. Using `auto` as a flex-basis tells the item to check for a width declaration (`width: 250px`).
 
-> #### important note about flex-basis
+> #### Important note about flex-basis:
 > There is a difference between the default value of `flex-basis` and the way the `flex` shorthand defines it if no `flex-basis` is given. The actual default value for `flex-basis` is `auto`, but when you specify `flex: 1` on an element, it interprets that as `flex: 1 1 0`. If you want to _only_ adjust an item's `flex-grow` you can simply do so directly, without the shorthand, or you can be more verbose and use the full 3 value shorthand `flex: 1 1 auto`
 
 ### In practice...


### PR DESCRIPTION
Fix capitalization and punctuation of subject of block quotes under flex-basis heading.
Lesson: "Foundations" => "Flexbox" => "Growing and Shrinking"

<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [ ✔️ ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).

#### 1.Describe the changes made:

Fixed capitalization and punctuation

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
