### PR TITLE
Issue-22802 Add Learning Outcomes, Knowledge Checks and Knowledge Checks Links in React JS Advanced Concepts

### DIFF
--- a/javascript/react-js/advanced-concepts.md
+++ b/javascript/react-js/advanced-concepts.md
@@ -13,14 +13,14 @@ Good Luck!
 
 ### Learning Outcomes
 
-By the end of this lesson, you should known:
+By the end of this lesson, you should be able to do the following:
 
-* PropTypes.
-* Styled Components.
-* Redux and state management systems.
-* High-order Components.
-* Routers in web pages.
-* Your own React Hooks.
+* Explain PropTypes.
+* Explain Styled Components.
+* Explain Redux and state management systems.
+* Explain higher-order Components.
+* Explain Routers in web pages.
+* Explain how to make your own React Hooks.
 
 ### Guide to Advanced React
 


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [X] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [X] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:

There were missing the Learning Outcomes, Knowledge Checks and Knowledge Checks Links in React JS Advanced Concepts

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number (and any [relevant keywords](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)) below:

resolves #22802 
