### PR TITLE
Update CSS Foundations lesson wording for clarity in Chaining Selectors section

### DIFF
--- a/foundations/html_css/css-foundations.md
+++ b/foundations/html_css/css-foundations.md
@@ -157,9 +157,7 @@ We have two elements with the `subsection` class that have some sort of unique s
 }
 ~~~
 
-What `.subsection.header` does is it selects any element that has both the `subsection` *and* `header` classes.
-
-Notice how there isn't any space between the `.subsection` and `.header` selectors. This syntax basically works for chaining any combination of selectors except for multiple type selectors. This is because `divp` would try to select a literal `<divp>` element which doesn’t exist, and either way, an element can’t be two different types at once.
+What `.subsection.header` does is it selects any element that has both the `subsection` *and* `header` classes. Notice how there isn't any space between the `.subsection` and `.header` selectors. This syntax basically works for chaining any combination of selectors except for multiple type selectors. For example, if you tried to chain the `div` and `p` type selectors like `divp`, then the selector would try to select a literal `<divp>` element which doesn’t exist. In general, a type selector can't be chained since an element can’t be two different types at once.
 
 #### Descendant Combinator
 

--- a/foundations/html_css/css-foundations.md
+++ b/foundations/html_css/css-foundations.md
@@ -157,7 +157,7 @@ We have two elements with the `subsection` class that have some sort of unique s
 }
 ~~~
 
-Notice how there isn't any space between the two selectors here. What `.subsection.header` does is it selects any element that has both the `subsection` *and* `header` classes. This basically works with any combination of selectors except multiple type selectors (since an element can't be two different types at once, and `divp` would try to select a literal `<divp>` element which doesn't exist).
+What `.subsection.header` does is it selects any element that has both the `subsection` *and* `header` classes. Notice how there isn't any space between the `.subsection` and `.header` selectors. This syntax basically works for chaining any combination of selectors except for multiple type selectors (since an element can’t be two different types at once, and `divp` would try to select a literal `<divp>` element which doesn’t exist).
 
 #### Descendant Combinator
 

--- a/foundations/html_css/css-foundations.md
+++ b/foundations/html_css/css-foundations.md
@@ -157,7 +157,9 @@ We have two elements with the `subsection` class that have some sort of unique s
 }
 ~~~
 
-What `.subsection.header` does is it selects any element that has both the `subsection` *and* `header` classes. Notice how there isn't any space between the `.subsection` and `.header` selectors. This syntax basically works for chaining any combination of selectors except for multiple type selectors (since `divp` would try to select a literal `<divp>` element which doesn’t exist, and either way, an element can’t be two different types at once).
+What `.subsection.header` does is it selects any element that has both the `subsection` *and* `header` classes.
+
+Notice how there isn't any space between the `.subsection` and `.header` selectors. This syntax basically works for chaining any combination of selectors except for multiple type selectors. This is because `divp` would try to select a literal `<divp>` element which doesn’t exist, and either way, an element can’t be two different types at once.
 
 #### Descendant Combinator
 

--- a/foundations/html_css/css-foundations.md
+++ b/foundations/html_css/css-foundations.md
@@ -157,9 +157,9 @@ We have two elements with the `subsection` class that have some sort of unique s
 }
 ~~~
 
-What `.subsection.header` does is it selects any element that has both the `subsection` *and* `header` classes. Notice how there isn't any space between the `.subsection` and `.header` class selectors. This syntax basically works for chaining any combination of selectors, with the exception of chaining more than one type (or element) selector.
+What `.subsection.header` does is it selects any element that has both the `subsection` *and* `header` classes. Notice how there isn't any space between the `.subsection` and `.header` class selectors. This syntax basically works for chaining any combination of selectors, with the exception of chaining more than one [type selector](#type-selectors).
 
-In general, you can't chain more than one type/element selector since an element can’t be two different types at once. For example, chaining two type selectors like `div` and `p`, would give us the selector `divp`, which wouldn't work since the selector would try to find a literal `<divp>` element, which doesn’t exist. 
+In general, you can't chain more than one type selector since an element can’t be two different types at once. For example, chaining two type selectors like `div` and `p`, would give us the selector `divp`, which wouldn't work since the selector would try to find a literal `<divp>` element, which doesn’t exist. 
 
 #### Descendant Combinator
 

--- a/foundations/html_css/css-foundations.md
+++ b/foundations/html_css/css-foundations.md
@@ -159,7 +159,7 @@ We have two elements with the `subsection` class that have some sort of unique s
 
 What `.subsection.header` does is it selects any element that has both the `subsection` *and* `header` classes. Notice how there isn't any space between the `.subsection` and `.header` selectors. This syntax basically works for chaining any combination of selectors, with the exception of type selectors.
 
-In general, type selectors can't be chained since an element can’t be two different types at once. Also, if you tried to chain the `div` and `p` type selectors like `divp`, it wouldn't work since the selector would try to find a literal `<divp>` element which doesn’t exist. 
+In general, type selectors can't be chained since an element can’t be two different types at once. Also, chaining two type selectors like `div` and `p`, would give us the selector `divp`. which wouldn't work since the selector would try to find a literal `<divp>` element, which doesn’t exist. 
 
 #### Descendant Combinator
 

--- a/foundations/html_css/css-foundations.md
+++ b/foundations/html_css/css-foundations.md
@@ -157,7 +157,7 @@ We have two elements with the `subsection` class that have some sort of unique s
 }
 ~~~
 
-What `.subsection.header` does is it selects any element that has both the `subsection` *and* `header` classes. Notice how there isn't any space between the `.subsection` and `.header` selectors. This syntax basically works for chaining any combination of selectors except for multiple type selectors (since an element can’t be two different types at once, and `divp` would try to select a literal `<divp>` element which doesn’t exist).
+What `.subsection.header` does is it selects any element that has both the `subsection` *and* `header` classes. Notice how there isn't any space between the `.subsection` and `.header` selectors. This syntax basically works for chaining any combination of selectors except for multiple type selectors (since `divp` would try to select a literal `<divp>` element which doesn’t exist, and either way, an element can’t be two different types at once).
 
 #### Descendant Combinator
 

--- a/foundations/html_css/css-foundations.md
+++ b/foundations/html_css/css-foundations.md
@@ -159,7 +159,7 @@ We have two elements with the `subsection` class that have some sort of unique s
 
 What `.subsection.header` does is it selects any element that has both the `subsection` *and* `header` classes. Notice how there isn't any space between the `.subsection` and `.header` selectors. This syntax basically works for chaining any combination of selectors, with the exception of type selectors.
 
-In general, type selectors can't be chained since an element can’t be two different types at once. Also, chaining two type selectors like `div` and `p`, would give us the selector `divp`. which wouldn't work since the selector would try to find a literal `<divp>` element, which doesn’t exist. 
+In general, type selectors can't be chained since an element can’t be two different types at once. Also, chaining two type selectors like `div` and `p`, would give us the selector `divp`, which wouldn't work since the selector would try to find a literal `<divp>` element, which doesn’t exist. 
 
 #### Descendant Combinator
 

--- a/foundations/html_css/css-foundations.md
+++ b/foundations/html_css/css-foundations.md
@@ -157,9 +157,9 @@ We have two elements with the `subsection` class that have some sort of unique s
 }
 ~~~
 
-What `.subsection.header` does is it selects any element that has both the `subsection` *and* `header` classes. Notice how there isn't any space between the `.subsection` and `.header` selectors. This syntax basically works for chaining any combination of selectors, with the exception of type selectors.
+What `.subsection.header` does is it selects any element that has both the `subsection` *and* `header` classes. Notice how there isn't any space between the `.subsection` and `.header` class selectors. This syntax basically works for chaining any combination of selectors, with the exception of chaining more than one type (or element) selector.
 
-In general, type selectors can't be chained since an element can’t be two different types at once. Also, chaining two type selectors like `div` and `p`, would give us the selector `divp`, which wouldn't work since the selector would try to find a literal `<divp>` element, which doesn’t exist. 
+In general, you can't chain more than one type/element selector since an element can’t be two different types at once. For example, chaining two type selectors like `div` and `p`, would give us the selector `divp`, which wouldn't work since the selector would try to find a literal `<divp>` element, which doesn’t exist. 
 
 #### Descendant Combinator
 

--- a/foundations/html_css/css-foundations.md
+++ b/foundations/html_css/css-foundations.md
@@ -157,7 +157,9 @@ We have two elements with the `subsection` class that have some sort of unique s
 }
 ~~~
 
-What `.subsection.header` does is it selects any element that has both the `subsection` *and* `header` classes. Notice how there isn't any space between the `.subsection` and `.header` selectors. This syntax basically works for chaining any combination of selectors except for multiple type selectors. For example, if you tried to chain the `div` and `p` type selectors like `divp`, then the selector would try to select a literal `<divp>` element which doesn’t exist. In general, a type selector can't be chained since an element can’t be two different types at once.
+What `.subsection.header` does is it selects any element that has both the `subsection` *and* `header` classes. Notice how there isn't any space between the `.subsection` and `.header` selectors. This syntax basically works for chaining any combination of selectors, with the exception of type selectors.
+
+In general, type selectors can't be chained since an element can’t be two different types at once. Also, if you tried to chain the `div` and `p` type selectors like `divp`, it wouldn't work since the selector would try to find a literal `<divp>` element which doesn’t exist. 
 
 #### Descendant Combinator
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [ ] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

If you lookup "multiple type selectors" on the Discord you can see some confusion about what is meant by "multiple type selectors". I reordered the sentences, included the word "syntax", and added some more detail to make it clear that the paragraph is talking about how this syntax wouldn't work for type selectors.

#### 2. Related Issue

Closes #XXXXX
