### PR TITLE
Add devdocs source to intro-to-html-css

### DIFF
--- a/foundations/html_css/intro-to-html-css.md
+++ b/foundations/html_css/intro-to-html-css.md
@@ -18,6 +18,7 @@ If you want to get technical, HTML and CSS aren't _programming languages_ becaus
 This section contains helpful links to other content.  It isn't required, so consider it supplemental or if you need to dive deeper into something.
 
 * [This FreeCodeCamp article](https://www.freecodecamp.org/news/html-css-and-javascript-explained-for-beginners/) goes into a little more depth than the assigned one. It covers things we'll be teaching explicitly in later lessons though, so don't worry about memorizing any of the details.
+* Bookmark [DevDocs.io](https://devdocs.io). Read the “Welcome” message. Massive API documentation collection that even works offline. Essential collection of reference material for everything covered and more. (Maintained by [FreeCodeCamp](https://freecodecamp.org))
 
 ### Knowledge Check
 * What do HTML and CSS stand for?


### PR DESCRIPTION
`DevDocs` was previously mentioned in the old `intro to front-end` lesson which is a great reference material. So here it is added to the additional resources of the new lesson `into-to-html-css`.

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
