### PR TITLE
added explanation for difference with FCC video when using create-react-app

### DIFF
--- a/javascript/react-js/lifecycle-methods.md
+++ b/javascript/react-js/lifecycle-methods.md
@@ -57,7 +57,7 @@ A few examples are:
 <div class="lesson-content__panel" markdown="1">
 1. Read [this article](https://programmingwithmosh.com/javascript/react-lifecycle-methods/) for a great overview of lifecycle methods in React.
 2. The React documentation is always a good source as it's well structured. In [this article](https://reactjs.org/docs/react-component.html) you can read more about lifecycle methods from the people who made it!
-3. Code along with [this video](https://www.youtube.com/watch?v=m_mtV4YaI8c), it gives you a practical examples about how those methods work and when React calls them.*
+3. Code along with [this video](https://www.youtube.com/watch?v=m_mtV4YaI8c), it gives you a practical example about how those methods work and when React calls them.*
 
 *If you coded along with the last video, and you used `create-react-app` to setup your environment, you may have noticed that the last lifecycle method talked about, `componentDidCatch`, does not function the same way for you as in the video. You can read about it [here](https://stackoverflow.com/a/48354840).
 </div>


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [X] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [X] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:

I added a link to an explanation as to why part of the code-along video doesn't work the same way if using create-react-app, specifically the componentDidCatch part. I was not sure if I should have it as a 4th step (instead of an asterisk) or if it is even necessary, but it's always useful to point to differences between videos and how the students will experience it.

I have another PR (#22827) for the same lesson, but since they were not for the same part/reason I though I should make a 2nd PR, but if you want me to I make a single one with both the changes.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number (and any [relevant keywords](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)) below:

#XXXXX
