### PR TITLE
Fix typos in additional resources section INTERMEDIATE CSS (2. CSS Units & 3. More Text Styles)

### DIFF
--- a/html_css/intermediate_css/css-units.md
+++ b/html_css/intermediate_css/css-units.md
@@ -32,9 +32,7 @@ The units `vh` and `vw` relate to the size of the viewport. Specifically, `1vh` 
 </div>
 
 ### Additional Resources
-This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something
-
-* []()
+This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something.
 
 ### Knowledge Check
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.

--- a/html_css/intermediate_css/more-text-styles.md
+++ b/html_css/intermediate_css/more-text-styles.md
@@ -125,8 +125,7 @@ You can see more detail and an example in [this CSS Tricks Article](https://css-
 
 
 ### Additional Resources
-This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something
-* []()
+This section contains helpful links to other content. It isn't required, so consider it supplemental for if you need to dive deeper into something.
 
 ### Knowledge Check
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.


### PR DESCRIPTION
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

Added missing periods to the end of the final sentence of Intermediate CSS lessons 2 (CSS Units) and 3 (More Text Styles). Also removed empty bullet point in that followed this sentence in lesson 2 and a "*" that followed this sentence in lesson 3.

#### 2. Related Issue

None I am aware of.
