### PR TITLE
Adjusted content in additional resources paragraph within predicate-enumerable-methods lesson

### DIFF
--- a/ruby_programming/basic_ruby/predicate_enumerable_methods.md
+++ b/ruby_programming/basic_ruby/predicate_enumerable_methods.md
@@ -221,7 +221,7 @@ fruits.none? { |fruit| fruit.length > 6 }
 ### Additional Resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
-* There are many more enumerable methods than are covered in this lesson (e.g., `#member?` and `#one?`). For a full listing, you can check out the [Ruby Docs](https://ruby-doc.org/core-2.5.0/Enumerable.html).
+* There are many more enumerable methods than are covered in this lesson (e.g., `#member?`). For a full listing, you can check out the [Ruby Docs](https://ruby-doc.org/core-2.5.0/Enumerable.html).
 
 ### Knowledge Check
 This section contains questions for you to check your understanding of this lesson. If you're having trouble answering the questions below on your own, review the material above to find the answer.


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [X] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [X] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [X] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
- [X] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1.Describe the changes made and include why they are necessary or important:

The wording in "Additional Resources" states there are more methods than covered in the lesson (with the example of #one). However, the lesson does in-fact cover **#one?** enumerable method. It's within the exercise and within the article you read as part of the assignment.

Here is the text:

"Additional Resources
This section contains helpful links to other content. It isn’t required, so consider it supplemental.

There are many more enumerable methods than are covered in this lesson (e.g., #member? and **#one?**). For a full listing, you can check out the Ruby Docs."

My solution is to remove this example.

#### 2. Related Issue

N/A
