### PR TITLE
chore(foundations): remove 'what the flexbox'

### DIFF
--- a/foundations/html_css/flexbox/flexbox-alignment.md
+++ b/foundations/html_css/flexbox/flexbox-alignment.md
@@ -69,7 +69,6 @@ It may take you a while to get through all of them, and the difficulty ramps up 
 ### Additional Resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
-* [What the Flexbox!?](https://flexbox.io/) is a great free video course from Wes Bos. If videos are your thing, this is a great resource for you. It's a good refresher if you're having a hard time getting this stuff to stick. Free, but requires your email to join the course.
 * [Flexbox Froggy](https://flexboxfroggy.com/) is a funny little game for practicing moving things around with flexbox.
 * [Flexbox Zombies](https://mastery.games/flexboxzombies/) is another gamified take on flexbox. Free, but requires an account.
 * This [Flexbox Tutorial](https://www.freecodecamp.org/news/css-flexbox-tutorial-with-cheatsheet/) from freecodecamp is another decent resource.


### PR DESCRIPTION
Removes Wes Bos 'what the flexbox' from additional resources due to misalignment with our curriculum.
