### PR TITLE
Replace Wrong Word in Debugging Lesson

### DIFF
--- a/ruby_programming/basic_ruby/debugging.md
+++ b/ruby_programming/basic_ruby/debugging.md
@@ -199,7 +199,7 @@ This section contains helpful links to other content. It isn't required, so cons
 * Read through [HOWTO debug your Ruby code](https://readysteadycode.com/howto-debug-your-ruby-code), especially the first section on `puts` debugging, by ReadySteadyCode.
 * Read the article on [Debugging without doom and gloom](https://practicingruby.com/articles/debugging-without-doom-and-gloom) by Practicing Ruby.
 * Poke around [Pry's wiki](https://github.com/pry/pry/wiki) for a collection of resources that will help you master this invaluable gem.
-* Read [this](https://medium.com/@roni.shabo/overcoming-ruby-error-messages-ebf53928b64e) brilliant error about reading Ruby error messages
+* Read this brilliant article about [reading Ruby error messages](https://medium.com/@roni.shabo/overcoming-ruby-error-messages-ebf53928b64e)
 
 ### Knowledge Check
 This section contains questions for you to check your understanding of this lesson. If you're having trouble answering the questions below on your own, review the material above to find the answer.


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
- [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1.Describe the changes made and include why they are necessary or important:

The existing text describes the link as a "brilliant error", which doesn't make sense. I replaced "error" with "article".

In addition, I moved the link to be around the description of the article rather than around the word "this". This change brings the link into alignment with the [Web Content Accessibility Guidelines](https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/F84#F84-description) and makes the link more descriptive for screen-reader users.

#### 2. Related Issue

keyword #XXXXX
