### PR TITLE
Fix Ruby/Enumerable Methods each_with_index heading formatting

### DIFF
--- a/ruby_programming/basic_ruby/basic_enumerable_methods.md
+++ b/ruby_programming/basic_ruby/basic_enumerable_methods.md
@@ -132,7 +132,7 @@ friends.each { |friend| friend.upcase }
 
 You might expect this to return `['SHARON', 'LEO', 'LEILA', 'BRIAN', 'ARUN']`, but you'd be wrong---dead wrong. It actually returns the original array you called `#each` on. You're *still* not invited, Brian.
 
-<span id="the-each_with_index-method"></span>### The each_with_index Method
+### The each_with_index Method
 This method is nearly the same as `#each`, but it provides some additional functionality by yielding two **block variables** instead of one as it iterates through an array. The first variable's value is the element itself, while the second variable's value is the index of that element within the array. This allows you to do things that are a bit more complex.
 
 For example, if we only want to print every other word from an array of strings, we can achieve this like so:
@@ -434,7 +434,7 @@ This section contains helpful links to other content. It isn't required, so cons
 This section contains questions for you to check your understanding of this lesson. If you're having trouble answering the questions below on your own, review the material above to find the answer.
 
  * <a class="knowledge-check-link" href="#the-each-method">What does the `#each` method do? What does it return?</a>
- * <a class="knowledge-check-link" href="#the-each_with_index-method">What does the `#each_with_index` method do?</a>
+ * <a class="knowledge-check-link" href="#the-eachwithindex-method">What does the `#each_with_index` method do?</a>
  * <a class="knowledge-check-link" href="#the-map-method">What does the `#map` method do?</a>
  * <a class="knowledge-check-link" href="#the-select-method">What does the `#select` method do?</a>
  * <a class="knowledge-check-link" href="#the-reduce-method">What does the `#reduce` method do?</a>


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:

Fix the broken heading styling of the Ruby Enumerable Methods each_with_index heading.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number (and any [relevant keywords](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)) below:

Closes #22999 
