### PR TITLE
Add Knowledge Checks with links and revise Learning Outcomes in Rails Advanced Forms lesson

### DIFF
--- a/rails_programming/advanced_forms_and_activerecord/forms_advanced.md
+++ b/rails_programming/advanced_forms_and_activerecord/forms_advanced.md
@@ -8,12 +8,11 @@ In this section, we'll take a look at some of the options you have to make a for
 
 By the end of this lesson, you should be able to:
 
-* Prepopulate a dropdown menu with objects
-* Describe the differences between the `#select_tag` and `#select` helpers
+* Build dropdown menus
+* Work with model objects
 * Make nested forms
-* Prepare models to create nested objects
 * Whitelist nested parameters
-* Allow dropdown fields or checkboxes to be set to `nil`
+* Delete records via form fields
 
 ### Prepopulating `select` Tags with Collections
 

--- a/rails_programming/advanced_forms_and_activerecord/forms_advanced.md
+++ b/rails_programming/advanced_forms_and_activerecord/forms_advanced.md
@@ -10,7 +10,6 @@ By the end of this lesson, you should be able to:
 
 * Prepopulate a dropdown menu with objects
 * Describe the differences between the `#select_tag` and `#select` helpers
-* Know how to input values to `#options_for_select`
 * Make nested forms
 * Prepare models to create nested objects
 * Whitelist nested parameters
@@ -49,7 +48,7 @@ This creates a dropdown list with each user's name as an option.  Your `#create`
 
 But Rails provides some less verbose ways of doing the same thing, namely using the `#select_tag` helper in conjunction with the `#options_for_select` helper.  The `#select_tag` will create the surrounding tag while the `#options_for_select` gives `#select_tag` the array of options it needs.
 
-`#options_for_select` expects a very specific input -- an array of arrays which provide the text for the dropdown option and the value it represents.  So `options_for_select([["choice1",1],["choice2",2]])` creates a couple of option tags, one for each choice.  This is great, because that's exactly what `#select_tag` expects for its second argument.  The only wrinkle here is that you need to convert your `@users` collection, which has full User objects, into a simple array with just `name` and `value`.  That's easy using `#map`:
+<span id='options-knowledge-check'>`#options_for_select` expects a very specific input -- an array of arrays which provide the text for the dropdown option and the value it represents.<span>  So `options_for_select([["choice1",1],["choice2",2]])` creates a couple of option tags, one for each choice.  This is great, because that's exactly what `#select_tag` expects for its second argument.  The only wrinkle here is that you need to convert your `@users` collection, which has full User objects, into a simple array with just `name` and `value`.  That's easy using `#map`:
 
 ~~~ruby
   # app/controllers/posts_controller.rb
@@ -68,7 +67,7 @@ But Rails provides some less verbose ways of doing the same thing, namely using 
 
 So just pass `#select_tag` the name it should use for your chosen value and the collection and it will output the exact same thing!
 
-If you want to avoid the whole `options_for_select` thing altogether and your form is designed to build a model instance (e.g. a Post object), just use the more generic `#select` helper in your view:
+<span id='select-knowledge-check'>If you want to avoid the whole `options_for_select` thing altogether and your form is designed to build a model instance (e.g. a Post object), just use the more generic `#select` helper in your view:</span>
 
 ~~~ruby
   # app/views/posts/new.html.erb
@@ -106,7 +105,7 @@ As you can imagine, it's important to get the names and parameters properly list
 
 We'll do a broad overview of the process here:
 
-1. You will need to prepare the User model so that it knows to create one or more ShippingAddress objects if it receives their attributes when creating a normal User.  This is done by adding a method to your User model called `#accepts_nested_attributes_for` which accepts the name of an association, e.g:
+<span id='model-knowledge-check'>1. You will need to prepare the User model so that it knows to create one or more ShippingAddress objects if it receives their attributes when creating a normal User.  This is done by adding a method to your User model called `#accepts_nested_attributes_for` which accepts the name of an association, e.g:<span>
 
 ~~~ruby
   # app/models/user.rb
@@ -198,11 +197,10 @@ This section contains helpful links to other content. It isn't required, so cons
 ### Knowledge Check
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
-- <a class="knowledge-check-link" href='#prepopulating-select-tags-with-collections'>How do you prepopulate a dropdown menu with data?</a>
 - <a class="knowledge-check-link" href='#prepopulating-select-tags-with-collections'>What does the `#select_tag` helper do?</a>
-- <a class="knowledge-check-link" href='#prepopulating-select-tags-with-collections'>When would you use the `#select` helper?</a>
-- <a class="knowledge-check-link" href='#prepopulating-select-tags-with-collections'>When using `#options_for_select`, what format does the array need to be in?</a>
+- <a class="knowledge-check-link" href='#select-knowledge-check'>When would you use the `#select` helper?</a>
+- <a class="knowledge-check-link" href='#options-knowledge-check'>When using `#options_for_select`, what format does the array need to be in?</a>
 - <a class="knowledge-check-link" href='#nested-forms'>How can you prevent users from having to submit multiple forms?</a>
-- <a class="knowledge-check-link" href='#nested-forms'>What do you add to the model that allows nested forms to create new objects?</a>
+- <a class="knowledge-check-link" href='#model-knowledge-check'>What do you add to the model that allows nested forms to create new objects?</a>
 - <a class="knowledge-check-link" href='https://www.createdbypete.com/2014/04/04/working-with-nested-forms-and-a-many-to-many-association-in-rails-4.html'>How do you whitelist the nested parameters in your controller?</a>
- - <a class="knowledge-check-link" href='#miscellania-blank-submissions-that-mean-delete'>Can you delete something by leaving a form field (e.g. a checkbox) blank (unchecked)?</a>
+ - <a class="knowledge-check-link" href='#miscellania-blank-submissions-that-mean-delete'>What happens if you leave a form field (e.g. a checkbox) blank (unchecked)?</a>

--- a/rails_programming/advanced_forms_and_activerecord/forms_advanced.md
+++ b/rails_programming/advanced_forms_and_activerecord/forms_advanced.md
@@ -48,7 +48,7 @@ This creates a dropdown list with each user's name as an option.  Your `#create`
 
 But Rails provides some less verbose ways of doing the same thing, namely using the `#select_tag` helper in conjunction with the `#options_for_select` helper.  The `#select_tag` will create the surrounding tag while the `#options_for_select` gives `#select_tag` the array of options it needs.
 
-<span id='options-knowledge-check'>`#options_for_select` expects a very specific input -- an array of arrays which provide the text for the dropdown option and the value it represents.<span>  So `options_for_select([["choice1",1],["choice2",2]])` creates a couple of option tags, one for each choice.  This is great, because that's exactly what `#select_tag` expects for its second argument.  The only wrinkle here is that you need to convert your `@users` collection, which has full User objects, into a simple array with just `name` and `value`.  That's easy using `#map`:
+<span id='options-for-select'>`#options_for_select` expects a very specific input -- an array of arrays which provide the text for the dropdown option and the value it represents.<span>  So `options_for_select([["choice1",1],["choice2",2]])` creates a couple of option tags, one for each choice.  This is great, because that's exactly what `#select_tag` expects for its second argument.  The only wrinkle here is that you need to convert your `@users` collection, which has full User objects, into a simple array with just `name` and `value`.  That's easy using `#map`:
 
 ~~~ruby
   # app/controllers/posts_controller.rb
@@ -67,7 +67,7 @@ But Rails provides some less verbose ways of doing the same thing, namely using 
 
 So just pass `#select_tag` the name it should use for your chosen value and the collection and it will output the exact same thing!
 
-<span id='select-knowledge-check'>If you want to avoid the whole `options_for_select` thing altogether and your form is designed to build a model instance (e.g. a Post object), just use the more generic `#select` helper in your view:</span>
+<span id='select-helper'>If you want to avoid the whole `options_for_select` thing altogether and your form is designed to build a model instance (e.g. a Post object), just use the more generic `#select` helper in your view:</span>
 
 ~~~ruby
   # app/views/posts/new.html.erb
@@ -105,7 +105,7 @@ As you can imagine, it's important to get the names and parameters properly list
 
 We'll do a broad overview of the process here:
 
-<span id='model-knowledge-check'>1. You will need to prepare the User model so that it knows to create one or more ShippingAddress objects if it receives their attributes when creating a normal User.  This is done by adding a method to your User model called `#accepts_nested_attributes_for` which accepts the name of an association, e.g:<span>
+<span id='accepts_nested_attributes_for'>1. You will need to prepare the User model so that it knows to create one or more ShippingAddress objects if it receives their attributes when creating a normal User.  This is done by adding a method to your User model called `#accepts_nested_attributes_for` which accepts the name of an association, e.g:<span>
 
 ~~~ruby
   # app/models/user.rb
@@ -198,9 +198,10 @@ This section contains helpful links to other content. It isn't required, so cons
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
 - <a class="knowledge-check-link" href='#prepopulating-select-tags-with-collections'>What does the `#select_tag` helper do?</a>
-- <a class="knowledge-check-link" href='#select-knowledge-check'>When would you use the `#select` helper?</a>
-- <a class="knowledge-check-link" href='#options-knowledge-check'>When using `#options_for_select`, what format does the array need to be in?</a>
+- <a class="knowledge-check-link" href='#options-for-select'>When using `#options_for_select`, what format does the array need to be in?</a>
+- <a class="knowledge-check-link" href='#select-helper'>When would you use the `#select` helper?</a>
 - <a class="knowledge-check-link" href='#nested-forms'>How can you prevent users from having to submit multiple forms?</a>
-- <a class="knowledge-check-link" href='#model-knowledge-check'>What do you add to the model that allows nested forms to create new objects?</a>
+- <a class="knowledge-check-link" href='#accepts_nested_attributes_for'>What do you add to the model that allows nested forms to create new objects?</a>
 - <a class="knowledge-check-link" href='https://www.createdbypete.com/2014/04/04/working-with-nested-forms-and-a-many-to-many-association-in-rails-4.html'>How do you whitelist the nested parameters in your controller?</a>
- - <a class="knowledge-check-link" href='#miscellania-blank-submissions-that-mean-delete'>What happens if you leave a form field (e.g. a checkbox) blank (unchecked)?</a>
+ - <a class="knowledge-check-link" href='#miscellania-blank-submissions-that-mean-delete'>How can you set up a dropdown or checkbox to delete a record that already exists?</a>
+ 

--- a/rails_programming/advanced_forms_and_activerecord/forms_advanced.md
+++ b/rails_programming/advanced_forms_and_activerecord/forms_advanced.md
@@ -5,15 +5,16 @@ You learned about the basics of building forms in HTML and Rails in previous les
 In this section, we'll take a look at some of the options you have to make a form handle multiple model objects at once.  You'll also learn how to prepopulate a dropdown menu with objects.
 
 ### Learning Outcomes
-Look through these now and then use them to test yourself after doing the assignment:
 
-* How do you prepopulate a dropdown menu with data?
-* What is the difference between the `#select_tag` helper and the `#select` helper?
-* What format does the array you input to `#options_for_select` need to be in?
-* Why would you need to use a nested form?
-* What do you need to change in the model to allow nested forms to create new objects properly?
-* How do you whitelist the nested parameters properly in your controller?
-* Why can't you just delete something by leaving a form field (e.g. a checkbox) blank (unchecked)?
+By the end of this lesson, you should be able to:
+
+* Prepopulate a dropdown menu with objects
+* Describe the differences between the `#select_tag` and `#select` helpers
+* Know how to input values to `#options_for_select`
+* Make nested forms
+* Prepare models to create nested objects
+* Whitelist nested parameters
+* Allow dropdown fields or checkboxes to be set to `nil`
 
 ### Prepopulating `select` Tags with Collections
 
@@ -193,3 +194,15 @@ This section contains helpful links to other content. It isn't required, so cons
 * [Using `inverse_of` to make `accepts_nested_attributes_for` work for `has_many :through` relationships](http://robots.thoughtbot.com/accepts-nested-attributes-for-with-has-many-through)
 * [Understanding Rails' form authenticity tokens](http://stackoverflow.com/questions/941594/understand-rails-authenticity-token)
 * [Why not to hardcode your application's secret token in production](http://daniel.fone.net.nz/blog/2013/05/20/a-better-way-to-manage-the-rails-secret-token/)
+
+### Knowledge Check
+This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
+
+- <a class="knowledge-check-link" href='#prepopulating-select-tags-with-collections'>How do you prepopulate a dropdown menu with data?</a>
+- <a class="knowledge-check-link" href='#prepopulating-select-tags-with-collections'>What does the `#select_tag` helper do?</a>
+- <a class="knowledge-check-link" href='#prepopulating-select-tags-with-collections'>When would you use the `#select` helper?</a>
+- <a class="knowledge-check-link" href='#prepopulating-select-tags-with-collections'>When using `#options_for_select`, what format does the array need to be in?</a>
+- <a class="knowledge-check-link" href='#nested-forms'>How can you prevent users from having to submit multiple forms?</a>
+- <a class="knowledge-check-link" href='#nested-forms'>What do you add to the model that allows nested forms to create new objects?</a>
+- <a class="knowledge-check-link" href='https://www.createdbypete.com/2014/04/04/working-with-nested-forms-and-a-many-to-many-association-in-rails-4.html'>How do you whitelist the nested parameters in your controller?</a>
+ - <a class="knowledge-check-link" href='#miscellania-blank-submissions-that-mean-delete'>Can you delete something by leaving a form field (e.g. a checkbox) blank (unchecked)?</a>


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [X] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [X] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [X] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [X] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [X] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

This PR adds a Knowledge Checks section to the Rails Advanced Forms lesson. The Knowledge Checks are reworked from the original Learning Outcomes questions. The Knowledge Checks link back to answers via section headers, specific lines and one assignment resource. This PR also adds new Learning Outcomes bullets at a high-level of the lesson. Please let me know any revisions you would like on these, thanks!

Please note: While working on this lesson I detected an issue with one of the section headers on the live site. The header marked "Prepopulating select Tags with Collections" has an extraneous title in the h3 tag prior to the anchor link. It only appears on the live site and does not appear in the markdown file. It looks like one of these section headers was meant to replace the other, but both show up on the live site. I just wanted to point that out, thanks!

#### 2. Related Issue

Closes #22948 
