### PR TITLE
Remove CodePen link in Intermediate CSS - CSS Functions

### DIFF
--- a/html_css/intermediate_css/css_math_functions.md
+++ b/html_css/intermediate_css/css_math_functions.md
@@ -55,9 +55,9 @@ To put it another way:  `main = 100vh - (header + footer)`.
 `calc()` is handling the math for us even though we are mixing vh, rem and px units.
 Combined with CSS variables, `calc()` can save us from the headache of repeating CSS rules.
 
-**Note:** The above is just an example of how `calc()` can affect a layout, but keep in mind that `calc()` is likely not the best way to go about it. We will talk more about layouts in future lessons.
+I encourage you to take a moment and edit the CodePen above to understand how `calc()` is being used. Play around with the different units and sizes of the elements and see what results you get before moving on.
 
-I encourage you to take a moment and edit the codepen. Play around with the different units and sizes of the elements by clicking here: <img src="https://imgur.com/a/9iDhtL0" alt="editCodePen">
+**Note:** The above is just an example of how `calc()` can affect a layout, but keep in mind that `calc()` is likely not the best way to go about it. We will talk more about layouts in future lessons.
 
 #### min()
 

--- a/html_css/intermediate_css/css_math_functions.md
+++ b/html_css/intermediate_css/css_math_functions.md
@@ -55,7 +55,7 @@ To put it another way:  `main = 100vh - (header + footer)`.
 `calc()` is handling the math for us even though we are mixing vh, rem and px units.
 Combined with CSS variables, `calc()` can save us from the headache of repeating CSS rules.
 
-I encourage you to take a moment and edit the CodePen above to understand how `calc()` is being used. Play around with the different units and sizes of the elements and see what results you get before moving on.
+You should be able to grasp how `calc()` is used in the above CodePen embed. We encourage you to play around with different units and sizes of the elements to see what results you get before moving on.
 
 **Note:** The above is just an example of how `calc()` can affect a layout, but keep in mind that `calc()` is likely not the best way to go about it. We will talk more about layouts in future lessons.
 


### PR DESCRIPTION
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

Removed the Edit CodePen link in the CSS Functions lesson of INTERMEDIATE CSS. Edited line 60 to instruct the reader to refer to the embedded CodePen above and moved the paragraph up to line 58.

#### 2. Related Issue

Closes #23404
