### PR TITLE
removed exercise that no longer exists in repo from keyframes.md

### DIFF
--- a/html_css/animation/keyframes.md
+++ b/html_css/animation/keyframes.md
@@ -124,7 +124,6 @@ Hopefully this gives you a glimpse into the power the `@keyframes` syntax provid
 Now let's make some cool animations! Go to the [CSS exercises repository](https://github.com/TheOdinProject/css-exercises) and do the exercises in the 'animation' folder in this order:
 
 1. button-hover
-2. drop-down
 3. pop-up
 
 ### Knowledge Check

--- a/html_css/animation/keyframes.md
+++ b/html_css/animation/keyframes.md
@@ -124,7 +124,7 @@ Hopefully this gives you a glimpse into the power the `@keyframes` syntax provid
 Now let's make some cool animations! Go to the [CSS exercises repository](https://github.com/TheOdinProject/css-exercises) and do the exercises in the 'animation' folder in this order:
 
 1. button-hover
-3. pop-up
+2. pop-up
 
 ### Knowledge Check
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

Second exercise, "2. drop-down", from [keyframes](https://www.theodinproject.com/paths/full-stack-javascript/courses/advanced-html-and-css/lessons/keyframes) has been removed from the [css repository](https://github.com/TheOdinProject/css-exercises/tree/main/animation). 
This pull request removes said exercise from the curriculum to reflect the change in the css repository.

**Current keyframes.md**
<img width="755" alt="keyframes" src="https://user-images.githubusercontent.com/20146375/153295128-5673f885-7234-438f-b8c6-0be71a410c2b.png">


**Current CSS Repo:** 
<img width="890" alt="css" src="https://user-images.githubusercontent.com/20146375/153294985-71d2a684-0189-45db-821a-7b6221fb4106.png">


#### 2. Related Issue

Closes #XXXXX
