### PR TITLE
Corrected 'manually' to 'automatically in Webpack lesson

### DIFF
--- a/javascript/organizing-js/webpack.md
+++ b/javascript/organizing-js/webpack.md
@@ -10,7 +10,7 @@ After completing this lesson, you will be able to:
  - Manage output with webpack.
 
 1. Go through [this tutorial](https://webpack.js.org/guides/asset-management/) to see examples of using webpack to manage your website's assets.
-2. Read through [this tutorial](https://webpack.js.org/guides/output-management/) to learn how to let webpack manually manage your index.html and insert your bundle into the page for you!
+2. Read through [this tutorial](https://webpack.js.org/guides/output-management/) to learn how to let webpack automatically manage your index.html and insert your bundle into the page for you!
 3. Finally, the first part of [this tutorial](https://webpack.js.org/guides/development/) talks about source maps, a handy way to track down which source file (index.js, a.js, b.js) an error is coming from when you use webpack to bundle them together. This is essential to debugging bundled code in your browser's DevTools. If the error comes from b.js the error will reference that file instead of the bundle. It also walks through an example of the `--watch` feature you _definitely_ should have taken note of above.
 4. You don't need to do the rest of the webpack tutorials at this time, but take a look at what's offered on the sidebar of their [guides page](https://webpack.js.org/guides/). There are several sweet features that you might want to use in future projects such as code-splitting, lazy-loading, and tree-shaking. Now that you have a handle on webpack's configuration system adding these features is as easy as using the right plugins and loaders!
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
- [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1.Describe the changes made and include why they are necessary or important:

Looks like the linked tutorial teaches you to use webpack to _automatically_ manage your index.html file, but the description says you're learning to have webpack _manually_ manage your index.html file. Seems like it should be "automatically" in this context.

#### 2. Related Issue

N/A
