### PR TITLE
Update installation_overview to flag Chromebooks

### DIFF
--- a/foundations/installations/installation_overview.md
+++ b/foundations/installations/installation_overview.md
@@ -22,7 +22,7 @@ At the end of the next lesson, you'll be up and running with many of the tools y
 * Google, Google, Google.
 * Never be afraid to [ask for help](https://discord.gg/fbFCkYabZB)!
 
-For Chromebook users, your OS has choice effectively been made for you. However, if your device [supports](https://www.chromium.org/chromium-os/chrome-os-systems-supporting-linux) the Linux Beta, there are instructions in the next lesson on how to set this up on your device.
+For Chromebook users, your OS choice has effectively been made for you. However, if your device [supports](https://www.chromium.org/chromium-os/chrome-os-systems-supporting-linux) the Linux Beta, there are instructions in the next lesson on how to set this up on your device.
 
 ### OS Options
 


### PR DESCRIPTION
Added a few lines to call out that certain Chromebooks are supported as they can install Linux.

<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:

The installation overview doesn't explicitly mention that Chromebooks may support Linux, and some users may not be aware that their Chromebooks may actually be a supported device. The next lesson explicitly covers Chromebooks, but by the time a user gets there, they may have already reconsidered using their Chromebook.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number (and any [relevant keywords](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)) below:

Closes no issues.
