### PR TITLE
Fixes incorrect explanation in fundamentals-1.md

### DIFF
--- a/foundations/javascript_basics/fundamentals-1.md
+++ b/foundations/javascript_basics/fundamentals-1.md
@@ -88,7 +88,7 @@ Try the following exercises (and don't forget to use `console.log()`!):
    4. If you type `percentage` in the console and press enter you should see a value like `0.7719`
 6. Take a few minutes to keep playing around with various things in your script tag.  Eventually, we will learn how to actually make those numbers and things show up on the webpage, but all of this logic will remain the same, so make sure you're comfortable with it before moving on.
 
-_* As you might have noticed by running Javascript code in the console, the console prints the result of the code it executes (called a return statement). You will learn more about these in the next lessons, however for now it is good to remember that an assignment (such as `b = 7 * a`) returns `undefined` and so you cannot assign a value to a variable and read its value in the same line.`_
+_* As you might have noticed by running Javascript code in the console, the console prints the result of the code it executes (called a return statement). You will learn more about these in the next lessons, however for now it is good to remember that a declaration with an assignment (such as `let b = 7 * a`) returns `undefined` and so you cannot declare and assign a value to a variable and read its value in the same line.`_
 
 ### Additional Resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental.


### PR DESCRIPTION
There's a mistake in fundamentals-1. You can assign a variable to an expression and read the value immediately. It's just not possible if the variable was declared in the same line.

<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [ x ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [ x ] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [ x ] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) and reference it with the `#` sign and the issue number.
 - [ x ] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [ x ] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

There's a mistake in fundamentals-1. You can assign a variable to an expression and read the value immediately. It's just not possible if the variable was declared in the same line.

#### 2. Related Issue

Closes #XXXXX
