### PR TITLE
Prompt learners to close all terminals in Installing Ruby lesson

### DIFF
--- a/ruby_programming/introduction/installing_ruby.md
+++ b/ruby_programming/introduction/installing_ruby.md
@@ -71,7 +71,7 @@ echo 'eval "$(rbenv init -)"' >> ~/.bashrc
 exit
 ~~~
 
-After running the final `exit` command, you will need to close and open a new terminal (see Step 1.1 above).
+After running the final `exit` command, you will need to close out of all open terminals and open a new terminal (see Step 1.1 above).
 
 Next, you need to install `ruby-build` to help compile the Ruby binaries. Run these commands in the terminal to create a directory for the ruby-build plugin and then download it to the proper directory.
 


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:

Ubuntu instructions tell learners to close and open a new terminal after adding some commands; however, ideally all terminals should be closed, or the learner may run into an issue.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number (and any [relevant keywords](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)) below:

#XXXXX
