### PR TITLE
Fixes dead link in the HTML and CSS/CSS Basics lesson

### DIFF
--- a/html_css/css_basics.md
+++ b/html_css/css_basics.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-This again should represent a review from what you've already covered in the [Foundations Lesson on HTML/CSS](/courses/foundations/lessons/html-and-css-basics), but if you're unable to answer the questions posed below in the "Learning Outcomes" section, you could probably benefit from the review of the basic stuff.
+This again should represent a review from what you've already covered in the [Foundations Lesson on HTML/CSS](/courses/foundations/lessons/introduction-to-html-and-css), but if you're unable to answer the questions posed below in the "Learning Outcomes" section, you could probably benefit from the review of the basic stuff.
 
 ### Learning Outcomes
 


### PR DESCRIPTION
There is no "html-and-css-basics" lesson in foundations. I believe the lesson that is meant to be here is "introduction-to-html-and-css".

<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

There is no "html-and-css-basics" lesson in foundations. I believe the lesson that is meant to be here is "introduction-to-html-and-css". The change is necessary/important because the link is broken so some users may not know where they are supposed to go.

#### 2. Related Issue
N/A?
