### PR TITLE
Fix incorrect youtube link in Intermediate HTML and CSS FORM VALIDATION assignment

### DIFF
--- a/html_css/intermediate_html/form-validations.md
+++ b/html_css/intermediate_html/form-validations.md
@@ -187,7 +187,7 @@ It's also worth noting client-side validations are not a silver bullet for ensur
 
 1. Read and follow along to [MDN's Client-Side Form Validation Guide](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation)
 2. SitePoint's [Complete Guide to HTML Forms and Constraint Validation Guide](https://www.sitepoint.com/html-forms-constraint-validation-complete-guide/)
-3. Watch [Web Dev Simplified's JavaScript Form Validations Tutorial](https://www.youtube.com/watch?v=Dorf8i6lCuk)
+3. Watch [Web Dev Simplified's JavaScript Form Validations Tutorial](https://www.youtube.com/watch?v=In0nB0ABaUk&ab_channel=WebDevSimplified)
 4. Read CSS Tricks brilliant [Form Validation UX in HTML and CSS Guide](https://css-tricks.com/form-validation-ux-html-css/)
 
 </div>


### PR DESCRIPTION
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

Fixed link "Web Dev Simplified’s JavaScript Form Validations Tutorial" to the video from Web Dev simplified as it is currently linking to a React crash course video by Academind. This can be found in the assignment section of the Intermediate HTML and CSS FORM VALIDATION lesson.

#### 2. Related Issue

No related issue I am aware of.
