### PR TITLE
es6-modules-knowledge-check-issue

### DIFF
--- a/javascript/organizing-js/es6-modules.md
+++ b/javascript/organizing-js/es6-modules.md
@@ -153,7 +153,7 @@ The various import/export methods are best explained in the docs that we linked 
 ### Knowledge Check
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
-- <a class="knowledge-check-link" href="#npm">Explain what npm is and where it was commonly used before being adopted on the frontend.</a>
+- <a class="knowledge-check-link" href="https://peterxjang.com/blog/modern-javascript-explained-for-dinosaurs.html">Explain what npm is and where it was commonly used before being adopted on the frontend.</a>
 - <a class="knowledge-check-link" href="https://docs.npmjs.com/creating-a-package-json-file">Describe what `npm init` does and what `package.json` is.</a>
 - <a class="knowledge-check-link" href="https://docs.npmjs.com/downloading-and-installing-packages-locally">Know how to install packages using npm.</a>
 - <a class="knowledge-check-link" href="https://peterxjang.com/blog/modern-javascript-explained-for-dinosaurs.html">Describe what a JavaScript module bundler like webpack is.</a>


### PR DESCRIPTION
The first knowledge check expects you to briefly explain what npm is and where it was commonly used before being adopted on the frontend.
That knowledge check was linked to the #npm section in the page, but in that section none of the links talks about where npm was commonly used before being adopted on the frontend while in the 'Modern JavaScript Explained For Dinosaurs' article they talk about the history of npm, where was commonly used before being adopted on the frontend and what npm is.

<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [ ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [ ] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [ ] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [ ] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [ ] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

The first knowledge check expects you to briefly explain what npm is and where it was commonly used before being adopted on the frontend.
That knowledge check was linked to the #npm section in the page, but in that section none of the links talks about where npm was commonly used before being adopted on the frontend while in the 'Modern JavaScript Explained For Dinosaurs' article they talk about the history of npm, where was commonly used before being adopted on the frontend and what npm is.

#### 2. Related Issue

Closes #XXXXX
