### PR TITLE
Closes #23457 remove SOLIDUS character (/) on meta tag in Foundations fundamentals 1 for consistency

### DIFF
--- a/foundations/javascript_basics/fundamentals-1.md
+++ b/foundations/javascript_basics/fundamentals-1.md
@@ -28,7 +28,7 @@ The simplest way to get started is to simply create an HTML file with the JavaSc
 <html>
 <head>
   <title>Page Title</title>
-  <meta charset="UTF-8"/>
+  <meta charset="UTF-8">
 </head>
 <body>
   <script>


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get PRs closed in a reasonable amount of time, we request that you include a baseline of information about the changes you are proposing. Please complete each applicable checkbox and answer the following triage questions:
-->

 - [X] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [X] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [X] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) and reference it with the `#` sign and the issue number.
 - [X] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [X] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

I removed the Solidus (/) character in the html skeleton meta tag of the fundamentals part 1 lesson.

I think this is important because:
In the [Fundamentals part 1 lesson](https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/fundamentals-part-1) we get instructed to type the basic html skeleton of which the preview is not consistent with the boilerplate we had to memorise [in this lesson](https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/html-boilerplate) since the memorised version does not include the (optional) solidus.

#### 2. Related Issue

Closes #23457
