### PR TITLE
Fixes typo in Rails Websockets and Actioncable Lesson

### DIFF
--- a/rails_programming/mailers_advanced_topics/websockets_and_actioncable.md
+++ b/rails_programming/mailers_advanced_topics/websockets_and_actioncable.md
@@ -148,7 +148,7 @@ You can see here it does try to create all files we would need and if any exist,
 
 ### Client-server interactions
 
-Let's take a closer look at the chat_channel.rb and chat_channel.js files that were created by the generator.
+Let's take a closer look at the room_channel.rb and room_channel.js files that were created by the generator.
 
 As mentioned earlier the generator will create a channel in the `app/channels` directory. In our example it was `room_channel.rb` which produces some boilerplate code
 
@@ -312,5 +312,3 @@ The connection only remains active while the http request remains unbroken. Refr
 ### Conclusion
 
 There is more to Action Cable but it's still quite a niche use case so it's not something you should seek to use on every app you build. Look to keep it simple and only introduce WebSockets when you see a real opportunity to add value to your site.
-
-


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [X] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [X] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:

In the first sentence of the _Client-server interactions_ section: 
  "Let’s take a closer look at the **chat_**channel.rb and **chat_**channel.js files..."

The screenshot just prior to this from the generate channel example has the files named **room_**channel.rb and **room_**channel.js. I've gone ahead and updated the text from 'chat_' to 'room_' to match the example.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number (and any [relevant keywords](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)) below:

#XXXXX
