### PR TITLE
Update dead link from Ruby Serialization Lesson

### DIFF
--- a/ruby_programming/files_and_serialization/lesson_serialization.md
+++ b/ruby_programming/files_and_serialization/lesson_serialization.md
@@ -35,4 +35,4 @@ This section contains helpful links to other content. It isn't required, so cons
 
 * [Zetcode's section on Input/Output in Ruby](http://zetcode.com/lang/rubytutorial/io/) should be another useful perspective on the material.
 * [Ruby Monk's section on Serializing](https://web.archive.org/web/20160505174806/http://rubymonk.com/learning/books/4-ruby-primer-ascent/chapters/45-more-classes/lessons/104-serializing)
-* [Short Example of Serialization](http://rubylearning.com/satishtalim/object_serialization.html) from Ruby Learning
+* [Short Example of Serialization](https://web.archive.org/web/20200627063721/http://rubylearning.com/satishtalim/object_serialization.html) from Ruby Learning


### PR DESCRIPTION
Link for 'Short Example of Serialization' is dead, used Wayback Machine to load the site.