### PR TITLE
Fix typo in Form Basics Lesson

### DIFF
--- a/html_css/intermediate_html/form-basics.md
+++ b/html_css/intermediate_html/form-basics.md
@@ -237,7 +237,7 @@ We can set one of the options to be the default selected element when the browse
 </select>
 ~~~
 
-We may also split the list of options into groups using the `<optgroup>` element. The optgroup element take a `label` attribute which the browser uses as the label for each group:
+We may also split the list of options into groups using the `<optgroup>` element. The optgroup element takes a `label` attribute which the browser uses as the label for each group:
 
 ~~~html
 <select name="fashion">


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [X] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [X] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [X] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [X] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [X] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

I changed the word "take" to "takes" in line 240 of form-basics.md I think that there was a typo since "takes" makes more sense.

Previous: "The optgroup element take a 'label' attribute..."
Change: "The optgroup element takes a 'label' attribute..."

#### 2. Related Issue

Closes #XXXXX
