### PR TITLE
Updated Rails blog project link to reference Rails 6.1 tutorial version.

### DIFF
--- a/rails_programming/rails_basics/project_blog_app.md
+++ b/rails_programming/rails_basics/project_blog_app.md
@@ -8,7 +8,7 @@ To be honest, you're kind of going into the deep end so don't worry if you don't
 
 <div class="lesson-content__panel" markdown="1">
 
-  1. Do the [The Ruby on Rails Guides: Getting Started](http://guides.rubyonrails.org/getting_started.html) project through section 8.2, from the Rails Guides. It gives a pretty good overview of the common commands you'll use when using Rails. Section 8.3 is causing a few problems (but should be fixed soon). However, if you want to explore additional functionality of deleting or basic authentication, you can do Section 9 and 10.
+  1. Do the [The Ruby on Rails Guides: Getting Started](https://guides.rubyonrails.org/v6.1/getting_started.html) project through section 8.2, from the Rails Guides. It gives a pretty good overview of the common commands you'll use when using Rails. Section 8.3 is causing a few problems (but should be fixed soon). However, if you want to explore additional functionality of deleting or basic authentication, you can do Section 9 and 10.
   2. You should have Rails installed already so section 3.1 might not be relevant. It still might be prudent to run the `--version` commands to check you have everything you need though.
   3. Make sure you commit to git regularly so if you run into any issues you can revert to an earlier commit without having to start over from scratch. As a rough guide look to commit at the end of each section.
   4. Pay attention to any error messages you get as you build the app, even though they'll be unplanned.  You'll see all these messages again and again when you're building Rails apps, so it's helpful to start getting familiar with which portions of the message you should pay attention to (and maybe put into Google if you can't figure out what caused it).


### PR DESCRIPTION

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

Currently, the rails blog project link points to Rails version 7 whereas the course currently asks individuals to run Rails 6.1. This change corrects the link to point to the rails 6.1 blog tutorial to avoid learner confusion or errors due to the tutorial being done in a different version of Rails.
#### 2. Related Issue

N/A
