### PR TITLE
Fix: Remove broken link in web frameworks section

### DIFF
--- a/foundations/the_back_end/introduction_to_frameworks.md
+++ b/foundations/the_back_end/introduction_to_frameworks.md
@@ -19,7 +19,7 @@ Look through these now and then use them to test yourself after doing the assign
 
 <div class="lesson-content__panel" markdown="1">
 
-  1. Get introduced to frameworks by reading these brief articles from [Wired (originally from WebMonkey)](https://web.archive.org/web/20180402231229/https://www.wired.com/2010/02/get_started_with_web_frameworks/) and [Dev.to](https://dev.to/aspittel/what-is-a-web-framework-and-why-should-i-use-one-38c0).
+  1. Get introduced to frameworks by reading this brief article from [Dev.to](https://dev.to/aspittel/what-is-a-web-framework-and-why-should-i-use-one-38c0).
   2. Glance over [this article](https://rubygarage.org/blog/technology-stack-for-web-development) from RubyGarage or [this description](https://developer.mozilla.org/en-US/docs/Learn/Server-side/First_steps/Web_frameworks) from Mozilla's website to understand some of the thought process that goes into picking a framework.
 
 </div>


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [X ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [X ] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [ N/A] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
- [ X] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1.Describe the changes made and include why they are necessary or important:

In the web frameworks section, there was a broken link leading to a Wired article. The link itself was broken, and I tried to find a different link, but the article has been removed from the website.

I have removed the broken link, and changed the wording in the sentence (i.e. "Read these articles" -> "Read this article") for the remaining article. 

#### 2. Related Issue

N/A - this is a self-flagged issue
