### PR TITLE
Move dev tool shortcuts into dropdowns and update them in Javascript Developer Tools lesson

### DIFF
--- a/foundations/javascript_basics/javascript_developer_tools.md
+++ b/foundations/javascript_basics/javascript_developer_tools.md
@@ -22,11 +22,19 @@ After completing this lesson, you will be able to:
 
 There are three ways to open the Developer Tools menu:
 
-1. From the Browser Menu:
-    - Chrome: Select the `Chrome Menu` > `More Tools` > `Developer Tools`
-    - Firefox: Select the Firefox `Menu` > `Web Developer`> `Toggle Tools`  
+<details open markdown="block">
+<summary><b>Chrome</b></summary>
+1. Select the `Chrome Menu` > `More Tools` > `Developer Tools`
 2. Right-click anywhere on a webpage and select `Inspect`
-3. Use the keyboard shortcut `F12` or `CTRL + Shift + C` (`option + command + C` on Mac)
+3. Use the keyboard shortcut `F12` or `Ctrl + Shift + C` (`Cmd + Opt + C` on Mac)
+</details>
+
+<details markdown="block">
+<summary><b>Firefox</b></summary>
+1. Select the `Firefox Menu` > `More tools` > `Web Developer Tools`
+2. Right-click anywhere on a webpage and select `Inspect` (or press `Q` after right-clicking)
+3. Use the keyboard shortcut `F12` or `Ctrl + Shift + I` (`Cmd + Opt + I` on Mac)
+</details>
 
 ### Assignment
 


### PR DESCRIPTION
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

...the Firefox shorcuts were outdated, and vary slightly from the Chrome shortcuts. So for the sake of organization, I moved them into dropdowns, and ensured the Chrome dropdown opens by default (due to Chrome's majority market share).
