### PR TITLE
Updated knowledge check link in JS Fundamentals part 2 (logical operators)

### DIFF
--- a/foundations/javascript_basics/fundamentals-2.md
+++ b/foundations/javascript_basics/fundamentals-2.md
@@ -69,7 +69,7 @@ This section contains questions for you to check your understanding of this less
 * <a class="knowledge-check-link" href="https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Strings#escaping_characters_in_a_string">How do you escape characters in a string?</a>
 * <a class="knowledge-check-link" href="https://www.w3schools.com/js/js_string_methods.asp">What are methods?</a>
 * <a class="knowledge-check-link" href="https://www.w3schools.com/js/js_string_methods.asp">What is the difference between slice/substring/substr?</a>
-* <a class="knowledge-check-link" href="https://javascript.info/comparison">What are the three logical operators and what do they stand for?</a>
+* <a class="knowledge-check-link" href="http://javascript.info/logical-operators">What are the three logical operators and what do they stand for?</a>
 * <a class="knowledge-check-link" href="https://javascript.info/comparison">What are the comparison operators?</a>
 * <a class="knowledge-check-link" href="https://javascript.info/comparison#boolean-is-the-result">What are truthy and falsy values?</a>
 * <a class="knowledge-check-link" href="https://javascript.info/comparison#string-comparison">What are the falsy values in JavaScript?</a>


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:

In the Foundations -> Javascript Fundamentals Part 2, the knowledge check 
"What are the three logical operators and what do they stand for?"
incorrectly links to the [article describing comparisons](https://javascript.info/comparison).
This has been updated to link to the [article explaining logical operators](https://javascript.info/logical-operators).

I am going through this part of the curriculum myself and thus this is my first pull request, so apologies if I have done anything incorrectly!

Thank you

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number (and any [relevant keywords](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)) below:
