### PR TITLE
Fix typo in Git Basics lesson: screenshots -> snapshots

### DIFF
--- a/foundations/git_basics/git_basics.md
+++ b/foundations/git_basics/git_basics.md
@@ -64,7 +64,7 @@ By the end of this lesson, you should be able to do the following:
 
 4. <span id="git-commit"></span>Type `git commit -m "Add hello_world.txt"` and then type `git status` once more. The output should now say: "*nothing to commit, working tree clean*", indicating your changes have been committed. Don't worry if you get a message that says "*upstream is gone*", this is totally normal and only showing because your cloned repository currently has no branches. It will be resolved once you have followed the rest of the steps in this project.
 
-    "*Your branch is ahead of 'origin/main' by 1 commit*" this message just means that you now have newer screenshots than what is on your remote repository. You will be uploading your snapshots further down in this lesson.
+    "*Your branch is ahead of 'origin/main' by 1 commit*" this message just means that you now have newer snapshots than what is on your remote repository. You will be uploading your snapshots further down in this lesson.
 
     <a href="https://cdn.statically.io/gh/TheOdinProject/curriculum/b54d14c5dcee1c6fac61aee02fca7e9ef7ba1510/foundations/git_basics/project_practicing_git_basics/imgs/09.png"><img class="tutorial-img" src="https://cdn.statically.io/gh/TheOdinProject/curriculum/b54d14c5dcee1c6fac61aee02fca7e9ef7ba1510/foundations/git_basics/project_practicing_git_basics/imgs/09.png" title="Commit hello_world and check repo status again using CLI" /></a>
 


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:

In the _Foundations: Git Basics_ lesson, there was a minor typo in _Assignments -> Use the Git Workflow -> 4._ where "screenshots" was used instead of "snapshots" when referring to git snapshots. This has been fixed in this pull request. 

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number (and any [relevant keywords](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)) below:

n.a.
