### PR TITLE
Remove firefox mentions from various lessons #

### DIFF
--- a/foundations/html_css/html-foundations/html-boilerplate.md
+++ b/foundations/html_css/html-foundations/html-boilerplate.md
@@ -110,10 +110,13 @@ To complete the boilerplate, add a body element to the `index.html` file. The bo
 
 The HTML boilerplate in the `index.html` file is complete at this point, but how do you view it in the browser?  There are a couple of different options:
 
-1. You can drag and drop an HTML file from your text editor into the address bar of your favorite browser.
+> A note:
+> In order to avoid branching our lesson's instructions to accomodate for all of the differences between browsers, we are going to be using Google Chrome as our primary browser for the remainder of this course.  All references to the browser will pertain specifically to google chrome.  We **strongly** suggest that you use Google Chrome for all of your testing going forward.  
+
+1. You can drag and drop an HTML file from your text editor into the address bar of your browser.
 2. You can find the HTML file in your file system and then double click it. This will open up the file in the default browser your system uses.
 3. You can use the terminal to open the file in your browser.
-   * `Ubuntu` - Navigate to the directory containing the file and use `firefox index.html` or `google-chrome index.html`
+   * `Ubuntu` - Navigate to the directory containing the file and use `google-chrome index.html`
    * `macOS` - Navigate to the directory containing the file and use `open ./index.html`
 
 Using one of the methods above, open up the index.html file we have been working on. You'll notice the screen is blank. This is because we don't have anything in our body to display.

--- a/foundations/html_css/inspecting-html-and-css/inspecting-html-and-css.md
+++ b/foundations/html_css/inspecting-html-and-css/inspecting-html-and-css.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-Being able to inspect and debug your HTML and CSS is critical to frontend development. This lesson will take us through the Chrome Dev Tools, which allow you to see detailed information about your elements and CSS rules, as well as assist you in finding and fixing problems in your code. If you're using Firefox or some other non-Chrome browser, you can follow along, as the majority of the tools look and function similarly for each browser, but you may need to Google a bit or check out the documentation for your browser of choice if you get stuck.
+Being able to inspect and debug your HTML and CSS is critical to frontend development. This lesson will take us through the Chrome Dev Tools, which allow you to see detailed information about your elements and CSS rules, as well as assist you in finding and fixing problems in your code.
 
 ### Learning Outcomes
 
@@ -44,12 +44,6 @@ In the below image, we have altered the value of `margin-bottom` in the `.hero__
 - [Open Chrome DevTools](https://developer.chrome.com/docs/devtools/open/): similar to what we went over above, but with some nice extras.
 - [CSS](https://developer.chrome.com/docs/devtools/#css): be sure to follow along with any interactive instructions! Note that while you haven't used CSS Grid yet, you should still read the "Inspect CSS Grid" section in order to be familiar with how to inspect it in case you see it in the wild.
 - [Get Started With Viewing And Changing The DOM](https://developer.chrome.com/docs/devtools/dom/): skip through any part that uses the JavaScript console.
-
-For Firefox users:
-
-- [Firefox Dev Tools](https://developer.mozilla.org/en-US/docs/Tools)
-- [Style Editor](https://developer.mozilla.org/en-US/docs/Tools/Style_Editor)
-- [Page Inspector](https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector)
 </div>
 
 ### Additional Resources

--- a/foundations/javascript_basics/javascript_developer_tools.md
+++ b/foundations/javascript_basics/javascript_developer_tools.md
@@ -24,7 +24,6 @@ There are three ways to open the Developer Tools menu:
 
 1. From the Browser Menu:
     - Chrome: Select the `Chrome Menu` > `More Tools` > `Developer Tools`
-    - Firefox: Select the Firefox `Menu` > `More Tools`> `Web Developer Tools`
 2. Right-click anywhere on a webpage and select `Inspect`
 3. Use the keyboard shortcut `F12` or `CTRL + Shift + C` (`option + command + C` on Mac)
 
@@ -55,7 +54,6 @@ Google has updated some of the required sections in the below tutorials and some
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
 1. Learn 14 tips and tricks in this [JavaScript 30 Video](https://www.youtube.com/watch?v=xkzDaKwinA8) by Wes Bos
-1. Learn the new Firefox Dev Tools in this [Video](https://youtu.be/yznVkCuohGg) by Wes Bos
 
 ### Knowledge Check 
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.

--- a/html_css/accessibility/accessibility_auditing.md
+++ b/html_css/accessibility/accessibility_auditing.md
@@ -2,8 +2,6 @@
 
 By now you should feel confident enough to start making your websites a little more accessible for a lot of users. What can really help you make sure you're implementing certain a11y features correctly, though, is learning how to view the accessibility tree in your DevTools and how to audit your web pages for any outstanding a11y issues.
 
-This lesson covers both Chrome and Firefox, since there is a significant enough difference between both browsers' accessibility DevTools. Since Microsoft Edge is now Chromium-based (as of versions released in January 2020 and after), many if not all accessibility features for the Chrome DevTools mentioned in this lesson should also work in Edge.
-
 ### Learning Outcomes
 By the end of this lesson, you should be able to:
 
@@ -18,9 +16,9 @@ Using your browser's DevTools is beyond useful for several things, from checking
 
 There are plenty of third party tools to audit the accessibility of a web page, each with their own pros and cons, though we're only going to mention three of those tools here. By getting into the habit of auditing your web pages, you'll be able to track down any outstanding a11y issues that you may have missed. If you decide to utilize one of these tools, or another auditing tool if you prefer one you come across, you should focus on fixing issues related to the concepts introduced in these lessons only for now.
 
-* [axe DevTools for Chrome](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US) and [axe for Firefox](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/) are extension-based tools that return a list of issues ranked by severity level, and will note any issues for you to manually check.
+* [axe DevTools for Chrome](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US) is an extension-based tool that returns a list of issues ranked by severity level, and will note any issues for you to manually check.
 
-* [Lighthouse for Chrome](https://developers.google.com/web/tools/lighthouse) is available in the Chrome DevTools by default (it might also be listed as the Auditing tab) or it can be ran from the command line. The [Lighthouse Firefox Addon](https://addons.mozilla.org/en-US/firefox/addon/google-lighthouse/) is also available. Lighthouse provides more than just a11y auditing, including performance, best practices, search engine optimization (SEO), and progressive web app (PWA) if applicable. Any issues will be separated by category, and like the axe DevTools there may be a list of issues for you to manually check.
+* [Lighthouse for Chrome](https://developers.google.com/web/tools/lighthouse) is available in the Chrome DevTools by default (it might also be listed as the Auditing tab) or it can be ran from the command line. Lighthouse provides more than just a11y auditing, including performance, best practices, search engine optimization (SEO), and progressive web app (PWA) if applicable. Any issues will be separated by category, and like the axe DevTools there may be a list of issues for you to manually check.
 
 * [WebAIM's WAVE](https://wave.webaim.org/) is a website based tool where you enter the URL of the page you want to audit, though there are also browser extension and API options. WAVE will return a preview of the page with an overlay if icons on it, and issues are separated into categories of alerts, warnings, and contrast errors. Unfortunately the icons that are placed on the page may cause the layout to break, but that could be a minor issue if you're more focused on the a11y issues that are found.
 
@@ -29,16 +27,11 @@ Of course, one of the best ways to check the accessibility of your websites is t
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">
-1. If your primary browser is Chrome, read the following resources:
+1. Read the following resources:
     * [Accessibility features reference](https://developer.chrome.com/docs/devtools/accessibility/reference/#pane), starting from the Accessibility pane section, provides a brief overview of Chrome's accessibility features in the DevTools. 
     * [Emulate vision deficiencies](https://developer.chrome.com/blog/new-in-devtools-83/#vision-deficiencies) from the Chrome 83 update page. 
     * The [Open the Issues tab](https://developer.chrome.com/docs/devtools/issues/#open) section. You can ignore any mentions of anything that isn't accessibility related on this page, as we just want you to know how to open this tab in your DevTools. Once you do, you'll be able to see a11y issues in addition to any other issues found.
     * Although there will be differences between the browsers, such as the value of the role property or how a11y properties are presented, also check out the "Features of the Accessibility panel" section mentioned below for MDN's documentation. There is some useful information that, while more tailored to Firefox, can still be useful to a Chrome user.
-2. If your primary browser is Firefox, read through the following sections on [MDN's Accessibility Inspector](https://developer.mozilla.org/en-US/docs/Tools/Accessibility_inspector):
-    * "Features of the Accessibility panel": Focus only on the name, role, value, description, states, and relations properties. For Chrome, states are presented within the Computed Properties of the Devtools, and relations are listed as several properties within the name property (`aria-labelledby`, `aria-label`, etc.).
-    * "Check for accessibility issues"
-    * "Simulate"
-    * "Accessibility picker"
 </div>
 
 ### Additional Resources

--- a/html_css/accessibility/accessible_colors.md
+++ b/html_css/accessibility/accessible_colors.md
@@ -32,7 +32,7 @@ At this point you might be thinking, "18.66 pixels? 4.5:1? How the heck am I sup
 
 [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/) is a fantastic tool for checking contrast ratios. Just enter the HEX code of the foreground and background colors and it calculates what conformance levels, if any, the contrast ratio passes. The page also has a link for a link contrast checker, which goes over what the contrast ratio should be if a text link isn't underlined.
 
-You can also check the contrast ratio of the text within an element using your browser's dev tools. In **Chrome**, you would click the "element picker" tool in the Elements tab, then hover over an element on the web page. You can do the same thing in **Firefox**, except you have to click the "accessible object picker" tool in the Accessibility tab instead. For both browsers, if you select an element with text in the Inspector (Firefox) or Elements (Chrome) tab, you can click on the color picker tool for the "color" property under Styles to view the contrast ratio as well.
+You can also check the contrast ratio of the text within an element using your browser's dev tools. In **Chrome**, you would click the "element picker" tool in the Elements tab, then hover over an element on the web page. If you select an element with text in the Elements tab, you can click on the color picker tool for the "color" property under Styles to view the contrast ratio as well.
 
 ### Conveying Information
 

--- a/html_css/accessibility_auditing.md
+++ b/html_css/accessibility_auditing.md
@@ -2,8 +2,6 @@
 
 By now you should feel confident enough to start making your websites a little more accessible for a lot of users. What can really help you make sure you're implementing certain a11y features correctly, though, is learning how to view the accessibility tree in your DevTools and how to audit your web pages for any outstanding a11y issues.
 
-This lesson covers both Chrome and Firefox, since there is a significant enough difference between both browsers' accessibility DevTools. Since Microsoft Edge is now Chromium-based (as of versions released in January 2020 and after), many if not all accessibility features for the Chrome DevTools mentioned in this lesson should also work in Edge.
-
 ### Learning Outcomes
 By the end of this lesson, you should be able to:
 
@@ -18,9 +16,9 @@ Using your browser's DevTools is beyond useful for several things, from checking
 
 There are plenty of third party tools to audit the accessibility of a web page, each with their own pros and cons, though we're only going to mention three of those tools here. By getting into the habit of auditing your web pages, you'll be able to track down any outstanding a11y issues that you may have missed. If you decide to utilize one of these tools, or another auditing tool if you prefer one you come across, you should focus on fixing issues related to the concepts introduced in these lessons only for now.
 
-* [axe DevTools for Chrome](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US) and [axe for Firefox](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/) are extension-based tools that return a list of issues ranked by severity level, and will note any issues for you to manually check.
+* [axe DevTools for Chrome](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US) is an extension-based tool that returns a list of issues ranked by severity level, and will note any issues for you to manually check.
 
-* [Lighthouse for Chrome](https://developers.google.com/web/tools/lighthouse) is available in the Chrome DevTools by default (it might also be listed as the Auditing tab) or it can be ran from the command line. The [Lighthouse Firefox Addon](https://addons.mozilla.org/en-US/firefox/addon/google-lighthouse/) is also available. Lighthouse provides more than just a11y auditing, including performance, best practices, search engine optimization (SEO), and progressive web app (PWA) if applicable. Any issues will be separated by category, and like the axe DevTools there may be a list of issues for you to manually check.
+* [Lighthouse for Chrome](https://developers.google.com/web/tools/lighthouse) is available in the Chrome DevTools by default (it might also be listed as the Auditing tab) or it can be ran from the command line. Lighthouse provides more than just a11y auditing, including performance, best practices, search engine optimization (SEO), and progressive web app (PWA) if applicable. Any issues will be separated by category, and like the axe DevTools there may be a list of issues for you to manually check.
 
 * [WebAIM's WAVE](https://wave.webaim.org/) is a website based tool where you enter the URL of the page you want to audit, though there are also browser extension and API options. WAVE will return a preview of the page with an overlay of icons on it, and issues are separated into categories of alerts, warnings, and contrast errors. Unfortunately the icons that are placed on the page may cause the layout to break, but that could be a minor issue if you're more focused on the a11y issues that are found.
 
@@ -29,16 +27,11 @@ Of course, one of the best ways to check the accessibility of your websites is t
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">
-1. If your primary browser is Chrome, read the following resources:
+1. Read the following resources:
     * [Accessibility features reference](https://developer.chrome.com/docs/devtools/accessibility/reference/#pane), starting from the Accessibility pane section, provides a brief overview of Chrome's accessibility features in the DevTools. 
     * [Emulate vision deficiencies](https://developer.chrome.com/blog/new-in-devtools-83/#vision-deficiencies) from the Chrome 83 update page. 
     * The [Open the Issues tab](https://developer.chrome.com/docs/devtools/issues/#open) section. You can ignore any mentions of anything that isn't accessibility related on this page, as we just want you to know how to open this tab in your DevTools. Once you do, you'll be able to see a11y issues in addition to any other issues found.
     * Although there will be differences between the browsers, such as the value of the role property or how a11y properties are presented, also check out the "Features of the Accessibility panel" section mentioned below for MDN's documentation. There is some useful information that, while more tailored to Firefox, can still be useful to a Chrome user.
-2. If your primary browser is Firefox, read through the following sections on [MDN's Accessibility Inspector](https://developer.mozilla.org/en-US/docs/Tools/Accessibility_inspector):
-    * "Features of the Accessibility panel": Focus only on the name, role, value, description, states, and relations properties. For Chrome, states are presented within the Computed Properties of the Devtools, and relations are listed as several properties within the name property (`aria-labelledby`, `aria-label`, etc.).
-    * "Check for accessibility issues"
-    * "Simulate"
-    * "Accessibility picker"
 </div>
 
 ### Additional Resources


### PR DESCRIPTION
 - [ x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [ x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [ x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [ x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [ x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

This PR removes all mentions of Firefox from the bottom 6 lessons in issue #23306.  I also added a brief note in the first lesson that has people working with browsers (html-boilerplate.md) to highlight that learners should be using Google Chrome.  

#### 2. Related Issue
#23306 

