### PR TITLE
Fix and remove two outdated links in JS How this course will work lesson

### DIFF
--- a/javascript/introduction/introduction.md
+++ b/javascript/introduction/introduction.md
@@ -1,17 +1,18 @@
 ### Introduction
+
 JavaScript is the future of the web. More and more of the logic is making its way to the client side in order to facilitate lightning-fast user experiences. JavaScript is even moving to the server side with Node.js. That's why in this course we'll be diving deep into it to make sure you come out with a good understanding of how it works.
 
-You've already completed the [Foundations course](/courses/foundations/#section-the-front-end), right? Good, because now we'll be moving at warp speed into new frontiers. This section will cover a lot of ground and your brain may melt down a few times, but don't worry, that's just a flesh wound. Patch 'er up and keep going! When in doubt, build something.
+You've already completed the [Foundations course](/courses/foundations), right? Good, because now we'll be moving at warp speed into new frontiers. This section will cover a lot of ground and your brain may melt down a few times, but don't worry, that's just a flesh wound. Patch 'er up and keep going! When in doubt, build something.
 
 ### The Path
 
-How is this course set up? It starts with a deeper look at the basics, just like the [Ruby Programming course](/courses/ruby-programming) did with Ruby. You don't need to have completed the Ruby Programming course or [the Ruby on Rails course](/courses/ruby-on-rails) to understand these basics. We won't be focusing deeply on the really basic coding items, so it will move quickly. You should, however, already have completed the [Foundations course](/courses/foundations) - specifically the [Front End Section](/courses/foundations#the-front-end) - before starting this course. You might also find this [Git Section](https://www.theodinproject.com/courses/ruby-programming#git) on more intermediate-level uses of Git helpful.
+How is this course set up? It starts with a deeper look at the basics, just like the [Ruby Programming course](/courses/ruby-programming) did with Ruby. You don't need to have completed the Ruby Programming course or [the Ruby on Rails course](/courses/ruby-on-rails) to understand these basics. We won't be focusing deeply on the really basic coding items, so it will move quickly. You should, however, already have completed the [Foundations course](/courses/foundations) before starting this course. You might also find this [Git Section](https://www.theodinproject.com/courses/ruby-programming#git) on more intermediate-level uses of Git helpful.
 
-The last thing you'll do is a final project which integrates everything you've learned in all the courses of this curriculum. This is the kind of project that you'll be telling employers all about and a great chance to prove that you're now, officially, a serious web developer.  
+The last thing you'll do is a final project which integrates everything you've learned in all the courses of this curriculum. This is the kind of project that you'll be telling employers all about and a great chance to prove that you're now, officially, a serious web developer.
 
 ### Format
 
-There is a lot to cover, but this course has been broken up into bite-sized lessons and their accompanying projects. These projects will give you a chance to apply what you have learned and to show what you are capable of. After a few of them, you'll really start getting the hang of things.  
+There is a lot to cover, but this course has been broken up into bite-sized lessons and their accompanying projects. These projects will give you a chance to apply what you have learned and to show what you are capable of. After a few of them, you'll really start getting the hang of things.
 
 ### In each lesson:
 

--- a/javascript/introduction/introduction.md
+++ b/javascript/introduction/introduction.md
@@ -6,7 +6,7 @@ You've already completed the [Foundations course](/courses/foundations), right? 
 
 ### The Path
 
-How is this course set up? It starts with a deeper look at the basics, just like the [Ruby Programming course](/courses/ruby-programming) did with Ruby. You don't need to have completed the Ruby Programming course or [the Ruby on Rails course](/courses/ruby-on-rails) to understand these basics. We won't be focusing deeply on the really basic coding items, so it will move quickly. You should, however, already have completed the [Foundations course](/courses/foundations) before starting this course. You might also find this [Git Section](https://www.theodinproject.com/courses/ruby-programming#git) on more intermediate-level uses of Git helpful.
+How is this course set up? It starts with a deeper look at the basics, just like the [Ruby Programming course](/courses/ruby-programming) did with Ruby. You don't need to have completed the Ruby Programming course or [the Ruby on Rails course](/courses/ruby-on-rails) to understand these basics. We won't be focusing deeply on the really basic coding items, so it will move quickly. You should, however, already have completed the [Foundations course](/courses/foundations) -- specifically, the [JavaScript Basics section ](/courses/foundations#javascript-basics) -- before starting this course. You might also find this [Git section](https://www.theodinproject.com/courses/ruby-programming#git) on more intermediate-level uses of Git helpful.
 
 The last thing you'll do is a final project which integrates everything you've learned in all the courses of this curriculum. This is the kind of project that you'll be telling employers all about and a great chance to prove that you're now, officially, a serious web developer.
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [ ] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:
The first "Foundations course" link includes a hash mark in the URL, linking to a section that no longer exists. While the link is not necessarily broken, the hash link to the specific subsection should be removed for consistency with the curriculum. Further, second link "Front End Section" was removed as this section is nonexistent in the Foundations curriculum. 

#### 2. Related Issue
N/A
