### PR TITLE
Misspelled insensitivity and missing a comma in CSS Selectors lesson | html_css/intermediate_css/selectors.md 

### DIFF
--- a/html_css/intermediate_css/selectors.md
+++ b/html_css/intermediate_css/selectors.md
@@ -235,7 +235,7 @@ Sometimes we need to be more general in how we access these attributes. For exam
 }
 ~~~
 
-To see what other things you can achieve with attribute selectors, such as searching case insensitively, or sub-strings separated by hyphens have a browse through the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors).
+To see what other things you can achieve with attribute selectors, such as searching case insensitivity, or sub-strings separated by hyphens, have a browse through the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors).
 
 
 ### Assignment


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

Lesson "Intermediate CSS" had a typo near the end that said "insensitively" rather than case insensitivity. The sentence was also missing a comma. 

#### 2. Related Issue

Closes #XXXXX
