### PR TITLE
Updates a concept under the Anchor Elements subsection in the Links and Images lesson in HTML Foundations

### DIFF
--- a/foundations/html_css/html-foundations/links-and-images.md
+++ b/foundations/html_css/html-foundations/links-and-images.md
@@ -44,7 +44,7 @@ Add the following href attribute to the anchor element we created previously and
 <a href="https://www.theodinproject.com/about">click me</a>
 ~~~
 
-By default, the browser will give any text wrapped in an anchor tag a blue color and underline it to signify it is a link.
+By default, any text wrapped with just the anchor tag (an anchor tag without any attributes) will look like plain text. If the text is wrapped in an anchor tag with the href attribute, the browser will give the text a blue color and underline it to signify it is a link.
 
 It's worth noting you can use anchor tags link to any kind of resource on the internet, not just other HTML documents. You can link to videos, pdf files, images, and so on, but for the most part, you will be linking to other HTML documents.
 


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [ Yes ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [ Yes ] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:

...  It may be known to a lot of people that wrapping a text with just the anchor tag without any attributes may give us back the plain text on the browser, but when I had read the section for the first time, it had made me a bit confused. By default, it should only give plain text. I had later tried this concept out by giving an empty href attribute with the anchor tag, which then gives us the blue color and the underline to signify it's a link.  I just wanted to give a little more clarity over here since even Kevin Powell's HTML Links video at 1:35 mentions this thing.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
