### PR TITLE
Included backslash in 'fieldset' example under Intermediate HTML and CSS: Form Basics

### DIFF
--- a/html_css/intermediate_html/form-basics.md
+++ b/html_css/intermediate_html/form-basics.md
@@ -408,7 +408,7 @@ To create a fieldset, we use the `<fieldset>` element. Whatever form inputs we w
 
   <label for="last_name">Last Name</label>
   <input type="text" id="last_name" name="last_name">
-<fieldset>
+</fieldset>
 ~~~
 
 **Legend**


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

There was no backslash for the fieldset, so it didn't render as expected in html.

#### 2. Related Issue

No related issues
