### PR TITLE
Remove unnecessary knowledge check from "Introduction to Frameworks" Foundations lesson

### DIFF
--- a/foundations/the_back_end/introduction_to_frameworks.md
+++ b/foundations/the_back_end/introduction_to_frameworks.md
@@ -32,7 +32,6 @@ This section contains helpful links to other content. It isn't required, so cons
 ### Knowledge Check
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
-* <a class="knowledge-check-link" href="https://web.archive.org/web/20180402231229/https://www.wired.com/2010/02/get_started_with_web_frameworks/">What are the four general tasks that developers have to handle?</a>
 * <a class="knowledge-check-link" href="https://developer.mozilla.org/en-US/docs/Learn/Server-side/First_steps/Web_frameworks#what_can_a_web_framework_do_for_you">What problems do frameworks solve? </a>
 * <a class="knowledge-check-link" href="https://dev.to/aspittel/what-is-a-web-framework-and-why-should-i-use-one-38c0">Name some popular front-end and back-end frameworks. </a>
 * <a class="knowledge-check-link" href="https://developer.mozilla.org/en-US/docs/Learn/Server-side/First_steps/Web_frameworks#how_to_select_a_web_framework">Describe the process of choosing a framework.</a>


### PR DESCRIPTION
The lesson in question is "Introduction to Frameworks".

<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [ ] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

As per issue #23311 I have removed the first knowledge check from the lesson due to it asking to explain CRUD which is not explained in the lesson directly but otherwise the lesson makes a case for frameworks quite clearly.

#### 2. Related Issue

Closes #23311 
