### PR TITLE
changed "radio" to "checkbox" in checkbox Topic

### DIFF
--- a/html_css/intermediate_html/form-basics.md
+++ b/html_css/intermediate_html/form-basics.md
@@ -309,22 +309,22 @@ To create a checkbox, we use the input element with a type attribute of "checkbo
 <h1>Pizza Toppings</h1>
 
 <div>
-  <input type="radio" id="child" name="topping" value="sausage">
+  <input type="checkbox" id="child" name="topping" value="sausage">
   <label for="sausage">Sausage</label>
 </div>
 
 <div>
-  <input type="radio" id="onions" name="topping" value="onions">
+  <input type="checkbox" id="onions" name="topping" value="onions">
   <label for="onions">Onions</label>
 </div>
 
 <div>
-  <input type="radio" id="pepperoni" name="topping" value="pepperoni">
+  <input type="checkbox" id="pepperoni" name="topping" value="pepperoni">
   <label for="pepperoni">Pepperoni</label>
 </div>
 
 <div>
-  <input type="radio" id="mushrooms" name="topping" value="mushrooms">
+  <input type="checkbox" id="mushrooms" name="topping" value="mushrooms">
   <label for="mushrooms">Mushrooms</label>
 </div>
 ~~~


### PR DESCRIPTION
The type was "radio" in the Pizza Toppins example. I believe it is a mistake and that the type should've been checkboxes because if the toppings are type "radio" then user can select only one topping, however, the user should be able to select as many.

<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

Removed conflict from the example.
In the checkboxes topic, the example Pizza Topping should contain the input type "checkbox" however, it contains type "radio" which I believe is incorrect. Therefore, it should be changed.

#### 2. Related Issue

Closes #XXXXX
