### PR TITLE
Fixed heading issue for Advanced Grid lesson

### DIFF
--- a/html_css/grid-lessons/advanced_grid_properties.md
+++ b/html_css/grid-lessons/advanced_grid_properties.md
@@ -242,7 +242,7 @@ Notice how the tracks stay at `20%` of the width of the container until they hit
 
 Using `clamp()` and `minmax()` are fantastic methods for making grids more responsive while ensuring we don't hit critical breakpoints that make our website look bad. This is imperative when using images and elements that may have a tendency to overflow or render in undesirable ways when pushed to extreme sizes.
 
-### `auto-fit` and `auto-fill`
+### auto-fit and auto-fill
 
 These two values are actually a part of the `repeat()` function specification, but they were saved for the end of the lesson because their usefulness is not apparent until after you understand the `minmax()` function. Here's the use case: You want to give your grid a number of columns that is flexible based on the size of the grid. For example, if our grid is only `200px` wide, we may only want one column. If it's `400px` wide, we may want two, and so on. Solving this problem with media queries would be a _lot_ of typing. Thankfully, `auto-fit` and `auto-fill` are here to save the day!
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

The "auto-fill and auto-fit" heading showed a weird additional heading above it due to the backticks inside the h3. I removed the backticks. 

<img width="887" alt="Screen Shot 2022-02-02 at 1 47 40 PM" src="https://user-images.githubusercontent.com/46337715/152246637-75ef8b13-00bc-4b7e-afd1-19c819b5c68e.png">

#### 2. Related Issue



Closes #XXXXX
