### PR TITLE
Capitalize "html" in JavaScript Developer Tools lesson for consistency

### DIFF
--- a/foundations/javascript_basics/javascript_developer_tools.md
+++ b/foundations/javascript_basics/javascript_developer_tools.md
@@ -9,7 +9,7 @@ After completing this lesson, you will be able to:
 - View and change the DOM
 - Debug JavaScript 
 - Use breakpoints
-- View and edit html in the Elements tab
+- View and edit HTML in the Elements tab
 - View the Resources Panel to check the scripts running on a website 
 - Add CSS Pseudostate to a Class
 - View CSS Properties in Alphabetical Order


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

The changes change "html" to "HTML" for consistency. Having HTML not be capitalized is a bit confusing and it helps the quality of the lesson overall.

#### 2. Related Issue
No issue open is related to this PR.
