### PR TITLE
Fixes typos in Form Basics

### DIFF
--- a/html_css/intermediate_html/form-basics.md
+++ b/html_css/intermediate_html/form-basics.md
@@ -81,7 +81,8 @@ This is done by adding a `placeholder` attribute to an input. The value will be 
 <input type="text" id="first_name" placeholder="Bob...">
 ~~~
 
-Placeholder text should be example text that demonstrates what should be entered and in what format.
+Use placeholder text to demonstrate how text should be entered and formatted. 
+//fixed awkward wording and repetitive uses of "text" and "should be". 
 
 
 <span id="the-name-attribute">**The Name Attribute**</span>
@@ -487,7 +488,7 @@ Text-based form controls like text, email, password and text areas are reasonabl
 
 Things get more tricky when creating custom styles for radio buttons and checkboxes. But there are many [guides](https://moderncss.dev/pure-css-custom-checkbox-style) out there you can use to achieve your desired design. There have also been [new CSS properties](https://developer.mozilla.org/en-US/docs/Web/CSS/accent-color) made available in recent times to make styling radio buttons and checkboxes much easier.
 
-Certain aspects of other elements are downright impossible to style, for example, calendar of date pickers. If we want custom styles for these, we will have to build custom form control with JavaScript or use one of the many JavaScript libraries that provide us with ready-made solutions.
+Certain aspects of other elements are downright impossible to style, for example, calendar or date pickers. If we want custom styles for these, we will have to build custom form controls with JavaScript or use one of the many JavaScript libraries that provide us with ready-made solutions.
 
 ### Assignment
 

--- a/html_css/intermediate_html/form-basics.md
+++ b/html_css/intermediate_html/form-basics.md
@@ -82,7 +82,6 @@ This is done by adding a `placeholder` attribute to an input. The value will be 
 ~~~
 
 Use placeholder text to demonstrate how text should be entered and formatted. 
-//fixed awkward wording and repetitive uses of "text" and "should be". 
 
 
 <span id="the-name-attribute">**The Name Attribute**</span>


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and 
 - [x] where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

The original sentence on line 84 read, "Placeholder text should be example text that demonstrates what should be entered and in what format."

"Should be" and "text" were both used twice in the same sentence making it overly wordy and hard to understand. I made the sentence active voice for brevity and clarity.

On line 490 it said "Certain aspects of other elements are downright impossible to style, for example, calendar of date pickers. It should either read "...for example, THE calendar of date pickers" or "...for example, calendar or date pickers". 

Lastly, it said "we will have to build custom form control with Javascript" and I believe control should be plural "we will have to build custom form controls with Javascript." 

#### 2. Related Issue

Closes #XXXXX
