### PR TITLE
Added npm instructions link in the ES6 Modules lesson

### DIFF
--- a/javascript/organizing-js/es6-modules.md
+++ b/javascript/organizing-js/es6-modules.md
@@ -26,7 +26,7 @@ Why do we even need or want this stuff? What do you gain from all of this added 
 
 ### npm
 
-The __node package manager__ is a command-line tool that gives you access to a gigantic repository of plugins, libraries and tools. If you have done our Fundamentals course, you will probably have encountered it when you installed the Jest testing framework to do our exercises.
+The __node package manager__ is a command-line tool that gives you access to a gigantic repository of plugins, libraries and tools. If you have done our Fundamentals course, you will probably have encountered it when you [installed the Jest testing framework](https://github.com/TheOdinProject/javascript-exercises#how-to-use-these-exercises) to do our exercises.
 
 Read through the npm links below but don't worry about running any of the commands on your computer. This section is about growing your awareness of npm. You will have an opportunity to use what you learn here in upcoming projects.
 


### PR DESCRIPTION
<!--
Thanks for your interest in The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The PR title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 
#### 1.Describe the changes made and include why they are necessary or important:

This lesson briefly mentions that you may have already installed npm in the Fundamentals course, but doesn't provide any more guidance on how to find those instructions. I had changed computers since that Fundamentals lesson, and couldn't remember where those instructions had been. So I'm simply adding a link to them in the paragraph where they're mentioned so people can easily jump back to them if they need to.

#### 2. If this PR is related to an open issue please reference it with the `#` operator and the issue number (and any [relevant keywords](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests)) below:

N/A
