### PR TITLE
Fix CSS specificity bullets and clarify symbols/combinators in CSS foundations lesson

### DIFF
--- a/foundations/html_css/css-foundations.md
+++ b/foundations/html_css/css-foundations.md
@@ -254,7 +254,6 @@ A CSS declaration that is more specific will take precedence over ones that are 
 1. ID selectors (most specific selector)
 2. Class selectors
 3. Type selectors
-4. Universal selector and combinators (no specificity)
 
 Specificity will only be taken into account when an element has multiple, conflicting declarations targeting it, sort of like a tie-breaker. An ID selector will always beat any number of class selectors, <span id="high-specificity-class-type">a class selector will always beat any number of type selectors</span>, and a type selector will always beat any number of anything less specific than it. When no declaration has a selector with a higher specificity, a larger amount of a single selector will beat a smaller amount of that same selector.
 
@@ -304,6 +303,50 @@ In the example above, despite rule 2 having more class selectors than ID selecto
 In this final example, both rules are using ID and class selectors, so neither rule is using a more specific selector than the other. The cascade then checks the amounts of each selector type. Both rules only have one ID selector, but rule 2 has more class selectors, so rule 2 has a higher specificity!
 
 While the `color: red` declaration would take precedence, the `background-color: yellow` declaration would still be applied since there's no conflicting declaration for it.
+
+Note: when comparing selectors you may come across special symbols for the universal selector (`*`) as well as combinators (`+`, `~`, `>`, and an empty space). These symbols do not add any specificity in and of themselves.
+
+~~~css
+/* rule 1 */
+.class.second-class {
+  font-size: 12px;
+}
+
+/* rule 2 */
+.class .second-class {
+  font-size: 24px;
+}
+~~~
+
+Here both rule 1 and rule 2 have the same specificity. Rule 1 uses a chaining selector (no space) and rule 2 uses a descendant combinator (the empty space). But both rules have two classes and the combinator symbol itself does not add to the specificity.
+
+~~~css
+/* rule 1 */
+.class.second-class {
+  font-size: 12px;
+}
+
+/* rule 2 */
+.class > .second-class {
+  font-size: 24px;
+}
+~~~
+
+This example shows the same thing. Even though rule 2 is using a child combinator (`>`), this does not change the specificity value. Both rules still have two classes so they have the same specificity values.
+
+~~~css
+/* rule 1 */
+* {
+  color: black;
+}
+
+/* rule 2 */
+h1 {
+  color: orange;
+}
+~~~
+
+In this example, rule 2 would have higher specificity and the `orange` value would take precedence for this element. Rule 2 uses a type selector, which has the lowest specificity value. But rule 1 uses the universal selector (`*`) which has no specificity value.
 
 #### Inheritance
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [X] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [X] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [X] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
- [X] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1.Describe the changes made and include why they are necessary or important:

As outlined in issue #22975, this PR clarifies learner confusion on CSS specificity in regards to combinations vs. combinators vs. chaining selectors.

This fix removes the 4th bullet from the specificity list which implied combinations had no specificity and caused multiple learners to get confused.

After the original code block examples, a new note on the usage of the universal selector and combinator symbols is added at the bottom of the section. These are followed up with examples that show how combinators and the universal selector have no specificity values in and of themselves.

#### 2. Related Issue

specificity #22975 
