### PR TITLE
add link to Introduction lesson of Node.js course to Node Event Loop video

### DIFF
--- a/nodeJS/getting-started/Introduction.md
+++ b/nodeJS/getting-started/Introduction.md
@@ -68,8 +68,9 @@ While you may have learned React (or any other frontend framework) before, eithe
 
 1. [This short module](https://developer.mozilla.org/en-US/docs/Learn/Server-side/First_steps) on "The Server Side" from MDN is a great source for the background knowledge you need. Read through at least the first two articles posted under the 'Guides' section: Introduction to the server side and Client-Server Overview. The other two are interesting and worth reviewing, but less relevant to our immediate concerns.
 2. To gain a little more insight into the nature of Node, and to unpack the rest of the above definition, read [this article](https://medium.freecodecamp.org/what-exactly-is-node-js-ae36e97449f5). There's a long, but *really* fantastic video linked in that article, don't skip it!
-3. Take few minutes to go through the "Quick Start" section of the new official [Node.js website](https://nodejs.dev/learn).
-4. [This short video](https://www.youtube.com/watch?v=uVwtVBpw7RQ) is a great introduction as well!
+3.  What is the Node Event Loop?  Check out this long, but *really* [fantastic video](https://www.youtube.com/watch?v=8aGhZQkoFbQ)... don't skip it!
+4. Take few minutes to go through the "Quick Start" section of the new official [Node.js website](https://nodejs.dev/learn).
+5. [This short video](https://www.youtube.com/watch?v=uVwtVBpw7RQ) is a great introduction as well!
 
 </div>
 

--- a/nodeJS/getting-started/Introduction.md
+++ b/nodeJS/getting-started/Introduction.md
@@ -67,8 +67,8 @@ While you may have learned React (or any other frontend framework) before, eithe
 <div class="lesson-content__panel" markdown="1">
 
 1. [This short module](https://developer.mozilla.org/en-US/docs/Learn/Server-side/First_steps) on "The Server Side" from MDN is a great source for the background knowledge you need. Read through at least the first two articles posted under the 'Guides' section: Introduction to the server side and Client-Server Overview. The other two are interesting and worth reviewing, but less relevant to our immediate concerns.
-2. To gain a little more insight into the nature of Node, and to unpack the rest of the above definition, read [this article](https://medium.freecodecamp.org/what-exactly-is-node-js-ae36e97449f5). There's a long, but *really* fantastic video linked in that article, don't skip it!
-3.  What is the Node Event Loop?  Check out this long, but *really* [fantastic video](https://www.youtube.com/watch?v=8aGhZQkoFbQ)... don't skip it!
+2. To gain a little more insight into the nature of Node, and to unpack the rest of the above definition, read [this article](https://medium.freecodecamp.org/what-exactly-is-node-js-ae36e97449f5).
+3. What is the Node Event Loop? Check out this long, but *really* [fantastic video](https://www.youtube.com/watch?v=8aGhZQkoFbQ)... don't skip it!
 4. Take few minutes to go through the "Quick Start" section of the new official [Node.js website](https://nodejs.dev/learn).
 5. [This short video](https://www.youtube.com/watch?v=uVwtVBpw7RQ) is a great introduction as well!
 


### PR DESCRIPTION
add link to Introduction.md for Node Event Loop video which is no longer linked to in FreeCodeCamp article

<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:

-  add link to Introduction lesson of Node.js course to Node Event Loop video
- The FreeCodeCamp [article](https://www.freecodecamp.org/news/what-exactly-is-node-js-ae36e97449f5/)  apparently used to link to this video, which was part of the "Assignment" materials in the Introduction lesson, but it no longer seems to have the link.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
