### PR TITLE
fix/typo-selectors-lesson

### DIFF
--- a/html_css/v2/main-course/intermediate_css/selectors.md
+++ b/html_css/v2/main-course/intermediate_css/selectors.md
@@ -126,7 +126,7 @@ Structural pseudo-classes are a powerful way to select elements based on their p
 
 `:root` is generally the place where you will place your 'global' CSS rules that you want available everywhere - such as your custom properties and CSS variables, or rules such as `box-sizing: border-box;`.
 
-[`:first-child`](https://css-tricks.com/almanac/selectors/f/first-child/) and [`:last-child`](https://css-tricks.com/almanac/selectors/l/last-child/) will match elements that or the first or last sibling.
+[`:first-child`](https://css-tricks.com/almanac/selectors/f/first-child/) and [`:last-child`](https://css-tricks.com/almanac/selectors/l/last-child/) will match elements that are the first or last sibling.
 
 Similarly [`:empty`](https://css-tricks.com/almanac/selectors/e/empty/) and [`:only-child`](https://css-tricks.com/almanac/selectors/o/only-child/) will match elements that have no children at all, or just one.
 


### PR DESCRIPTION
Fix a typo in selector lesson of the html/css rewrite.

<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
- [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1.Describe the changes made and include why they are necessary or important:

Fix a small typo in the new selectors lesson.

#### 2. Related Issue

keyword #XXXXX
