### PR TITLE
Fix grammar mistake

### DIFF
--- a/foundations/html_css/html-foundations/elements-and-tags.md
+++ b/foundations/html_css/html-foundations/elements-and-tags.md
@@ -40,5 +40,5 @@ This section contains helpful links to other content.  It isn't required, so con
 
 ### Knowledge Check
 
-- What is a HTML tag?
-- What are the three parts of a HTML element?
+- What is an HTML tag?
+- What are the three parts of an HTML element?


### PR DESCRIPTION
`a html` in the knowledge check section changed to `an html` in lesson `elements and tags - foundations`.

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".

