### PR TITLE
Prepare Ruby's Debugging lesson to move before Enumerable lessons

### DIFF
--- a/ruby_programming/basic_ruby/debugging.md
+++ b/ruby_programming/basic_ruby/debugging.md
@@ -22,7 +22,7 @@ The stack trace prints each line of code in your program that was executed befor
 
 <a href="https://cdn.statically.io/gh/TheOdinProject/curriculum/284f0cdc998be7e4751e29e8458323ad5d320303/ruby_programming/basic_ruby/debugging/imgs/01.png"><img class="tutorial-img" src="https://cdn.statically.io/gh/TheOdinProject/curriculum/284f0cdc998be7e4751e29e8458323ad5d320303/ruby_programming/basic_ruby/debugging/imgs/01.png" title="source: imgur.com" alt="first line of stack trace" /></a>
 
-<span id='stack-trace-first-line-info'>First, this line of the stack trace will tell you what specific line caused the runtime error. In the above example, the error was encountered in line 30 of the file `lib/bottles.rb`. This line also provides a brief explanation of the error and the name of the error. (In this case, it's a [`NameError`](https://ruby-doc.org/core-2.6/NameError.html)). And yes, in Ruby, [errors](https://ruby-doc.org/core-2.6/Exception.html) are *also* objects.</span>
+<span id='stack-trace-first-line-info'>First, this line of the stack trace will tell you what specific line caused the runtime error. In the above example, the error was encountered in line 30 of the file `lib/bottles.rb`. This line also provides a brief explanation of the error and the name of the error. (In this case, it's a [`NameError`](https://ruby-doc.org/core-2.7.4/NameError.html)). And yes, in Ruby, [errors](https://ruby-doc.org/core-2.7.4/Exception.html) are *also* objects.</span>
 
 There you have it. The stack trace really is that simple. At this point, you know where in your code the exception is being raised, and you know the type of error you're dealing with. You might even know what fixes need to be implemented in your code.
 
@@ -33,68 +33,71 @@ The debugging process is all about confirming assumptions about your code until 
 
 The easiest and quickest way to confirm your assumptions while debugging is by using `puts` statements to output the return value of variables, methods, calculations, iterations, or even entire lines of code to your terminal.
 
-Let's say that for *whatever* reason, we need to write a method that takes a string and doubles each word in that string. Perhaps it's a hostage situation that requires a pro debugger? Let's take a look at a (simple) first draft:
+Let's say that for *whatever* reason, we need to write a method that takes a string and checks if the string is an **isogram** (a word that has no repeating letters) or not. Perhaps it's a hostage situation that requires a pro debugger? Let's take a look at a (simple) first draft:
 
 ~~~ruby
-def double_words_in_phrase(string)
-  string_array = string.split(' ')
-  string_array.map { |word| word * 2 }
-  string_array.join(' ')
+def isogram?(string)
+  original_length = string.length
+  string_array = string.downcase.split
+  unique_length = string_array.uniq.length
+  original_length == unique_length
 end
 
-double_words_in_phrase("This is a test")
+isogram?("Odin")
 
-#=> "This is a test"
+#=> false
 ~~~
 
-Okay, that didn't work. We didn't expect that. The method didn't throw an exception, so we don't even have a line to start debugging at. Now what?
+Okay, that didn't work. We didn't expect that. Why? Because the string *Odin* is an isogram but we got `false`. The method didn't throw an exception, so we don't even have a line to start debugging at. Now what?
 
-We know that `string_array.join(' ')` returns `"This is a test"` since it's the last statement, so why not place a `puts` on the line before that to see what `string_array` is. As an alternative to `puts`, `p` is also commonly used for debugging; `p` is a combination of `puts` and `inspect` (more on that below). To better show the differences between what Ruby is printing to the terminal and returning, the examples in this section use the full IRB syntax, which is exactly what you'd see if you typed these commands into your own terminal IRB session.
+We know that `original_length == unique_length` returns `false` since it's the last statement, so why not place a `puts` on the line before that to see what `unique_length` is. As an alternative to `puts`, `p` is also commonly used for debugging; `p` is a combination of `puts` and `inspect` (more on that below). To better show the differences between what Ruby is printing to the terminal and returning, the examples in this section use the full IRB syntax, which is exactly what you'd see if you typed these commands into your own terminal IRB session.
 
 ~~~ruby
-irb(main):001:0> def double_words_in_phrase(string)
-irb(main):002:1>   string_array = string.split(' ')
-irb(main):003:1>   string_array.map { |word| word * 2 }
-irb(main):004:1>
-irb(main):005:1>   p string_array
-irb(main):006:1>
-irb(main):007:1>   string_array.join(' ')
-irb(main):008:1> end
-=> :double_words_in_phrase
-
-irb(main):009:0> double_words_in_phrase("This is a test")
-["This", "is", "a", "test"]
-=> "This is a test"
+irb(main):001:1* def isogram?(string)
+irb(main):002:1*   original_length = string.length
+irb(main):003:1*   string_array = string.downcase.split
+irb(main):004:1*   unique_length = string_array.uniq.length
+irb(main):005:1*   
+irb(main):006:1*   p unique_length
+irb(main):007:1*   
+irb(main):008:1*   original_length == unique_length
+irb(main):009:0> end
+=> :isogram?
+irb(main):010:0> isogram?("Odin")
+1
+=> false
 ~~~
 
-*INTERESTING*. Using `p` on `string_array` prints it to the console and shows us that the words aren't doubled at all. Something must be wrong with how we called `#map` on `string_array`. For verification, let's place another `p` statement before the `map` statement:
+*INTERESTING*. Using `p` on `unique_length` prints it to the console and shows us something must be wrong with how we called `#uniq` on `string_array` because we know that we have `4` unique characters in our input but we got `1` as output. For verification, let's place another `p` statement before the `unique_length` statement:
 
 ~~~ruby
-irb(main):001:0> def double_words_in_phrase(string)
-irb(main):002:1>   string_array = string.split(' ')
-irb(main):003:1>
-irb(main):004:1>   p string_array
-irb(main):005:1>
-irb(main):006:1>   string_array.map { |word| word * 2 }
-irb(main):007:1>   p string_array
-irb(main):008:1>   string_array.join(' ')
-irb(main):009:1> end
-=> :double_words_in_phrase
-
-irb(main):010:0> double_words_in_phrase("This is a test")
-["This", "is", "a", "test"]
-["This", "is", "a", "test"]
-=> "This is a test"
+irb(main):001:1* def isogram?(string)
+irb(main):002:1*   original_length = string.length
+irb(main):003:1*   string_array = string.downcase.split
+irb(main):004:1*   
+irb(main):005:1*   p string_array
+irb(main):006:1*   
+irb(main):007:1*   unique_length = string_array.uniq.length
+irb(main):008:1*   
+irb(main):009:1*   p unique_length
+irb(main):010:1* 
+irb(main):011:1*   original_length == unique_length
+irb(main):012:0> end
+=> :isogram?
+irb(main):013:0> isogram?("Odin")
+["odin"]
+1
+=> false
 ~~~
 
-Indeed, we didn't use `#map` correctly, as this particular method creates a new array rather than acting on the array it's called on. Try running the above code in a REPL or IRB using `#map!` instead, and you'll see the difference.
+Indeed, we didn't use `#split` correctly, as this particular creates an array with the given string rather than creating an array of characters of the given string. Why? By default, if we didn't provide arguments, [#split](https://ruby-doc.org/core-2.7.4/String.html#method-i-split) will divide the string using `whitespace` as the delimiter. Try running the above code in a REPL or IRB using `#split('')` instead, and you'll see the difference.
 
 Hostage situation resolved! That wasn't so bad, was it?
 
 #### Debugging with `puts` and `nil`
 Using `puts` is a great way to debug, but there's a **HUGE** caveat with using it: calling `puts` on anything that is `nil` or an empty string or collection will just print a blank line to your terminal.
 
-This is one instance where using `p` will yield more information. As mentioned above, `p` is a combination of `puts` and [#inspect](https://ruby-doc.org/core-2.6.1/Object.html#method-i-inspect), the latter of which essentially prints a string representation of whatever it's called on. To illustrate this, try the following in a REPL:
+This is one instance where using `p` will yield more information. As mentioned above, `p` is a combination of `puts` and [#inspect](https://ruby-doc.org/core-2.7.4/Object.html#method-i-inspect), the latter of which essentially prints a string representation of whatever it's called on. To illustrate this, try the following in a REPL:
 
 ~~~ruby
 puts "Using puts:"
@@ -113,16 +116,17 @@ To follow along with these examples save the code into a Ruby file (e.g., `scrip
 ~~~ruby
 require 'pry-byebug'
 
-def double_words_in_phrase(string)
-  string_array = string.split(' ')
+def isogram?(string)
+  original_length = string.length
+  string_array = string.downcase.split
 
   binding.pry
 
-  string_array.map { |word| word * 2 }
-  string_array.join(' ')
+  unique_length = string_array.uniq.length
+  original_length == unique_length
 end
 
-double_words_in_phrase("This is a test")
+isogram?("Odin")
 ~~~
 
 When your code executes and gets to `binding.pry`, it will open an IRB-like session in your terminal. You can then use that session to check the values of anything within the scope of where you included `binding.pry`. However, keep in mind that any code written *after* the `binding.pry` statement will not have been evaluated during the Pry session. Thus, adding a `binding.pry` line in our code is similar to creating a breakpoint in JavaScript.

--- a/ruby_programming/basic_ruby/debugging.md
+++ b/ruby_programming/basic_ruby/debugging.md
@@ -129,7 +129,11 @@ end
 isogram?("Odin")
 ~~~
 
-When your code executes and gets to `binding.pry`, it will open an IRB-like session in your terminal. You can then use that session to check the values of anything within the scope of where you included `binding.pry`. However, keep in mind that any code written *after* the `binding.pry` statement will not have been evaluated during the Pry session. Thus, adding a `binding.pry` line in our code is similar to creating a breakpoint in JavaScript.
+When your code executes and gets to `binding.pry`, it will open an IRB-like session in your terminal. You can then use that session to check the values of anything within the scope of where you included `binding.pry`. However, keep in mind that any code written *after* the `binding.pry` statement will not have been evaluated during the Pry session. 
+
+For example, here `original_length` and `string_array` are in scope. However, `unique_length` is not in scope, because it is written after `binding.pry` and has not been evaluated yet.
+
+Thus, adding a `binding.pry` line in our code is similar to creating a breakpoint in JavaScript.
 
 To see this point in action, try running the following:
 

--- a/ruby_programming/basic_ruby/debugging.md
+++ b/ruby_programming/basic_ruby/debugging.md
@@ -203,7 +203,7 @@ This section contains helpful links to other content. It isn't required, so cons
 * Read through [HOWTO debug your Ruby code](https://readysteadycode.com/howto-debug-your-ruby-code), especially the first section on `puts` debugging, by ReadySteadyCode.
 * Read the article on [Debugging without doom and gloom](https://practicingruby.com/articles/debugging-without-doom-and-gloom) by Practicing Ruby.
 * Poke around [Pry's wiki](https://github.com/pry/pry/wiki) for a collection of resources that will help you master this invaluable gem.
-* Read this brilliant article about [reading Ruby error messages](https://medium.com/@roni.shabo/overcoming-ruby-error-messages-ebf53928b64e)
+* Read this brilliant article about [reading Ruby error messages](https://medium.com/@roni.shabo/overcoming-ruby-error-messages-ebf53928b64e).
 
 ### Knowledge Check
 This section contains questions for you to check your understanding of this lesson. If you're having trouble answering the questions below on your own, review the material above to find the answer.


### PR DESCRIPTION
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

Prepare Ruby's Debugging lesson to move before Enumerable lessons

- [x] Replaced enumerables examples
- [x] Updated the surrounding context/explanations of the debugging examples
- [x] Added a link to documentation when explaining why a method is not working as expected.

#### 2. Related Issue

Closes #23224 
