### PR TITLE
Remove <span> tag from the headings and update knowledge checks of JavaScript lesson.

### DIFF
--- a/javascript/organizing-js/es6-modules.md
+++ b/javascript/organizing-js/es6-modules.md
@@ -24,7 +24,7 @@ Why do we even need or want this stuff? What do you gain from all of this added 
 
 - Read [this article](https://peterxjang.com/blog/modern-javascript-explained-for-dinosaurs.html) for a bit of a history lesson. It's long, but it puts what we're doing here in great perspective. This article is a bit older, and those who have coded along with the example have frequently run into issues, so we don't suggest that you code along (you'll be following along with the official Webpack documentation later). Nevertheless, this article is extremely important conceptually and really clarifies the 'WHY' of the rest of this lesson.
 
-### npm <span id="npm-knowledge-check"></span>
+### npm
 
 The __node package manager__ is a command-line tool that gives you access to a gigantic repository of plugins, libraries and tools. If you have done our Fundamentals course, you will probably have encountered it when you installed the Jest testing framework to do our exercises.
 
@@ -51,7 +51,7 @@ To get us started, we are going to refer to the official documentation.
 
 Let's discuss what's going on there. After installing webpack using npm, we set up a simple project that required an external library (lodash - check it out [here](https://lodash.com/) if it's new to you) using a simple `script` tag. The site lists a few reasons why this is probably _not_ ideal and then steps through using webpack to accomplish the same thing.
 
-<span id="npm-knowledge-check"></span> 
+<span id="webpack-knowledge-check"></span> 
 There are a couple of key concepts to understanding how webpack works - __entry__ and __output__. In this example, we rearranged the files into a `src` and `dist` folder. Technically we could have called those folders anything, but those names are typical. `src` is our _source_ directory. In other words, `src` is where we write all of the code that webpack is going to bundle up for us. When webpack runs, it goes through all of our files looking for any `import` statements and then compiles _all_ of the code we need to run our site into a single file inside of the `dist` folder (short for _distribution_). Our __entry__ file, then is the main application file that links (either directly or indirectly) to all of the other modules in our project. In this example, it is `/src/index.js`. The __output__ file is the compiled version - `dist/main.js`.
 
 - Browse [this document](https://webpack.js.org/concepts/) for more details. We'll talk plugins and loaders in another lesson.
@@ -153,7 +153,7 @@ The various import/export methods are best explained in the docs that we linked 
 ### Knowledge Check
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
-- <a class="knowledge-check-link" href="#npm-knowledge-check">Explain what npm is and where it was commonly used before being adopted on the frontend.</a>
+- <a class="knowledge-check-link" href="#npm">Explain what npm is and where it was commonly used before being adopted on the frontend.</a>
 - <a class="knowledge-check-link" href="https://docs.npmjs.com/creating-a-package-json-file">Describe what `npm init` does and what `package.json` is.</a>
 - <a class="knowledge-check-link" href="https://docs.npmjs.com/downloading-and-installing-packages-locally">Know how to install packages using npm.</a>
 - <a class="knowledge-check-link" href="https://peterxjang.com/blog/modern-javascript-explained-for-dinosaurs.html">Describe what a JavaScript module bundler like webpack is.</a>

--- a/javascript/organizing-js/factory-functions.md
+++ b/javascript/organizing-js/factory-functions.md
@@ -23,7 +23,7 @@ By the end of this lesson, you should be able to do the following:
 - Describe IIFE. What does it stand for?
 - Briefly explain namespacing and how it's useful.
 
-### Factory function introduction <span id='factory-function'></span>
+### Factory function introduction
 
 The factory function pattern is similar to constructors, but instead of using `new` to create an object, factory functions simply set up and return the new object when you call the function. Check out this example:
 
@@ -206,7 +206,7 @@ Take a minute to look through this example and see if you can figure out what's 
 
 What would happen here if we tried to call `jimmie.die()`? What if we tried to manipulate the health: `jimmie.health -= 1000`? Well, those are things that we have NOT exposed publicly so we would get an error. This is a very good thing! Setting up objects like this makes it easier for us to use them because we've actually put some thought into how and when we are going to want to use the information. In this case, we have jimmie's health hiding as a private variable inside of the object which means we need to export a function if we want to manipulate it. In the long run, this will make our code _much_ easier to reason about because all of the logic is encapsulated in an appropriate place.
 
-#### Inheritance with factories <span id='inheritance-factory-pattern'></span>
+#### Inheritance with factories
 
 In the constructors lesson, we looked fairly deeply into the concept of prototypes and inheritance, or giving our objects access to the methods and properties of another object. There are a few easy ways to accomplish this while using factories. Check this one out:
 
@@ -241,7 +241,7 @@ const Nerd = (name) => {
 
 - Before moving on have a look at [this](https://medium.com/javascript-scene/3-different-kinds-of-prototypal-inheritance-es6-edition-32d777fa16c9) article. In the second half of the article, the author goes into some things that we aren't really talking too much about here, but you'll be rewarded if you spend some time figuring out what he's talking about. Good stuff!
 
-### The Module Pattern <span id='#module-pattern'></span>
+### The Module Pattern
 
 > Quick sidenote: ES6 introduced a new feature in JavaScript called 'modules'. These are essentially a syntax for importing and exporting code between different JavaScript files. They're very powerful and we WILL be covering them later. They are _not_, however, what we're talking about here.
 
@@ -277,7 +277,7 @@ The concepts are exactly the same as the factory function. However, instead of c
 
 In our calculator example above, the function inside the IIFE is a simple factory function, but we can just go ahead and assign the object to the variable `calculator` since we aren't going to need to be making lots of calculators, we only need one. Just like the factory example, we can have as many private functions and variables as we want, and they stay neatly organized, tucked away inside of our module, only exposing the functions we actually want to use in our program.
 
-<span id='#name-spacing'></span>A useful side-effect of encapsulating the inner workings of our programs into objects is __namespacing__. Namespacing is a technique that is used to avoid naming collisions in our programs. For example, it's easy to imagine scenarios where you could write multiple functions with the same name. In our calculator example, what if we had a function that added things to our HTML display, and a function that added numbers and operators to our stack as the users input them? It is conceivable that we would want to call all three of these functions `add` which, of course, would cause trouble in our program. If all of them were nicely encapsulated inside of an object, then we would have no trouble: `calculator.add()`, `displayController.add()`, `operatorStack.add()`.
+<span id='name-spacing'></span>A useful side-effect of encapsulating the inner workings of our programs into objects is __namespacing__. Namespacing is a technique that is used to avoid naming collisions in our programs. For example, it's easy to imagine scenarios where you could write multiple functions with the same name. In our calculator example, what if we had a function that added things to our HTML display, and a function that added numbers and operators to our stack as the users input them? It is conceivable that we would want to call all three of these functions `add` which, of course, would cause trouble in our program. If all of them were nicely encapsulated inside of an object, then we would have no trouble: `calculator.add()`, `displayController.add()`, `operatorStack.add()`.
 
 ### Additional Resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
@@ -288,11 +288,11 @@ This section contains helpful links to other content. It isn't required, so cons
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
 - <a class="knowledge-check-link" href='https://tsherif.wordpress.com/2013/08/04/constructors-are-bad-for-javascript/'> Describe common bugs you might run into using constructors.</a>
-- <a class="knowledge-check-link" href='#factory-function'> Write a factory method that returns an object.</a>
+- <a class="knowledge-check-link" href='#factory-function-introduction'> Write a factory method that returns an object.</a>
 - <a class="knowledge-check-link" href='https://wesbos.com/javascript-scoping'> Explain how scope works in JavaScript (bonus points if you can point out what ES6 changed!).</a>
 - <a class="knowledge-check-link" href='#closure'> Explain what Closure is and how it impacts private functions & variables.</a>
 - <a class="knowledge-check-link" href='#private-functions-variables'> Describe how private functions & variables are useful.</a>
-- <a class="knowledge-check-link" href='#inheritance-factory-pattern'> Use inheritance in objects using the factory pattern.</a>
-- <a class="knowledge-check-link" href='#module-pattern'> Explain the module pattern.</a>
+- <a class="knowledge-check-link" href='#inheritance-with-factories'> Use inheritance in objects using the factory pattern.</a>
+- <a class="knowledge-check-link" href='#the-module-pattern'> Explain the module pattern.</a>
 - <a class="knowledge-check-link" href='http://adripofjavascript.com/blog/drips/an-introduction-to-iffes-immediately-invoked-function-expressions.html'> Describe IIFE. What does it stand for?</a>
 - <a class="knowledge-check-link" href='#name-spacing'> Briefly explain namespacing and how it's useful.</a>

--- a/javascript/organizing-js/objects-constructors.md
+++ b/javascript/organizing-js/objects-constructors.md
@@ -93,7 +93,7 @@ function gameOver(winningPlayer){
 
 Or, what if we aren't making a 2 player game, but something more complicated such as an online shopping site with a large inventory? In that case, using objects to keep track of an item's name, price, description and other things is the only way to go. Unfortunately, in that type of situation, manually typing out the contents of our objects is not feasible either. We need a cleaner way to create our objects, which brings us to...
 
-### Object Constructors <span id='javascript-object-constructor'></span>
+### Object Constructors
 
 When you have a specific type of object that you need to duplicate like our player or inventory items, a better way to create them is using an object constructor, which is a function that looks like this:
 
@@ -146,7 +146,7 @@ Note: It is almost _always_ best to `return` things rather than putting `console
 console.log(theHobbit.info());
 ~~~
 
-### The Prototype <span id='javascript-prototype'></span>
+### The Prototype
 
 Before we go much further, there's something important you need to understand about JavaScript objects. All objects in JavaScript have a `prototype`. Stated simply, the prototype is another object that the original object _inherits_ from, which is to say, the original object has access to all of its prototype's methods and properties.
 
@@ -173,7 +173,7 @@ Student.prototype.goToProm = function() {
 
 If you're using constructors to make your objects it is best to define functions on the `prototype` of that object. Doing so means that a single instance of each function will be shared between all of the Student objects. If we declare the function directly in the constructor, like we did when they were first introduced, that function would be duplicated every time a new Student is created. In this example, that wouldn't really matter much, but in a project that is creating thousands of objects, it really can make a difference.
 
-#### Recommended Method for Prototypal Inheritance <span id='javascript-prototypical-inheritance'></span>
+#### Recommended Method for Prototypal Inheritance
 
 So far you have seen several ways of making an object inherit the prototype from another object. At this point in history, the recommended way of setting the prototype of an object is `Object.create` ([here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create) is the documentation for that method). `Object.create` very simply returns a new object with the specified prototype and any additional properties you want to add. For our purposes, you use it like so:
 
@@ -251,8 +251,8 @@ Nicholas C. Zakas is really great to understand OOP in javascript, which explain
 ### Knowledge Check
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
-- <a class="knowledge-check-link" href='#javascript-object-constructor'>Write an object constructor and instantiate the object.</a>
-- <a class="knowledge-check-link" href='#javascript-prototype'>Describe what a prototype is and how it can be used.</a>
+- <a class="knowledge-check-link" href='#object-constructors'>Write an object constructor and instantiate the object.</a>
+- <a class="knowledge-check-link" href='#the-prototype'>Describe what a prototype is and how it can be used.</a>
 - <a class="knowledge-check-link" href='https://javascript.info/prototype-inheritance'>Explain prototypal inheritance.</a>
-- <a class="knowledge-check-link" href='#javascript-prototypical-inheritance'>Understand the basic do's and don't's of prototypical inheritance.</a>
+- <a class="knowledge-check-link" href='#recommended-method-for-prototypal-inheritance'>Understand the basic do's and don't's of prototypical inheritance.</a>
 - <a class="knowledge-check-link" href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create'>Explain what `Object.create` does</a>


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:
1. Remove 'span' tag from the headings and link the section using headings name, in full-stack-JavaScript/javascript  lessons(objects-constructors.md, factory-functions.md, es6-modules.md).
2. and update knowledge check links.
3. Apart from that this PR might also solved [this issue](https://github.com/TheOdinProject/theodinproject/issues/2356#issuecomment-964194245).

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number (and any [relevant keywords](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)) below:

#XXXXX
