### PR TITLE
Corrected codepen link from "fork on codepen" to "edit on codepen".

### DIFF
--- a/foundations/html_css/flexbox/flexbox-intro.md
+++ b/foundations/html_css/flexbox/flexbox-intro.md
@@ -31,7 +31,7 @@ We'll get into exactly what's going on here soon enough, but for now, uncomment 
 If you add another div to the HTML, inside of `.flex-container`, it will show up alongside the others, and everything will flex to make it fit.
 
 > #### Note
-> If it's hard to see what's going on in the small embedded CodePen, feel free to click the "Fork on CodePen" button. This will bring the example into a full-sized environment. Some of the later examples might especially benefit from doing this.
+> If it's hard to see what's going on in the small embedded CodePen, feel free to click the "Edit on CodePen" button. This will bring the example into a full-sized environment. Some of the later examples might especially benefit from doing this.
 
 #### Flex Containers and Flex Items
 As you've seen, flexbox isn't just a single css property, but a whole toolbox of properties that you can use to put things where you need them. Some of these properties belong on the _flex container_ and some go on the _flex items_. This is a simple but important concept.


### PR DESCRIPTION
Embedded CodePens used to have a link that read "Fork on Codepen". They changed the link to say "Edit on Codepen".
