### PR TITLE
Foundations: Add Node Installation instructions as a lesson before JavaScript Fundamentals Part 4

### DIFF
--- a/foundations/javascript_basics/installing_nodejs.md
+++ b/foundations/javascript_basics/installing_nodejs.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-Node is a JavaScript runtime environment that allows you to run JavaScript outside of your web browser, this means that you can code the server side of your application in JavaScript. To get started, there are some required tools we need before we can install Node on your system.
+Node.js is a JavaScript runtime environment that allows you to run JavaScript outside of your web browser. We will need this for some exercises in the upcoming lessons. To get started, there are some required tools we need before we can install Node on your system.
 
 We're going to install it using `nvm` (Node Version Manager), because it makes it easy to change Node versions and upgrade Node. There is another tool called `npm` (Node Package Manager) that you will use later to install the various libraries and tools used in JavaScript environments. It can be easy to confuse these two so read carefully!
 
@@ -8,8 +8,8 @@ Node is also very easy to install using nvm, so this should go quickly :)
 
 ### Installing nvm
 
-<details>
-  <summary><b>Installation on Linux</b></summary>
+<details markdown="block">
+  <summary class="dropDown-header">Installation on Linux</summary>
 
 #### Step 0: Prerequisites 
 To install nvm properly, you'll need `curl`. Simply run the command below:
@@ -47,8 +47,8 @@ if this returns `nvm: command not found` close the terminal and re-open it.
 
 </details>
 
-<details>
-  <summary><b>Installation on macOS</b></summary>
+<details markdown="block">
+  <summary class="dropDown-header">Installation on macOS</summary>
   <br/>
   
 On macOS 10.15 and above, the default shell is now zsh. During installation, nvm will look for a `.zshrc` file in your user home directory. By default, this file does not exist so we need to create it.

--- a/foundations/javascript_basics/installing_nodejs.md
+++ b/foundations/javascript_basics/installing_nodejs.md
@@ -109,7 +109,7 @@ We need to tell `nvm` which version of Node to use when we run the `node` comman
 nvm use --lts
 ~~~
 
-We have told `nvm` to use the most recent LTS version of Node installed on our computer. You **must** use the LTS version of Node to avoid incompatibilites with packages we will be installing in future lessons. The LTS version of Node is simply a version that is guaranteed support for thirty months after it's initial release. It is more stable and compatible with a variety of packages than a non-LTS version of Node. LTS versions can be identified by having an even number for the version. Non-LTS versions are odd-numbered.
+We have told `nvm` to use the most recent LTS version of Node installed on our computer. You **must** use the LTS version of Node to avoid incompatibilites with packages we will be installing in future lessons. The LTS version of Node is simply a version that is guaranteed support for thirty months after its initial release. It is more stable and compatible with a variety of packages than a non-LTS version of Node.
 
 Now when you run `node -v` you should see `v16.xx.x` or something similar. 
 

--- a/foundations/javascript_basics/installing_nodejs.md
+++ b/foundations/javascript_basics/installing_nodejs.md
@@ -93,22 +93,24 @@ Run:
 nvm install --lts
 ~~~
 
-This will install the most recent stable version of Node, and you’ll see a lot of output in the terminal. If everything worked, you should see something similar to this somewhere in the lines of output:
+This will install the most recent stable version of Node in 'long-term support' (LTS), and you’ll see a lot of output in the terminal. If everything worked, you should see something similar to this somewhere in the lines of output:
 
 ~~~bash
 Downloading and installing Node v16.xx.x...
 ~~~
 
-If not, close the terminal, re-open it and run `nvm install node` again.
+If not, close the terminal, re-open it and run `nvm install --lts` again.
 
 #### Step 2: Setting the Node Version
 
 We need to tell `nvm` which version of Node to use when we run the `node` command. It's easy, just run the following command:
 
 ~~~bash
-nvm use node
+nvm use --lts
 ~~~
 
-Now when you run `node -v` you should see `v16.xx.x` or something similar.
+We have told `nvm` to use the most recent LTS version of Node installed on our computer. You **must** use the LTS version of Node to avoid incompatibilites with packages we will be installing in future lessons. The LTS version of Node is simply a version that is guaranteed support for thirty months after it's initial release. It is more stable and compatible with a variety of packages than a non-LTS version of Node. LTS versions can be identified by having an even number for the version. Non-LTS versions are odd-numbered.
+
+Now when you run `node -v` you should see `v16.xx.x` or something similar. 
 
 If you see that, you have successfully installed Node!


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

Moves the Node Installation instructions out to be their own lesson to be placed before JavaScript Fundamentals Part 4. At the moment they are among the instructions for cloning the JavaScript Exercise repo and installing Jest. Breaking them out into their own lesson may ease this friction and reduce the number of questions relating to it in the Discord.

#### 2. Related Issue

This is related to issue [#23248](https://github.com/TheOdinProject/curriculum/issues/23248) but does not close it. If this change is approved and merged, then the change needs to be made in the TOP website repo and the JavaScript Exercises [README](https://github.com/TheOdinProject/javascript-exercises#readme) needs updated to reflect the change.