### PR TITLE
Fix typo in Javascript Tic Tac Toe project outline

### DIFF
--- a/javascript/organizing-js/tic-tac-toe-project.md
+++ b/javascript/organizing-js/tic-tac-toe-project.md
@@ -4,7 +4,7 @@ We're making a Tic Tac Toe game you can play in your browser!
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">
-1. Set up your project with a HTML, CSS and Javascript files and get the Git repo all set up.
+1. Set up your project with HTML, CSS and Javascript files and get the Git repo all set up.
 2. You're going to store the gameboard as an array inside of a Gameboard object, so start there!  Your players are also going to be stored in objects... and you're probably going to want an object to control the flow of the game itself.
    1. Your main goal here is to have as little global code as possible.  Try tucking everything away inside of a module or factory.  Rule of thumb: if you only ever need ONE of something (gameBoard, displayController), use a module.  If you need multiples of something (players!), create them with factories.
 3. Set up your HTML and write a JavaScript function that will render the contents of the gameboard array to the webpage (for now you can just manually fill in the array with `"X"`s and `"O"`s)


### PR DESCRIPTION
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

Removed an unnecessary 'a' from step 1 in the instructions for the Javascript Tic Tac Toe project that reads "Set up your project with ***a*** HTML, CSS and Javascript files..."

#### 2. Related Issue

None I am aware of.
