### PR TITLE
Fixes typos, punctuation, and grammar in Foundations: Command Line Basics lesson

### DIFF
--- a/foundations/installations/command_line_basics.md
+++ b/foundations/installations/command_line_basics.md
@@ -87,7 +87,7 @@ That's it--you're done with command line basics! If you commit to doing most thi
 ### Additional Resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
-* [The art of command line](https://github.com/jlevy/the-art-of-command-line#readme) is a complete pro-maker for beginners. It serves as a open source repository. This also has a lot of protips!
+* [The Art of Command Line](https://github.com/jlevy/the-art-of-command-line#readme) is a complete pro-maker for beginners. It serves as an open-source repository. This also has a lot of pro tips!
 * The online book [Learn Enough Command Line to Be Dangerous](https://www.learnenough.com/command-line-tutorial) is a great resource for mastering the command line. Chapter 1 is free and provides a good introduction to command line tools. The rest of the book is not free and goes into more depth than you really need at this point, but feel free to purchase and read the rest of the book if you like.
 * [ExplainShell.com](http://explainshell.com/) is a great resource for if you want to deconstruct a particularly strange shell command or learn how Bash works through guess-and-check.
 * [Unix/Linux Command Cheat Sheet](https://files.fosswire.com/2007/08/fwunixref.pdf) contains a list of important commands that you can refer to regularly as you become familiar with using Linux. You can print it out so you can have a physical copy with you when you're not at your computer.

--- a/foundations/installations/command_line_basics.md
+++ b/foundations/installations/command_line_basics.md
@@ -87,7 +87,7 @@ That's it--you're done with command line basics! If you commit to doing most thi
 ### Additional Resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
-* [The Art of Command Line](https://github.com/jlevy/the-art-of-command-line#readme) is a complete pro-maker for beginners. It serves as an open-source repository. This also has a lot of pro tips!
+* [The Art of Command Line](https://github.com/jlevy/the-art-of-command-line#readme) is a complete beginner's pro-maker. It serves as an open-source repository. This also has a lot of pro tips!
 * The online book [Learn Enough Command Line to Be Dangerous](https://www.learnenough.com/command-line-tutorial) is a great resource for mastering the command line. Chapter 1 is free and provides a good introduction to command line tools. The rest of the book is not free and goes into more depth than you really need at this point, but feel free to purchase and read the rest of the book if you like.
 * [ExplainShell.com](http://explainshell.com/) is a great resource for if you want to deconstruct a particularly strange shell command or learn how Bash works through guess-and-check.
 * [Unix/Linux Command Cheat Sheet](https://files.fosswire.com/2007/08/fwunixref.pdf) contains a list of important commands that you can refer to regularly as you become familiar with using Linux. You can print it out so you can have a physical copy with you when you're not at your computer.

--- a/foundations/installations/command_line_basics.md
+++ b/foundations/installations/command_line_basics.md
@@ -68,7 +68,7 @@ On Windows and Linux, you can open VSCode from the command line by typing `code`
 
 ##### MacOS Users:
 
-MacOS can do this too, but you need to set it up. After installing VSCode, launch it any way you're comfortable with. Once it's running, open the Command palette with `CMD + Shift + P`. In the little dialog that appears, type `shell command`. One of the choices that appears will be `Shell Command: Install 'code' command in PATH`. Select that option, and restart the terminal if you have it open.
+MacOS can do this too, but you need to set it up. After installing VSCode, launch it any way you're comfortable with. Once it's running, open the Command Palette with `CMD + Shift + P`. In the little dialog that appears, type `shell command`. One of the choices that appears will be `Shell Command: Install 'code' command in PATH`. Select that option, and restart the terminal if you have it open.
 
 ### Exercise
 In this exercise, you will practice creating files and directories and deleting them. You'll need to enter the commands for this exercise in your terminal. If you can't recall how to open a terminal, scroll up for a reminder.


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

##### Line 71
- **Changes**: "Command palette" to "Command Palette"
  - The word palette is a proper noun in the line's context. For example, "Mr. smith" will be "Mr. Smith." Besides, in VS Code's menu items, it's displayed as "Command Palette."
##### Line 90
- **Changes**: [The art of command line] to [The Art of Command Line]
  - The GitHub Repo's README clearly states the name as "The Art of Command Line" 
- **Changes**: "is a complete pro-maker for beginners." to "is a complete beginner's pro-maker."
  - The rephrasing sounds strong and shows absolute certainty.
- **Changes**: "It serves as a open source repository" to "It serves as an open source repository"
  - In the line "It serves as a open source repository", "an" agrees with the sound of "open source". "an" is usually used in front of any word with a vowel.
 - **Changes**: "It serves as an open source repository." to "It serves as an open-source repository."
   - In the fixed line "It serves as an open-source repository.", "open-source" is an adjective preceding the noun "repository."
   - "Hyphenate open-source as an adjective preceding a noun, as in open-source software. Don't use open-sourced as an adjective."
      - **Source**: https://docs.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/o/open-source
 - **Changes**: "protips!" to "pro tips!"
   - "protips" doesn't fit the context, especially with "pro-maker" and "`[The art of command line](https://github.com/jlevy/the-art-of-command-line#readme)` is a complete pro-maker for beginners. It serves as an open-source repository. This also has a lot of protips!"

#### 2. Related Issue

None that I am aware of.