### PR TITLE
Modify PR Template to say Closes instead of Keyword

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ Thank you for taking the time to contribute to The Odin Project. In order to get
  - [ ] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
  - [ ] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).
 
-#### 1.Describe the changes made and include why they are necessary or important:
+#### 1. Describe the changes made and include why they are necessary or important:
 
 ...your text here
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ Thank you for taking the time to contribute to The Odin Project. In order to get
  - [ ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
  - [ ] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
  - [ ] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
-- [ ] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).
+ - [ ] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).
 
 #### 1.Describe the changes made and include why they are necessary or important:
 
@@ -13,4 +13,4 @@ Thank you for taking the time to contribute to The Odin Project. In order to get
 
 #### 2. Related Issue
 
-keyword #XXXXX
+Closes #XXXXX


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
- [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

Switch the term "Keyword" to "Closes" to allow people to not have to change the default non-working keyword for issue linking and closing. Users do not seem to sometimes understand that there are multiple keywords to choose, and keyword is not one of them.

#### 2. Related Issue

No related issue.
