### PR TITLE
Fixes typo in bash example under 'Installing RSpec' heading in Introduction to RSpec lesson

### DIFF
--- a/ruby_programming/testing_with_rspec/introduction_to_rspec.md
+++ b/ruby_programming/testing_with_rspec/introduction_to_rspec.md
@@ -36,7 +36,7 @@ project
   |__spec
   |   |__spec_helper.rb
   |
-  |__.spec
+  |__.rspec
 ~~~
 
 That's it. Within two steps, you're up and running with RSpec. That wasn't so hard, was it?


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [X] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [X] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:

The current bash example under the 'Installing RSpec' heading showed that a .spec file is created when rspec is initialized instead of an .rspec file. I changed ".spec" to ".rspec".

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number (and any [relevant keywords](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)) below:

N/A
