### PR TITLE
Removed duplicate instruction to read the nodejs.dev Quick Start section in NodeJS Getting Started lesson

### DIFF
--- a/nodeJS/getting-started/Getting-Started.md
+++ b/nodeJS/getting-started/Getting-Started.md
@@ -18,8 +18,6 @@ By the end of this lesson, you should be able to do the following:
 <div class="lesson-content__panel" markdown="1">
 
 - Let's dive in and start looking at Node server-side code! We will be hopping around lessons in the [NodeJS.dev](https://nodejs.dev/learn) docs which you should follow along.
-  - Introduction
-    - Read the entire Quick Start section from [Introduction of Node.js](https://nodejs.dev/learn/introduction-to-nodejs) to [Differences between Node.js and the Browser](https://nodejs.dev/learn/differences-between-nodejs-and-the-browser). 
   - Get Started
     - Learn how to run Node.js scripts from the terminal in [this](https://nodejs.dev/learn/run-nodejs-scripts-from-the-command-line) lesson.
     - Learn quickly about .env files and how we use them [here](https://nodejs.dev/learn/how-to-read-environment-variables-from-nodejs)! This will become very important in the future when working with databases and other sensitive credentials!


### PR DESCRIPTION
 

- [YES ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [ YES] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:

The first two lessons in the NodeJS path both instruct the reader to visit nodejs.dev and read the Quick Start guide. As this is covered in the first lesson, it is not relevant to also include it in the second lesson.

Relevant lessons:

1. https://www.theodinproject.com/paths/full-stack-javascript/courses/nodejs/lessons/introduction-what-is-nodejs
2. https://www.theodinproject.com/paths/full-stack-javascript/courses/nodejs/lessons/getting-started

First raised on discord here: https://discord.com/channels/505093832157691914/540903304046182425/891998093434843156

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

N/A
