### PR TITLE
Fixed typo in 'Warm-up' (was 'Warmup') heading in the JavaScript Forms lesson

### DIFF
--- a/javascript/js-in-the-real-world/forms.md
+++ b/javascript/js-in-the-real-world/forms.md
@@ -15,7 +15,7 @@ By the end of this lesson, you should be able to do the following:
 
 ### Practice
 
-### Warmup
+### Warm-up
 
 Go back to your 'Library' project and add simple validation to that form! Don't let your users submit without filling in all the fields! Don't forget to use your Git workflow skills you learned in [this foundations lesson](https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/revisiting-rock-paper-scissors) to make a new branch, work on your feature and merge it back to main when it's all done.
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [ ] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [ ] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

I fixed one of the headings in the JavaScript Forms lesson to be 'Warm-up' instead of 'Warmup', as, according to [Merriam-Webster](https://www.merriam-webster.com/dictionary/warm-up), the noun (not the verb) 'Warm-up' is indeed spelled with a hyphen.

#### 2. Related Issue

No related issues