### PR TITLE
Fixed typo in Frameworks and PreProcessors

### DIFF
--- a/html_css/intermediate_css/frameworks-preprocessors.md
+++ b/html_css/intermediate_css/frameworks-preprocessors.md
@@ -4,7 +4,7 @@ At this point, you have written quite a bit of vanilla HTML and CSS, and learned
 
 You should be aware that, at this point in your learning, both frameworks and preprocessors are options for you, but that neither of them is necessary.
 
-An important reason to know about frameworks and preprocessors is that they are are commonly found in the workplace. In addition, many job requirements include Bootstrap, SASS, and related technology. So it's helpful for you to know what these tools are, and where to look for them once you've determined you need to learn them.
+An important reason to know about frameworks and preprocessors is that they are commonly found in the workplace. In addition, many job requirements include Bootstrap, SASS, and related technology. So it's helpful for you to know what these tools are, and where to look for them once you've determined you need to learn them.
 
 ### Learning Outcomes
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

There was a single typo in the Frameworks and Preprocessors Intro.

Changed the sentence:
An important reason to know about frameworks and preprocessors is that they are are commonly found in the workplace.

To (removed the double "are"):
An important reason to know about frameworks and preprocessors is that they are commonly found in the workplace.
