### PR TITLE
Add a missing /:postid in the DELETE example of API basics

### DIFF
--- a/nodeJS/APIs/APIs.md
+++ b/nodeJS/APIs/APIs.md
@@ -32,12 +32,12 @@ The actual technical definition of REST is a little complicated (you can read ab
 REST APIs are resource based, which basically means that instead of having names like `/getPostComments` or `/savePostInDatabase` we refer **directly to the resource** (in this case, the blog post) and use HTTP verbs such as GET, POST, PUT, and DELETE to determine the action.
 Typically this takes the form of 2 URI's per resource, one for the whole collection and one for a single object in that collection, for example, you might get a list of blog-posts from `/posts` and then get a specific post from `/posts/:postid`. You can also nest collections in this way. To get the list of comments on a single post you would access `/posts/:postid/comments` and then to get a single comment: `/posts/:postid/comments/:commentid`. Below are some other simple examples of endpoints you could have.
 
-| Verb   | Action | Example                                    |
-| ------ | ------ | ------------------------------------------ |
-| POST   | Create | `POST /posts` Creates a new blog post      |
-| GET    | Read   | `GET /posts/:postid` Fetches a single post |
-| PUT    | Update | `PUT /posts/:postid` Updates a single post |
-| DELETE | Delete | `DELETE /posts` Deletes a single post      |
+| Verb   | Action | Example                                            |
+| ------ | ------ | -------------------------------------------------- |
+| POST   | Create | `POST /posts` Creates a new blog post              |
+| GET    | Read   | `GET /posts/:postid` Fetches a single post         |
+| PUT    | Update | `PUT /posts/:postid` Updates a single post         |
+| DELETE | Delete | `DELETE /posts/:postid` Deletes a single post      |
 
 Each part of an API URI specifies the resource. For example, `GET /posts` would return the entire list of blog posts while `GET /posts/:postid` specifies the exact blog post we want. We could nest further with `GET /posts/:postid/comments` to return a list of comments for that blog post or even `GET /posts/:id/comments/:commentid` for a very specific blog post comment.
 


### PR DESCRIPTION
Add a missing /:postid in the DELETE example

<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

I noticed the DELETE example talking about "Deletes a single post", but it did not specify a post to delete. So I add `/:postid` params to it.
![image](https://user-images.githubusercontent.com/42641045/152081961-e2462770-dfd2-48ce-b07e-3918c9f2ada2.png)

#### 2. Related Issue

Closes #XXXXX
