### PR TITLE
Ubuntu Dual-Boot Intel RST Error Fix/Instructions

### DIFF
--- a/foundations/installations/prerequisites.md
+++ b/foundations/installations/prerequisites.md
@@ -219,6 +219,10 @@ If you would like to test out the version of Ubuntu on the flash drive, click 'T
 Installing Ubuntu is where the real changes start happening on your computer. The default settings are mostly perfect, but be sure to **"Install Ubuntu alongside Windows"** and change the allocated disk space allowed for Ubuntu to 30 GB (or more if you can).
 
 For step-by-step instructions, please follow this [installation guide](https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-desktop#0) from the creators of Ubuntu.
+   
+### Intel RST (Rapid Storage Technology)
+
+If you encounter an error requesting you to disable **Intel RST** while attempting to install Ubuntu, [these instructions from Stack Exchange](https://askubuntu.com/questions/1233623/workaround-to-install-ubuntu-20-04-with-intel-rst-systems/1233644#1233644), specifically **Choice #2**. The process forces Windows to boot into safemode after you switch your motherboard storage driver to work with Ubuntu. Once it boots into Windows, the forced-on safemode is disabled and you are free to attempt an installation of Ubuntu once again.
 
 </details>
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [X] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [X] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [X] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [X] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [X] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

This PR adds instructions to the Ubuntu dual-booting section to explain how to switch the motherboard to use AHCI with the storage drivers, which stops Intel RST from taking over the hard drive and preventing Ubuntu from installing. Students receive an error when they use Intel RST, which is typically preinstalled with the M.2 hard drives. This method offers a (test) safe and reliable way to disable Intel RST and allow them to move on with the curriculum.

#### 2. Related Issue

Closes #23200 
