### PR TITLE
Update Firefox dev tools location in JavaScript Developer Tools lesson

### DIFF
--- a/foundations/javascript_basics/javascript_developer_tools.md
+++ b/foundations/javascript_basics/javascript_developer_tools.md
@@ -24,7 +24,7 @@ There are three ways to open the Developer Tools menu:
 
 1. From the Browser Menu:
     - Chrome: Select the `Chrome Menu` > `More Tools` > `Developer Tools`
-    - Firefox: Select the Firefox `Menu` > `Web Developer`> `Toggle Tools`  
+    - Firefox: Select the Firefox `Menu` > `More Tools`> `Web Developer Tools`
 2. Right-click anywhere on a webpage and select `Inspect`
 3. Use the keyboard shortcut `F12` or `CTRL + Shift + C` (`option + command + C` on Mac)
 


### PR DESCRIPTION
Firefox's tools are located in a different menu now

<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [X] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [X] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [X] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [X] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

The current path isn't where Firefox puts its developer tools today. It is located under a different menu now. This will help users who open the menu with their mouse rather than keyboard.

#### 2. Related Issue

Closes #XXXXX