### PR TITLE
Add a note about the HTML boilerplate shortcut

### DIFF
--- a/foundations/html_css/html-foundations/html-boilerplate.md
+++ b/foundations/html_css/html-foundations/html-boilerplate.md
@@ -135,7 +135,7 @@ Back in the `index.html` file, lets add a heading (more on these later) to the b
 Now, if you refresh the page in the browser, you should see the changes take effect, and the heading "Hello World!" will be displayed.
 
 ### VSCode Shortcut
-VSCode has a built-in shortcut you can use for generating all the boilerplate in one go. To trigger the shortcut, delete everything in the `index.html` file and just enter `!` on the first line. This will bring up a couple of options. Press the enter key to choose the first one, and voila, you should have all the boilerplate populated for you.
+VSCode has a built-in shortcut you can use for generating all the boilerplate in one go.  Please note that this shortcut only works while editing a file with the'.html' extension or a text file with the HTML language already selected. To trigger the shortcut, delete everything in the `index.html` file and just enter `!` on the first line. This will bring up a couple of options. Press the enter key to choose the first one, and voila, you should have all the boilerplate populated for you.
 
 But it's still good to know how to write the boilerplate yourself in case you find yourself using a text editor like notepad (heaven forbid) which doesn't have this shortcut. Try not to use the shortcut in your first few HTML projects, so you can build some muscle memory of how to write the boilerplate code.
 


### PR DESCRIPTION
This VSCode shortcut only works while editing an HTML file or a text file with the HTML language already selected. Students may try this shortcut with a new text file and find themselves lost when the option to insert the HTML boilerplate doesn't come up.
