### PR TITLE
fix svg code block from ```xml to ~~~xml to display it properly

### DIFF
--- a/html_css/intermediate_html/svgs.md
+++ b/html_css/intermediate_html/svgs.md
@@ -34,12 +34,12 @@ The fact that SVG source-code is XML has a few key benefits.
 
 First, it means that it is _human readable_. If you were to open up a JPEG in a text editor, it would just look like gobbledygook. If you were to open up an SVG, however, it would look something like this:
 
-```xml
+~~~html
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
     <rect x=0 y=0 width=100 height=50 />
     <circle class="svg-circle" cx="50" cy="50" r="10"/>
 </svg>
-```
+~~~
 
 It might still be confusing, but hey--those are words! Tags! Attributes! Compared to [binary file formats](https://en.wikipedia.org/wiki/Binary_file) like JPEG, we're definitely in familiar territory.
 

--- a/html_css/intermediate_html/svgs.md
+++ b/html_css/intermediate_html/svgs.md
@@ -34,7 +34,7 @@ The fact that SVG source-code is XML has a few key benefits.
 
 First, it means that it is _human readable_. If you were to open up a JPEG in a text editor, it would just look like gobbledygook. If you were to open up an SVG, however, it would look something like this:
 
-~~~html
+~~~xml
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
     <rect x=0 y=0 width=100 height=50 />
     <circle class="svg-circle" cx="50" cy="50" r="10"/>


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

Previous code block was using ` ```xml ``` ` format which cause the code block not to display properly on the markdown. By changing to `~~~xml ~~~` format, the markdown is able to display the code snippet properly.

#### 2. Related Issue

Closes #23383
