### PR TITLE
Removed extra 'that' in Intermediate HTML & CSS Form Basics lesson (Fixes Issue #23453)

### DIFF
--- a/html_css/intermediate_html/form-basics.md
+++ b/html_css/intermediate_html/form-basics.md
@@ -303,7 +303,7 @@ We can set the default selected radio button by adding the `checked` attribute t
 
 **Checkboxes**
 
-Checkboxes are similar to radio buttons in that that they allow users to choose from a set of predefined options. But unlike radio buttons, they allow multiple options to be selected at once.
+Checkboxes are similar to radio buttons in that they allow users to choose from a set of predefined options. But unlike radio buttons, they allow multiple options to be selected at once.
 
 To create a checkbox, we use the input element with a `type` attribute of "checkbox":
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

The following sentence: `Checkboxes are similar to radio buttons in that that that they allow users to choose from a set of predefined options.` is present in the intermediate HTML & CSS Form Basics lesson, and I think it's pretty obvious that the extra 'that' is simply a mistake, and thus, should be removed. 

#### 2. Related Issue

Closes #23453
