### PR TITLE
Fixes npm init command in Project: Restaurant Page

### DIFF
--- a/javascript/organizing-js/restaurant-project.md
+++ b/javascript/organizing-js/restaurant-project.md
@@ -8,7 +8,7 @@ Let's use what we've learned and take a chance to continue practicing DOM manipu
 <div class="lesson-content__panel" markdown="1">
 
 1. Start the project the same way you began the webpack tutorial project.
-    1. run `npm init` in your project directory to generate a `package.json` file.
+    1. run `npm init -y` in your project directory to generate a `package.json` file.
     
     1. run `npm install webpack webpack-cli --save-dev` to install webpack to the node_modules directory of your project.
    


### PR DESCRIPTION

<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:

Updated 'npm init' command to 'npm init -y' (which is the same as used in the webpack tutorial), to instantly initialize the project because 'npm init' command prompts the user to input a few parameters which can be overwhelming for beginners.


#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number (and any [relevant keywords](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)) below:

#XXXXX
