### PR TITLE
Update flexbox.md to improve readability

### DIFF
--- a/foundations/html_css/flexbox/flexbox-axes.md
+++ b/foundations/html_css/flexbox/flexbox-axes.md
@@ -30,7 +30,7 @@ One thing to note is that in this example, `flex-direction: column` would not wo
 
 The reason for this is that the <span id='row-flex-basis'> flex shorthand expands `flex-basis` to `0`, which means that all `flex-grow`ing and `flex-shrink`ing would begin their calculations from `0`.</span> Empty divs by default have 0 height, so for our flex items to fill up the height of their container, they don't actually need to have any height at all.
 
-The example above fixed this by specifying `flex: 1 1 auto`, telling the flex items to default to their given `height`. We could also have fixed it by putting a height on the `.flex-container`, or by using `flex-grow: 1` instead of the shorthand.
+The example above fixed this by specifying `flex: 1 1 auto`, telling the flex items to default to their given `height`. We could also have fixed it by putting a height on the parent `.flex-container`, or by using `flex-grow: 1` instead of the shorthand.
 
 Another detail to notice: when we changed the <span id='column-flex-basis'>flex-direction to `column`, `flex-basis` referred to `height` instead of `width`.</span> Given the context this may be obvious, but it's something to be aware of.
 


### PR DESCRIPTION
Added the word `parent` when describing where to add the height attribute, so it isn't confused with the existing child height attribute in the CSS code.

<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [ X ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [ X ] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [n/a ] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [n/a ] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [n/a ] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

When reading this lesson, the part "We could also have fixed it by putting a height on the .flex-container," was a bit confusing because the CSS in the CodePen window above already had a `height: 80px;` entry. Upon re-reading it became clear this meant the parent `.flex-container` rather than the '.flex-container div' section of the CSS, however the prior sentence had been talking about the child section so it was anticipated that is where this sentence meant also. 

Adding the word `parent` to that sentence will help make this clearer. Students will still have to refer to the CSS to see where this `height` solution would be placed, so this edit does not take anything away anything from the learning process.

#### 2. Related Issue

n/a

