### PR TITLE
Change link destination from #CORS to #cors in Knowledge Check of Working with APIs

### DIFF
--- a/javascript/async-apis/APIs.md
+++ b/javascript/async-apis/APIs.md
@@ -229,4 +229,4 @@ While we are pushing this API key to the frontend, this isn't something you shou
  - <a class="knowledge-check-link" href="#apis">What is an API?</a>
  - <a class="knowledge-check-link" href="#apis">How is access to an API restricted?</a>
  - <a class="knowledge-check-link" href="#fetching-data">How do you fetch and extract data from an API?</a>
- - <a class="knowledge-check-link" href="#CORS">Why might your API request be blocked by the browser, and how might you fix this?</a>
+ - <a class="knowledge-check-link" href="#cors">Why might your API request be blocked by the browser, and how might you fix this?</a>


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:
In the Knowledge Check of Working with APIs in the JS course, the anchor of the question "Why might your API request be blocked by the browser, and how might you fix this?" would link to an element with the id of "#CORS". However, the title of the CORS section has the ID of "#cors", thus after clicking on the question, the reader was just re-directed to the top of the page. I changed the anchor href to "#cors" so that the user gets directed to the correct section of the page.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
