### PR TITLE
Changed Git setup to reflect the latest SSH ed25519 recommendations from Github Docs

### DIFF
--- a/foundations/installations/setting_up_git.md
+++ b/foundations/installations/setting_up_git.md
@@ -136,10 +136,10 @@ An SSH key is a cryptographically secure identifier. It's like a really long pas
 First, we need to see if you have an ed25519 SSH key already installed. Type this into the terminal and check the output with the information below:
 
 ~~~bash
-ls ~/.ssh/id_rsa.pub
+ls ~/.ssh/id_ed25519.pub
 ~~~
 
-If a message appears in the console containing the text "No such file or directory", then you do not yet have an SSH key, and you will need to create one. If no such message has appeared in the console output, you already have a key and can proceed to step 2.4.
+If a message appears in the console containing the text "No such file or directory", then you do not yet have an ed25519 SSH key, and you will need to create one. If no such message has appeared in the console output, you can proceed to step 2.4.
 
 To create a new SSH key, run the following command inside your terminal. The `-C` flag followed by your email address ensures that GitHub knows who you are. 
 

--- a/foundations/installations/setting_up_git.md
+++ b/foundations/installations/setting_up_git.md
@@ -133,13 +133,13 @@ Go to [GitHub.com](https://github.com/) and create an account! If you already ha
 
 An SSH key is a cryptographically secure identifier. It's like a really long password used to identify your machine. GitHub uses SSH keys to allow you to upload to your repository without having to type in your username and password every time.
 
-First, we need to see if you have an ed25519 SSH key already installed. Type this into the terminal and check the output with the information below:
+First, we need to see if you have an Ed25519 algorithm SSH key already installed. Type this into the terminal and check the output with the information below:
 
 ~~~bash
 ls ~/.ssh/id_ed25519.pub
 ~~~
 
-If a message appears in the console containing the text "No such file or directory", then you do not yet have an ed25519 SSH key, and you will need to create one. If no such message has appeared in the console output, you can proceed to step 2.4.
+If a message appears in the console containing the text "No such file or directory", then you do not yet have an Ed25519 SSH key, and you will need to create one. If no such message has appeared in the console output, you can proceed to step 2.4.
 
 To create a new SSH key, run the following command inside your terminal. The `-C` flag followed by your email address ensures that GitHub knows who you are. 
 
@@ -166,7 +166,7 @@ Now you need to copy your public SSH key. To do this, we're going to use a comma
 cat ~/.ssh/id_ed25519.pub
 ~~~
 
-Highlight and copy the output, which starts with `ssh-rsa` and ends with your email address. 
+Highlight and copy the output, which starts with `ssh-ed25519` and ends with your email address. 
 
 Now, go back to GitHub in your browser window and paste the key you copied into the key field. Then, click `Add SSH key`. You're done! You've successfully added your SSH key!
 

--- a/foundations/installations/setting_up_git.md
+++ b/foundations/installations/setting_up_git.md
@@ -143,10 +143,10 @@ If a message appears in the console containing the text "No such file or directo
 
 To create a new SSH key, run the following command inside your terminal. The `-C` flag followed by your email address ensures that GitHub knows who you are. 
 
-**Note:** The angle brackets (`< >`) in the code snippet below indicate that you should replace that part of the command with the appropriate information. Do not include the brackets themselves in your command. For example, if your email address is `odin@theodinproject.com`, then you would type `ssh-keygen -C odin@theodinproject.com`. You will see this convention of using angle brackets to indicate placeholder text used throughout The Odin Project's curriculum and other coding websites, so it's good to be familiar with what it means.
+**Note:** The angle brackets (`< >`) in the code snippet below indicate that you should replace that part of the command with the appropriate information. Do not include the brackets themselves in your command. For example, if your email address is `odin@theodinproject.com`, then you would type `ssh-keygen -t ed25519 -C odin@theodinproject.com`. You will see this convention of using angle brackets to indicate placeholder text used throughout The Odin Project's curriculum and other coding websites, so it's good to be familiar with what it means.
 
 ~~~bash
-ssh-keygen -C <youremail>
+ssh-keygen -t ed25519 -C <youremail>
 ~~~
 
 * When it prompts you for a location to save the generated key, just push `Enter`.

--- a/foundations/installations/setting_up_git.md
+++ b/foundations/installations/setting_up_git.md
@@ -133,7 +133,7 @@ Go to [GitHub.com](https://github.com/) and create an account! If you already ha
 
 An SSH key is a cryptographically secure identifier. It's like a really long password used to identify your machine. GitHub uses SSH keys to allow you to upload to your repository without having to type in your username and password every time.
 
-First, we need to see if you have an SSH key already installed. Type this into the terminal and check the output with the information below:
+First, we need to see if you have an ed25519 SSH key already installed. Type this into the terminal and check the output with the information below:
 
 ~~~bash
 ls ~/.ssh/id_rsa.pub

--- a/foundations/installations/setting_up_git.md
+++ b/foundations/installations/setting_up_git.md
@@ -163,7 +163,7 @@ Next, on the left-hand side, click `SSH and GPG keys`. Then, click the green but
 Now you need to copy your public SSH key. To do this, we're going to use a command called [`cat`](http://www.linfo.org/cat.html) to read the file to the console. (Note that the `.pub` file extension is important in this case.)
 
 ~~~bash
-cat ~/.ssh/id_rsa.pub
+cat ~/.ssh/id_ed25519.pub
 ~~~
 
 Highlight and copy the output, which starts with `ssh-rsa` and ends with your email address. 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [X] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [X] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [X] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [X] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [X] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

Changed the lesson to setup an SSH with an Ed25519 algorithm. This is the latest method in the Github Docs. https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent

In the current version it's RSA focused. It also states that if after the command `ls ~/.ssh/id_rsa.pub` the terminal shows: “No such file or directory”, there's no SSH key present. This is incorrect as it merely means there's no id_rsa.pub, we don't know with that command if the directory is present, and we only searched for an id_rsa.pub file, not the other options like Ecdsa or Ed25519. Changing this to specify exactly what we were looking for, namely an id_ed25519.pub version in this change, makes this part correct. 

Currently there are quite a few help requests on discord from people who state that they already have an SSH key but who still get the  “No such file or directory”. These threads and proposed solutions often end up in generating a new RSA key through TOP instructions while they might already have an Ed25519 installed from different tutorials for example.

Long story short, I think this update is more current and more correct with the Ed25519 focus. Plus it might lead to fewer help requests with the incorrect conslusion from the “No such file or directory” reworded. 

This issue and the proposed changes have been discussed in discord with BriggsE here: https://discord.com/channels/505093832157691914/931168767281610832/931170082674065459

Some decisions were made in the linked Discord thread regarding the choice for Ed25519 specifically and thus diverting a bit from the Github Docs for simplicity's sake.

#### 2. Related Issue
N/A

Closes #XXXXX
