### PR TITLE
Replaced 'root' with 'home' to reflect correct usage of ~ in Git Basics assignment

### DIFF
--- a/foundations/git_basics/git_basics.md
+++ b/foundations/git_basics/git_basics.md
@@ -36,7 +36,7 @@ By the end of this lesson, you should be able to do the following:
 
     <a href="https://cdn.statically.io/gh/TheOdinProject/curriculum/b54d14c5dcee1c6fac61aee02fca7e9ef7ba1510/foundations/git_basics/project_practicing_git_basics/imgs/02.png"><img class="tutorial-img" src="https://cdn.statically.io/gh/TheOdinProject/curriculum/b54d14c5dcee1c6fac61aee02fca7e9ef7ba1510/foundations/git_basics/project_practicing_git_basics/imgs/02.png" title="Copy SSH link using GitHub" /></a>
 
-5. In the command line on your local machine, let's make a new directory for all your Odin projects. Create a directory called `repos` with the `mkdir` command in your root folder. If you're not sure you're in your root folder, just type `cd ~`. Once it's made, move into it with the `cd` command.
+5. In the command line on your local machine, let's make a new directory for all your Odin projects. Create a directory called `repos` with the `mkdir` command in your home folder. If you're not sure you're in your home folder, just type `cd ~`. Once it's made, move into it with the `cd` command.
 
     <a href="https://cdn.statically.io/gh/TheOdinProject/curriculum/b54d14c5dcee1c6fac61aee02fca7e9ef7ba1510/foundations/git_basics/project_practicing_git_basics/imgs/03.png"><img class="tutorial-img" src="https://cdn.statically.io/gh/TheOdinProject/curriculum/b54d14c5dcee1c6fac61aee02fca7e9ef7ba1510/foundations/git_basics/project_practicing_git_basics/imgs/03.png" title="Creating a new directory" /></a>
 


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:

In the Git Basics lesson of Foundations, the assignment gives instructions to create a new repo. The 5th point states that `cd ~` is used to get to the root directory. This is incorrect as `~` represents the home directory, not the root directory. Furthermore, the context of the instructions makes it clear that the directory being talked about is really the home directory, and not the root directory. 

This PR replaces the word "root" with the word "home" in that point to fix the incorrect usage.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number (and any [relevant keywords](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)) below:

#XXXXX
