### PR TITLE
Fixed Pseudo Code Header on line 44

### DIFF
--- a/foundations/javascript_basics/problem_solving.md
+++ b/foundations/javascript_basics/problem_solving.md
@@ -41,7 +41,7 @@ Some of the questions you should answer at this stage of the process:
 
 The last question is where you will write out an algorithm to solve the problem. <span id="algorithm">You can think of an algorithm as a recipe for solving a particular problem. It defines the steps that need to be taken by the computer to solve a problem in pseudo code.</span>
 </span>
-#### Pseudo Code
+### Pseudo Code
 <span id="pseudo">Pseudo code is writing out the logic for your program in natural language instead of code. It helps you slow down and think through the steps your program will have to go through to solve the problem.</span>
 
 Here's an example of what the pseudo code for a simple program that prints all numbers up to an inputted number might look like:


### PR DESCRIPTION
Fixed pseudo code header not displaying correctly because of an extra # on line 44

<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:

The Foundations section of Problem Solving contains subheaders such as Introduction, Learning Outcomes, etc but the sub-section header for "Pseudo code" is not displaying as a header like the rest of the sub-section headers. Please see screenshot to see how it displays -->
![fix pseudo code header](https://user-images.githubusercontent.com/85803523/135854496-39ae7e16-5e42-4509-b7e2-69484420e2c5.png)


#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number below:

#XXXXX
