### PR TITLE
swap order of links to NodeJS event docs in NodeJS Getting Started

### DIFF
--- a/nodeJS/getting-started/Getting-Started.md
+++ b/nodeJS/getting-started/Getting-Started.md
@@ -36,7 +36,6 @@ By the end of this lesson, you should be able to do the following:
     - Follow along the [Event Emitter](https://nodejs.dev/learn/the-nodejs-event-emitter) section.
     - Look into [this](https://nodejs.dev/learn/the-nodejs-events-module) section to see the `events` module.
     
-
 - Optional Extra Credit!
   - Although a bit outdated, the W3 Schools introduction to Node.js is super useful!  Go to the [W3 Schools node tutorial](https://www.w3schools.com/nodejs/default.asp) and code along with the following lessons (which should be listed on the sidebar of their site). Specifically, work from the **Node.js Intro** through to **Node.js Events**. You can look at the **File Uploads** and **Email** sections if you're feeling particularly ambitious! **NOTE**: The URL module is very outdated. Refer to the earlier link if you run into issues in the Node.js URL Module from W3.
 

--- a/nodeJS/getting-started/Getting-Started.md
+++ b/nodeJS/getting-started/Getting-Started.md
@@ -33,8 +33,9 @@ By the end of this lesson, you should be able to do the following:
     - Let's get an [introduction](https://nodejs.dev/learn/an-introduction-to-the-npm-package-manager) to NPM.
     - After that, it's time to quickly get introduced to the [package.json file](https://nodejs.dev/learn/the-package-json-guide).
   - Events
-    - Start with [this](https://nodejs.dev/learn/the-nodejs-events-module) section to see the `events` module.
     - Follow along the [Event Emitter](https://nodejs.dev/learn/the-nodejs-event-emitter) section.
+    - Look into [this](https://nodejs.dev/learn/the-nodejs-events-module) section to see the `events` module.
+    
 
 - Optional Extra Credit!
   - Although a bit outdated, the W3 Schools introduction to Node.js is super useful!  Go to the [W3 Schools node tutorial](https://www.w3schools.com/nodejs/default.asp) and code along with the following lessons (which should be listed on the sidebar of their site). Specifically, work from the **Node.js Intro** through to **Node.js Events**. You can look at the **File Uploads** and **Email** sections if you're feeling particularly ambitious! **NOTE**: The URL module is very outdated. Refer to the earlier link if you run into issues in the Node.js URL Module from W3.


### PR DESCRIPTION


<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:
The order of these two links as they previously were was more confusing.  The Event Emitter article clarifies to the newbie some of the things that are detailed in the events module page, and the event emitter article itself links to the events module page at the bottom of the article.

I tried reading the events module page first and was confused.  Reading the event emitter article greatly elucidated the events module page.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
