### PR TITLE
Add blocks instruction back to BST Project

### DIFF
--- a/ruby_programming/computer_science/project_binary_search_trees.md
+++ b/ruby_programming/computer_science/project_binary_search_trees.md
@@ -21,7 +21,7 @@ You'll build a balanced BST in this assignment. Do not use duplicate values beca
 
 6. Write a `#level_order` method which accepts a block. This method should traverse the tree in breadth-first level order and yield each node to the provided block. This method can be implemented using either iteration or recursion (try implementing both!). The method should return an array of values if no block is given. **Tip:** You will want to use an array acting as a queue to keep track of all the child nodes that you have yet to traverse and to add new ones to the list (as you saw in the [video](https://www.youtube.com/watch?v=86g8jAQug04)).
 
-7. Write `#inorder`, `#preorder`, and `#postorder` methods that accepts a black. Each method should traverse the tree in their respective depth-first order and yield each node to the provided block. The methods should return an array of values if no block is given.
+7. Write `#inorder`, `#preorder`, and `#postorder` methods that accepts a block. Each method should traverse the tree in their respective depth-first order and yield each node to the provided block. The methods should return an array of values if no block is given.
 
 8. Write a `#height` method which accepts a node and returns its height. Height is defined as the number of edges in longest path from a given node to a leaf node.
 


### PR DESCRIPTION
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:

The BST Project used to have instructions about using blocks that was removed in this [PR](https://github.com/TheOdinProject/curriculum/pull/18256) because at the time blocks were removed from the curriculum (when Ruby Basics were re-written before the Advanced section was written). I forgot about adding them back after the new blocks lesson was added. I expanded the use of blocks to all transversal methods.

I realized this when I was looking at the instructions for `#rebalance`, because it often comes up why we suggest using the level-order to re-build the BST. I decided to change this to use any transversal method, because they should be accounting for an unordered array in `#build_tree`.
