### PR TITLE
Fixes transform order in animations lesson.

### DIFF
--- a/html_css/animation/transforms.md
+++ b/html_css/animation/transforms.md
@@ -142,7 +142,7 @@ There are two boxes located at the same position. We chained `rotate` and `trans
 </p>
 <script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
 
-If you guessed correctly, congratulations! Otherwise, you've now learned that when chaining multiple transforms, each transform function is applied from right to left. 
+If you guessed correctly, congratulations! Otherwise, you've now learned that when chaining multiple transforms, each transform function is applied from left to right. 
 
 While you can generally chain multiple transforms in any order for various results, there is one exception: `perspective`. This brings us nicely to the next section where `perspective` is involved.
 

--- a/html_css/animation/transforms.md
+++ b/html_css/animation/transforms.md
@@ -144,7 +144,7 @@ There are two boxes located at the same position. We chained `rotate` and `trans
 
 If you guessed correctly, congratulations! But this is a tricky concept. There is a bit of debate on how to read a chain of transform functions. According to [MDN's transform docs](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#values): "The transform functions are multiplied in order from left to right, meaning that composite transforms are effectively applied in order from right to left."
 
-To learn more about the "left to right" vs "right to left" interpretations, check out this visual article on [chaining transforms.](https://codepen.io/bali_balo/post/chaining-transforms).
+To learn more about the "left to right" vs "right to left" interpretations, check out this visual article on [chaining transforms](https://codepen.io/bali_balo/post/chaining-transforms).
 
 While you can generally chain multiple transforms in any order for various results, there is one exception: `perspective`. This brings us nicely to the next section where `perspective` is involved.
 

--- a/html_css/animation/transforms.md
+++ b/html_css/animation/transforms.md
@@ -142,7 +142,9 @@ There are two boxes located at the same position. We chained `rotate` and `trans
 </p>
 <script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
 
-If you guessed correctly, congratulations! Otherwise, you've now learned that when chaining multiple transforms, each transform function is applied from left to right. 
+If you guessed correctly, congratulations! But this is a tricky concept. There is a bit of debate on how to read a chain of transform functions. According to [MDN's transform docs](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#values): "The transform functions are multiplied in order from left to right, meaning that composite transforms are effectively applied in order from right to left."
+
+To learn more about the "left to right" vs "right to left" interpretations, check out this visual article on [chaining transforms.](https://codepen.io/bali_balo/post/chaining-transforms).
 
 While you can generally chain multiple transforms in any order for various results, there is one exception: `perspective`. This brings us nicely to the next section where `perspective` is involved.
 


### PR DESCRIPTION
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

The described order for multiple transforms in the _Advanced HTML and CSS_ course (animations section) is incorrect. It is not applied from right to left, but from left to right. 

This can be observed in the codepen or see e.g. [https://riptutorial.com/css/example/4130/multiple-transforms](https://riptutorial.com/css/example/4130/multiple-transforms).

#### 2. Related Issue

No issue relating to that bug exists.
