### PR TITLE
fix css function name to match lesson in css_math_functions.md

### DIFF
--- a/html_css/intermediate_css/css_math_functions.md
+++ b/html_css/intermediate_css/css_math_functions.md
@@ -14,7 +14,7 @@ In this lesson, we’ll cover the basics of what a function is and some common w
 As in other programming languages, functions are reusable pieces of code which perform specific tasks. Functions are passed “arguments” between parentheses, each of which is used by the function in a specific way. Some common examples are:
 
 ~~~css
-color: hsl(230, 100%, 50%);
+color: rgb(230, 100%, 50%);
 background: linear-gradient(90deg, blue, red);
 ~~~
 

--- a/html_css/intermediate_css/css_math_functions.md
+++ b/html_css/intermediate_css/css_math_functions.md
@@ -14,7 +14,7 @@ In this lesson, we’ll cover the basics of what a function is and some common w
 As in other programming languages, functions are reusable pieces of code which perform specific tasks. Functions are passed “arguments” between parentheses, each of which is used by the function in a specific way. Some common examples are:
 
 ~~~css
-color: rgb(230, 100%, 50%);
+color: rgb(0, 42, 255);
 background: linear-gradient(90deg, blue, red);
 ~~~
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

Lesson uses hsl() function in the code block but references rgb() below in the explanation text. Changed the code block to use RGB function instead.

<img width="738" alt="css_math_functions" src="https://user-images.githubusercontent.com/20146375/150921723-24aecfe5-442e-4ba7-9e8c-7fb8853de1d0.png">


#### 2. Related Issue

Closes #XXXXX
