### PR TITLE
Remove extra space - macOS dropdown - node install

### DIFF
--- a/foundations/javascript_basics/installing_nodejs.md
+++ b/foundations/javascript_basics/installing_nodejs.md
@@ -49,7 +49,6 @@ if this returns `nvm: command not found`, close the terminal and re-open it.
 
 <details markdown="block">
   <summary class="dropDown-header">Installation on macOS</summary>
-  <br/>
   
 On macOS 10.15 and above, the default shell is now zsh. During installation, nvm will look for a `.zshrc` file in your user home directory. By default, this file does not exist so we need to create it.
 


### PR DESCRIPTION
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md).
 - [x] The title summarizes the change and where it happened, for example: "Fixes punctuation in Clean Code lesson".
 - [x] If the PR is related to an open issue, use a [relevant keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) and reference it with the `#` sign and the issue number.
 - [x] You have previewed your markdown (if any) in the [Odin Markdown Preview Tool](https://www.theodinproject.com/lessons/preview)
 - [x] If changes are requested, please make the changes in a timely manner. After you submit the changes, request another review from the maintainer (top right).

#### 1. Describe the changes made and include why they are necessary or important:

There is too much space in macOS dropdown after summary.
![too-much!](https://user-images.githubusercontent.com/67100964/153896439-805d44a6-60c8-4c61-aaa5-639cc2264775.png)

Now if we update,
![update](https://user-images.githubusercontent.com/67100964/153896628-05a53b35-b422-42d0-b4bc-f01c7a5f49a4.png)

#### 2. Related Issue

None