### PR TITLE
Fixes markdown typo in HTML BoilerPlate lesson

### DIFF
--- a/foundations/html_css/html-foundations/html-boilerplate.md
+++ b/foundations/html_css/html-foundations/html-boilerplate.md
@@ -108,8 +108,10 @@ The HTML boilerplate in the `index.html` file is complete at this point, but how
 1. You can drag and drop an HTML file from your text editor into the address bar of your favorite browser.
 2. You can find the HTML file in your file system and then double click it. This will open up the file in the default browser your system uses.
 3. You can use the terminal to open the file in your browser.
-  a. Ubuntu - Navigate to the directory containing the file and use firefox index.html or google-chrome index.html
-  b. macOS - Navigate to the directory containing the file and use open ./index.html
+   
+   a. Ubuntu - Navigate to the directory containing the file and use firefox index.html or google-chrome index.html
+   
+   b. macOS - Navigate to the directory containing the file and use open ./index.html
 
 Using one of the methods above, open up the index.html file we have been working on. You'll notice the screen is blank. This is because we don't have anything in our body to display.
 


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:

Under "Viewing HTML Files in the Browser," the third item in the ordered list (i.e., using Terminal to open the files) looks like it wants to have a nested ordered list for Ubuntu and macOS options. A third space in front of "a" and "b," as well as line breaks are necessary to render properly as a nested ordered list (otherwise, they render in-line, which is confusing).

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number (and any [relevant keywords](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)) below:

#XXXXX
