### PR TITLE
Change COUNT(posts.*) to COUNT(*)  in 2nd and 3rd example of DATABASES AND SQL lesson

### DIFF
--- a/databases/databases.md
+++ b/databases/databases.md
@@ -129,7 +129,7 @@ You often see aliases (`AS`) used to rename columns or aggregate functions so yo
 Now we're getting into the fun stuff.  Aggregate functions like `COUNT` which return just a single value for your whole dataset are nice, but they become really useful when you want to use them on very specific chunks of your data and then group them together, e.g. displaying the `COUNT` of posts for EACH user (as opposed to the count of all posts by all users).  That would look like:
 
 ~~~sql
-  SELECT users.id, users.name, COUNT(*) AS posts_written
+  SELECT users.id, users.name, COUNT(posts.id) AS posts_written
   FROM users
   JOIN posts ON users.id = posts.user_id
   GROUP BY users.id;
@@ -140,7 +140,7 @@ See [w3 schools](http://www.w3schools.com/sql/trysql.asp?filename=trysql_select_
 The last nifty trick is if you want to only display a subset of your data.  In a normal situation, you'd use a `WHERE` clause to narrow it down.  But if you've used an aggregate function like `COUNT` (say to get the count of posts written for each user in the example above), `WHERE` won't work anymore.  So to conditionally retrieve records based on aggregate functions, you use the `HAVING` function, which is essentially the `WHERE` for aggregates.  So say I only want to display users who have written more than 10 posts:
 
 ~~~sql
-  SELECT users.id, users.name, COUNT(*) AS posts_written
+  SELECT users.id, users.name, COUNT(posts.id) AS posts_written
   FROM users
   JOIN posts ON users.id = posts.user_id
   GROUP BY users.id

--- a/databases/databases.md
+++ b/databases/databases.md
@@ -129,7 +129,7 @@ You often see aliases (`AS`) used to rename columns or aggregate functions so yo
 Now we're getting into the fun stuff.  Aggregate functions like `COUNT` which return just a single value for your whole dataset are nice, but they become really useful when you want to use them on very specific chunks of your data and then group them together, e.g. displaying the `COUNT` of posts for EACH user (as opposed to the count of all posts by all users).  That would look like:
 
 ~~~sql
-  SELECT users.id, users.name, COUNT(posts.*) AS posts_written
+  SELECT users.id, users.name, COUNT(*) AS posts_written
   FROM users
   JOIN posts ON users.id = posts.user_id
   GROUP BY users.id;
@@ -140,7 +140,7 @@ See [w3 schools](http://www.w3schools.com/sql/trysql.asp?filename=trysql_select_
 The last nifty trick is if you want to only display a subset of your data.  In a normal situation, you'd use a `WHERE` clause to narrow it down.  But if you've used an aggregate function like `COUNT` (say to get the count of posts written for each user in the example above), `WHERE` won't work anymore.  So to conditionally retrieve records based on aggregate functions, you use the `HAVING` function, which is essentially the `WHERE` for aggregates.  So say I only want to display users who have written more than 10 posts:
 
 ~~~sql
-  SELECT users.id, users.name, COUNT(posts.*) AS posts_written
+  SELECT users.id, users.name, COUNT(*) AS posts_written
   FROM users
   JOIN posts ON users.id = posts.user_id
   GROUP BY users.id


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
- [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1.Describe the changes made and include why they are necessary or important:

I believe COUNT(posts.\*) is incorrect because we joined post and users table. The correct one should be COUNT(*). In the W3 example in the same lesson https://www.w3schools.com/sql/trysql.asp?filename=trysql_select_groupby,  if we do something similar like
```sql
SELECT  Country, COUNT(Orders.*)
FROM Customers JOIN Orders by Customers.CustomerID = Orders.CustomerID 
GROUP BY Country
```
and press Run, error popup will be shown
#### 2. Related Issue

