### PR TITLE
Remove handlebars from Express-Lesson-1.md

### DIFF
--- a/nodeJS/express-basics/Express-Lesson-1.md
+++ b/nodeJS/express-basics/Express-Lesson-1.md
@@ -11,9 +11,9 @@ By the end of this lesson, you should be able to do the following:
 
 ### Templating Engines
 
-A templating engine is a tool that allows you to insert variables and simple logic into your views. For instance, you could have a header that updates with the actual user's name once they've logged in, something that is not possible with plain HTML. As the lesson mentions, there are several templating languages available for JavaScript.  The tutorial uses Pug (formerly known as Jade) which has a bit of a learning curve because it looks and feels dramatically different from regular HTML. If you've ever worked with Ruby on Rails you might be more comfortable with `ejs`, which is _very_ similar to `erb` or `hbs` (handlebars), which also looks and feels a lot like HTML, and inserts the dynamic bits inside of double curly brackets. 
+A templating engine is a tool that allows you to insert variables and simple logic into your views. For instance, you could have a header that updates with the actual user's name once they've logged in, something that is not possible with plain HTML. As the lesson mentions, there are several templating languages available for JavaScript.  The tutorial uses Pug (formerly known as Jade) which has a bit of a learning curve because it looks and feels dramatically different from regular HTML. If you've ever worked with Ruby on Rails you might be more comfortable with [ejs](https://ejs.co), which is _very_ similar to `erb`.
 
-It's up to you which you choose! If you choose not to use Pug you will still be able to follow the tutorial just fine. Most of the Odin staff prefer ejs or handlebars to Pug simply because we like working with HTML, but in the end, there is nothing wrong with Pug if you like the look of it or want to learn something new.
+It's up to you which you choose! If you choose not to use Pug you will still be able to follow the tutorial just fine. Most of the Odin staff prefer ejs to Pug simply because we like working with HTML, but in the end, there is nothing wrong with Pug if you like the look of it or want to learn something new.
 
 ### Middleware
 


### PR DESCRIPTION
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:

Please note this is my first time ever contributing to an open-source project, so apologies in advance if I haven't proposed this correctly! Below I have copied my feedback which I previously posted on the TOP 'contributions-suggestions-bugs-discussions'  discord channel. One of the core admins (BriggsE) suggested I make the pull request.

The lesson notes included a mention that students should consider using handlebars or EJS rather than the pug (previously Jade) template framework while completing the MDN tutorial. I followed this advice, and used handlebars.

I really wish I hadn't, as relying on handlebars has opened multiple cans of worms and detracted from focusing on the core parts of the lesson (i.e learning how to use express). For one thing, handlebars has made a major change to fix a security vulnerability (read more here: http://mahmoudsec.blogspot.com/2019/04/handlebars-template-injection-and-rce.html) which has in turn disrupted the flow of the MDN tutorial (which relies heavily on virtual properties on mongoose models, which handlebars no longer allows).

In addition to this, I have found that handlebars lacks basic key functionality / documentation. For example, something as simple as including an "else if" statement doesn't seem to be possible, while pug seems to make that easy. I also had to discover through trial and error how template extensions work with handlebars in express, as I couldn't find any documentation on this topic.

All in all I've wasted quite a bit of time dealing with handlebars and I think TOP could be majorly improved if more resources were provided to introduce the framework before attempting to use it in the MDN project. And given that security issue, it might be better if students just stayed away from it entirely. I ended up getting around that security block with this package, but the author made it clear in the notes that this is NOT a good solution and should not be used in the "real world". (read more: https://www.npmjs.com/package/@handlebars/allow-prototype-access).

CHANGES MADE:

- Removed references to handlebars in the Templating Engines section.
- Added a hyperlink to the first ejs mention to link directly to the ejs getting started page.
