### PR TITLE
Clarify wording in Rail's flight booker project

### DIFF
--- a/rails_programming/advanced_forms_and_activerecord/project_forms_advanced.md
+++ b/rails_programming/advanced_forms_and_activerecord/project_forms_advanced.md
@@ -5,7 +5,7 @@ In this project, you'll get a chance to tackle some more advanced forms.  This i
 A typical airline booking flow:
 
 1. Enter desired dates / airports and click "Search"
-2. Choose from among a list of eligible flights
+2. Choose from among a list of available flights
 3. Enter passenger information for all passengers
 4. Enter billing information
 
@@ -26,23 +26,21 @@ This project will require you to seed your database, so use your `db/seeds.rb` f
 
 #### Screen 1: Search
 
-For the first screen, you'll need a dropdown that lists a possible "From" airport and a possible "To" airport. Just assume all flights fly between SFO and NYC.  You'll need to set up a dropdown menu that contains all eligible flights.
+For the first screen, you will be creating 4 dropdown menus that will allow users to search for available flights -  departure airport, arrival airport, date, and number of passengers. This requires relatively vanilla forms that happen to be prepopulated with collections of data.  Working with dates will cover a bit of new ground for you.
 
-This requires relatively vanilla forms that happen to be prepopulated with collections of data.  Working with dates will cover a bit of new ground for you.
-
-1. Create an Airport model (which basically just needs an airport code like "SFO" or "NYC") and use the `db/seeds.rb` file to create several of them.
-2. Create a Flight model (with the start and finish airport `id`s, start datetime and flight duration).
-3. Set up associations so you can ask `Flight.first.from_airport`, `Flight.first.to_airport` and get back Airport objects.  Same for `Airport.first.departing_flights` and `Airport.first.arriving_flights`, which should return a list of Flight objects.
+1. Create an Airport model (which basically just needs an airport code like "SFO" or "NYC") and use the `db/seeds.rb` file to create several airports.
+2. Create a Flight model (with the departure and arrival airport `id`s, start datetime and flight duration).
+3. Set up associations so you can ask `Flight.first.departure_airport`, `Flight.first.arrival_airport` and get back Airport objects. Same for `Airport.first.departing_flights` and `Airport.first.arriving_flights`, which should return a list of Flight objects.
 4. Seed your database with flights.
 5. You will search and view results in the same page.  Set up your FlightsController and routes to make the Index page (`/flights`) the root route.
 6. Create your search form on the `/flights` index page to submit using a GET (not POST) request back to the same URL.
-7. The home page should contain four dropdown menus -- a list of FROM and TO airports, number of passengers (1-4) and a DATE dropdown for the flight date.  The DATE dropdown should only include dates that have existing flights.  Don't worry about restricting the contents of the FROM/TO dropdowns -- you'd normally use JavaScript -- so just allow the user to select any airport.  See [this SO post on formatting date in dropdown lists](http://stackoverflow.com/questions/15720940/rails-format-date-in-drop-down-list-in-view), [this quickie SO post on selecting months/years](http://stackoverflow.com/questions/13001904/rails-drop-down-select-month-year) and the Rails [DateHelper API Docs](http://api.rubyonrails.org/classes/ActionView/Helpers/DateHelper.html) for some help with creating Date selects.
+7. Add the four dropdown menus -- a list of departure airports, arrival airports, number of passengers (1-4), and a date dropdown for the flight date. The date dropdown should only include dates that have existing flights. Don't worry about restricting the contents of the airport dropdowns -- you'd normally use JavaScript -- so just allow the user to select any airport. See [this SO post on formatting date in dropdown lists](http://stackoverflow.com/questions/15720940/rails-format-date-in-drop-down-list-in-view), [this quickie SO post on selecting months/years](http://stackoverflow.com/questions/13001904/rails-drop-down-select-month-year) and the Rails [DateHelper API Docs](http://api.rubyonrails.org/classes/ActionView/Helpers/DateHelper.html) for some help with creating Date selects.
 
 #### Screen 2: Pick a Flight
 
-Once search results are returned, the user just needs to choose from among the eligible flights.
+Once search results are returned, the user just needs to choose from among the available flights.
 
-1. Once the user has submitted the form, your controller should detect the additional query parameters (e.g. from `/flights?from_code=SFO&to_code=NYC&date=20131215&num_tickets=2`) and should pull the flights which match that criteria from your database through smart querying model methods.
+1. Once the user has submitted the form, your controller should detect the additional query parameters (e.g. from `/flights?departure_code=SFO&arrival_code=NYC&date=20131215&num_tickets=2`) and should pull the flights which match that criteria from your database through smart querying model methods.
 2. Send those flights back to your `app/views/flights/index.html.erb` view.  Make it so that the view will display the results below (if present).
 3. Don't get rid of the search dropdowns -- keep the search form active at the top so the user can try running a new search.
 4. The search results will need to be in their own form -- this time for selecting which of the flights the user would like to choose.  Each returned flight should render with a radio button next to it.  The user will select which flight to submit and move onto the next step.  The form should submit to the `#new` action of the BookingsController you're about to create using another GET method.  You'll need to include a hidden field that contains the number of passengers.


### PR DESCRIPTION
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:

People found some of the wording confusing in this project & was discussed on Discord.
* Change to/from airports to departure/arrival
* Clarify wording around the dropdown menus on first screen
* Remove wording 'assume all flights fly between SFO and NYC'


#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number (and any [relevant keywords](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)) below:

#XXXXX
