### PR TITLE
Add `lang="en" to the <html> tags

### DIFF
--- a/foundations/html_css/html-foundations/html-boilerplate.md
+++ b/foundations/html_css/html-foundations/html-boilerplate.md
@@ -47,6 +47,20 @@ Back in the `index.html` lets add the `<html>` element by typing out its opening
 </html>
 ~~~
 
+### Lang Attribute
+
+We need to add a lang attribute to the `<html>` tag. So let's do it now.
+
+Back in the `index.html` let's add `lang="en"`(language is English) to the `<html>` tag.
+
+You can use other language codes for other languages [here](https://www.w3schools.com/tags/ref_language_codes.asp), too.
+
+~~~html
+<!DOCTYPE html>
+<html lang="en">
+</html>
+~~~
+
 ### Head Element
 
 The `<head>` element is where we put important meta-information **about** our webpages, and stuff required for our webpages to render correctly in the browser. Anything included within the head element will **not** be displayed to the user.
@@ -74,7 +88,7 @@ Back in our `index.html`, let's add a head element with a title and a charset me
 ~~~html
 <!DOCTYPE html>
 
-<html>
+<html lang="en">
   <head>
     <title>My First Webpage</title>
     <meta charset="UTF-8">
@@ -90,7 +104,7 @@ To complete the boilerplate, add a body element to the `index.html` file. The bo
 
 ~~~html
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>My First Webpage</title>
     <meta charset="UTF-8">
@@ -117,7 +131,7 @@ Back in the `index.html` file, lets add a heading (more on these later) to the b
 
 ~~~html
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>My First Webpage</title>
     <meta charset="UTF-8">


### PR DESCRIPTION
Add a lang attribute explanation to the html tag so the boilerplate code passes the W3C validator, as well as a link to the different language codes.

<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [done] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [done] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:

Adds the lang attribute to the html tag that is needed to pass W3C validation in the HTML boilerplate foundation lesson, and an explanation of it as well as a link to language codes for the lang tag.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number (and any [relevant keywords](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)) below:
