### PR TITLE
A Deeper Look at Git: Update for Style Guide

### DIFF
--- a/ruby_programming/git/lesson_a_deeper_look_at_git.md
+++ b/ruby_programming/git/lesson_a_deeper_look_at_git.md
@@ -145,15 +145,16 @@ So now that we've learned about the various dangerous of `git push --force`, you
 
 Let's review the dangers we've addressed so far. I know, I know, it's scary stuff - but we have to be mindful or our coworkers might end up hating our guts! If you look back through this lesson you'll see a common thread. `amend`, `rebase`, `reset`, `push --force` are all especially dangerous when you're collaborating with others. <span id='dangers'>These commands can destroy work your coworkers have created</span>. So keep that in mind. When attempting to rewrite history always check the dangers of the particular command you're using, and follow these best practices for the commands we've covered:
 <span id='best-practices'></span>
+
 1.  If working on a team project make sure rewriting history is safe to do, and others know you're doing it.
 1.  Ideally stick to using these commands only on branches that you're working with by yourself.
 1.  Using the `-f` flag to force something should scare you, and you better have a really good reason for using it.
 1.  Don't push after every single commit, changing published history should be avoided when possible.
 1.  Regarding the specific commands we've covered:
-  1.  For `git amend` never amend commits that have been pushed to remote repositories.
-  1.  For `git rebase` never rebase a repository that others may work off of.
-  1.  For `git reset` never reset commits thath have been pushed to remote repositories.
-  1.  For `git push --force` only use it when appropriate, use it with caution, and preferably default to using `git push --force-with-lease`.
+    1.  For `git amend` never amend commits that have been pushed to remote repositories.
+    1.  For `git rebase` never rebase a repository that others may work off of.
+    1.  For `git reset` never reset commits thath have been pushed to remote repositories.
+    1.  For `git push --force` only use it when appropriate, use it with caution, and preferably default to using `git push --force-with-lease`.
 
 ### Branches Are Pointers
 

--- a/ruby_programming/git/lesson_a_deeper_look_at_git.md
+++ b/ruby_programming/git/lesson_a_deeper_look_at_git.md
@@ -7,15 +7,16 @@ In this lesson, we'll help with the visualization by diving deeper than just the
 It is **very important** to take a look at all of this before progressing any further with the curriculum. The project work is becoming more and more complex, so using a disciplined Git workflow is no longer optional. Hopefully after going through this lesson you'll be much more comfortable changing you Git history, and have a better understanding of Git as a whole.
 
 
-### Learning Outcomes
-Look through these now and then use them to test yourself after going through the lesson:
+### Lesson Overview
 
-* Gain a deeper knowledge about Git commands
-* Learn about the different ways to change history
-* Learn how to work with remotes to change history
-* Explain the dangers of history-changing operations
-* Be able to point out best practices of history-changing operations
-* Learn about the concept of pointers
+This section contains a general overview of topics that you will learn in this lesson.
+
+* History changing Git commands
+* Different ways of changing history
+* Using remotes to change history
+* Dangers of history-changing operations
+* Best practices of history-changing operations
+* Pointers
 
 ### Changing History
 
@@ -28,7 +29,7 @@ Let's look at some ways we can change recent and distant history to fit our need
 - Squash commits together
 - Split up commits 
 
-## Changing The Last Commit
+#### Changing The Last Commit
 
 Let's say we execute a commit but *Uh-Oh!*, we're missing a file! Let's add our missing file, and run `$ git commit --amend`
 
@@ -42,7 +43,7 @@ What happened here is we first updated the staging area to includes the missing 
 
 Remember to **only amend commits that have not been pushed anywhere!** The reason for this  is that `git commit --amend` does not simply edit the last commit, it *replaces that commit with an entirely new one*. This means that if you were to amend a commit other developers are basing their work on, you're effectively destroying a commit they could be basing their work off of. When rewriting history always make sure that you're doing so in a safe manner, and that your coworkers are aware of what you're doing. 
 
-## Changing Multiple Commits
+#### Changing Multiple Commits
 
 Now let's say you have commits further back in your history that you want to modify. This is where the beautiful command `rebase` comes into play! We're going to get deeper into the complexities of `rebase` later on in this lesson, but for now we're going to start out with some very basic usage. 
 
@@ -80,7 +81,7 @@ Once you're satisfied with your changes, run
 These commit changes would be disastrous for me, so I won't *actually* do it, but it's a great tool to keep in mind for your future projects. That's all there is to it! It seems simple, but this is a very dangerous tool if misused, so be careful. Most importantly, remember to only rebase commits that exist in your repository. **If you have to rebase commits in a shared repository, make sure you're doing so for a very good reason that your coworkers are aware of.**
 
 
-## Squashing Commits
+#### Squashing Commits
 
 Using `squash` for your commits is a very handy way of keeping your Git history tidy. It's important to know how to `squash`, because this process may be the standard on some development teams. Squashing makes it easier for others to understand the history of your project. What often happens when a feature is merged, is you end up with some visually complex logs of all the changes a feature branch had on a main branch. These commits are important while the feature is in development, but aren't really necessary when looking through the entire history of your main branch.
 
@@ -94,7 +95,7 @@ squash 729db1da4 Begin work on Remotes
 
 That's it! When I save and exit the editor, the bottom two commits on that list get squashed into the top commit. 
 
-## Splitting Up a Commit
+#### Splitting Up a Commit
 
 Before diving into Remotes, we're going to have a look at a handy Git command called `reset`. Let's say one of my commits was `c85c71dd5 Add knight class and Add attack module`. That's a mouthful, and a bit much for one commit as you should have learned in the previous lesson on commits. So what we're going to do is split it up into two smaller commits, also using the interactive `rebase` tool. 
 
@@ -119,7 +120,7 @@ The last part of reset we want to touch upon is `git reset --hard`. What this do
 
 Thus far you've been working with remote repositories each time you've pushed or pulled from your own GitHub repository while working on the curriculum's various projects. In this section we're going to cover some slightly more advanced topics, which you might not have yet encountered or had to use. 
 
-## git push --force
+#### git push --force
 
 Let's say you're no longer working on a project all by yourself, but with someone else. You want to push a branch you've made changes on to a remote repository. Normally Git will only let you push your changes if you've already updated your local branch with the latest commits from this remote. 
 
@@ -140,26 +141,19 @@ So now that we've learned about the various dangerous of `git push --force`, you
 
 <span id='force-with-lease'>It is worth giving special mention to `git push --force-with-lease`</span>, a command which in some companies is the default option. The reason for this is that it's a fail-safe! It checks if the branch you're attempted to push to has been updated, and sends you an error if it has. This gives you an opportunity to, as mentioned before, `fetch` the work and update your local repository.
 
-## Merge Conflicts
-
-Let's go back to a situation we discussed in the previous section - merge conflicts. While these might seem intimidating, especially if you've encountered them before and shoved your way through them without fully understanding what's going on, merge conflicts are actually very simple. 
-
-Let's go straight to the source and read through [GitHub's documentation on merge conflicts](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/about-merge-conflicts). Take your time, and make sure you look at the two different ways the documentation suggests resolving merge conflicts - on GitHub itself, and on your command line. While you might not need this right now, keeping the source of this documentation in the back of your mind will prove invaluable for when you eventually run into a merge conflict and aren't sure where to find a simple solution. 
-
-
 ### Dangers and Best Practices
 
 Let's review the dangers we've addressed so far. I know, I know, it's scary stuff - but we have to be mindful or our coworkers might end up hating our guts! If you look back through this lesson you'll see a common thread. `amend`, `rebase`, `reset`, `push --force` are all especially dangerous when you're collaborating with others. <span id='dangers'>These commands can destroy work your coworkers have created</span>. So keep that in mind. When attempting to rewrite history always check the dangers of the particular command you're using, and follow these best practices for the commands we've covered:
 <span id='best-practices'>
-1) If working on a team project make sure rewriting history is safe to do, and others know you're doing it.</span>
-2) Ideally stick to using these commands only on branches that you're working with by yourself.
-3) Using the `-f` flag to force something should scare you, and you better have a really good reason for using it.
-4) Don't push after every single commit, changing published history should be avoided when possible
-5) Regarding the specific commands we've covered:
-  - For `git amend` never amend commits that have been pushed to remote repositories
-  - For `git rebase` never rebase a repository that others may work off of 
-  - For `git reset` never reset commits thath have been pushed to remote repositories
-  - For `git push --force` only use it when appropriate, use it with caution, and preferably default to using `git push --force-with-lease`
+1.  If working on a team project make sure rewriting history is safe to do, and others know you're doing it.</span>
+2.  Ideally stick to using these commands only on branches that you're working with by yourself.
+3.  Using the `-f` flag to force something should scare you, and you better have a really good reason for using it.
+4.  Don't push after every single commit, changing published history should be avoided when possible
+5.  Regarding the specific commands we've covered:
+  1.  For `git amend` never amend commits that have been pushed to remote repositories
+  2.  For `git rebase` never rebase a repository that others may work off of 
+  3.  For `git reset` never reset commits thath have been pushed to remote repositories
+  4.  For `git push --force` only use it when appropriate, use it with caution, and preferably default to using `git push --force-with-lease`
 
 ### Branches Are Pointers
 
@@ -173,21 +167,35 @@ Now that you've had a second to gather your thoughts and attempt to wrap your he
 
 You might be feeling overwhelmed at this point, so let's recap what we've learned. A branch is simply a pointer to a single commit. A commit is a snapshot, and a pointer at the commit directly behind it in history. That's it!
 
-### Additional Resources
-This section contains helpful links to other content. It isn't required, so consider it supplemental..
+### Assignment
 
-* Read this [Git Cheat Sheet](https://www.atlassian.com/git/tutorials/atlassian-git-cheatsheet) if you need a reference sheet.
-* Watch this [video about Rebase & Merge](https://www.youtube.com/watch?v=f1wnYdLEpgI) for an example of how to use both rebase and merge.
-* Read the chapter on [Branches covered by git-scm](https://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell) if you want an even deeper dive into Branches.
-* Read the chapter on [Rebasing covered by git-scm](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) for an even deeper dive into Rebasing.
-* Read the chapter on [Reset covered by git-scm](https://git-scm.com/book/en/v2/Git-Tools-Reset-Demystified) for a deeper dive into `git reset`.
+<div class="lesson-content__panel" markdown="1">
+
+1.  Read through [GitHub's documentation on merge conflicts](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/about-merge-conflicts)
+    *   It's only a matter of time until you run into one (if you haven't already)! While merge conflicts might seem intimidating, they're actually very simple. Take your time with this resource and make sure you look at the two different ways the documentation suggests resolving merge conflicts - on GitHub itself, and on your command line. While you might not need this right now, keeping the source of this documentation in the back of your mind will prove invaluable for when you eventually run into a merge conflict and aren't sure where to find a simple solution. 
+
+2.  Read [think-like-a-git](http://think-like-a-git.net/)
+    *   Take your time with this resource as well, it's very well written and will be very helpful in solidifying your understanding of git. 
+</div>
 
 ### Knowledge Check
-This section contains questions for you to check your understanding of this lesson. If you're having trouble answering the questions below on your own, review the material above to find the answer.
 
-* <a class='knowledge-check-link' href='https://git-scm.com/book/en/v2/Git-Basics-Undoing-Things'>How can you amend your last commit?</a>
-* <a class='knowledge-check-link' href='https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History'>What are some different ways to rewrite history?</a>
-* <a class='knowledge-check-link' href='#force-with-lease'>What is a safe way to push history changes to a remote repository?</a>
-* <a class='knowledge-check-link' href='#dangers'>What are the dangers of history-changing operations</a>
-* <a class='knowledge-check-link' href='#best-practices'>What are best practices of history-changing operations</a>
-* <a class='knowledge-check-link' href='https://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell'>Explain what it means for branches to be pointers</a>
+This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
+
+*   <a class='knowledge-check-link' href='https://git-scm.com/book/en/v2/Git-Basics-Undoing-Things'>How can you amend your last commit?</a>
+*   <a class='knowledge-check-link' href='https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History'>What are some different ways to rewrite history?</a>
+*   <a class='knowledge-check-link' href='#force-with-lease'>What is a safe way to push history changes to a remote repository?</a>
+*   <a class='knowledge-check-link' href='#dangers'>What are the dangers of history-changing operations</a>
+*   <a class='knowledge-check-link' href='#best-practices'>What are best practices of history-changing operations</a>
+*   <a class='knowledge-check-link' href='https://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell'>Explain what it means for branches to be pointers</a>
+
+### Additional Resources
+
+This section contains helpful links to related content. It isn’t required, so consider it supplemental.
+
+*   It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.
+*   Read this [Git Cheat Sheet](https://www.atlassian.com/git/tutorials/atlassian-git-cheatsheet) if you need a reference sheet.
+*   Watch this [video about Rebase & Merge](https://www.youtube.com/watch?v=f1wnYdLEpgI) for an example of how to use both rebase and merge.
+*   Read the chapter on [Branches covered by git-scm](https://git-scm.com/book/en/v2/Git-Branching-Branches-in-a-Nutshell) if you want an even deeper dive into Branches.
+*   Read the chapter on [Rebasing covered by git-scm](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) for an even deeper dive into Rebasing.
+*   Read the chapter on [Reset covered by git-scm](https://git-scm.com/book/en/v2/Git-Tools-Reset-Demystified) for a deeper dive into `git reset`.

--- a/ruby_programming/git/lesson_a_deeper_look_at_git.md
+++ b/ruby_programming/git/lesson_a_deeper_look_at_git.md
@@ -144,16 +144,16 @@ So now that we've learned about the various dangerous of `git push --force`, you
 ### Dangers and Best Practices
 
 Let's review the dangers we've addressed so far. I know, I know, it's scary stuff - but we have to be mindful or our coworkers might end up hating our guts! If you look back through this lesson you'll see a common thread. `amend`, `rebase`, `reset`, `push --force` are all especially dangerous when you're collaborating with others. <span id='dangers'>These commands can destroy work your coworkers have created</span>. So keep that in mind. When attempting to rewrite history always check the dangers of the particular command you're using, and follow these best practices for the commands we've covered:
-<span id='best-practices'>
-1.  If working on a team project make sure rewriting history is safe to do, and others know you're doing it.</span>
-2.  Ideally stick to using these commands only on branches that you're working with by yourself.
-3.  Using the `-f` flag to force something should scare you, and you better have a really good reason for using it.
-4.  Don't push after every single commit, changing published history should be avoided when possible
-5.  Regarding the specific commands we've covered:
-  1.  For `git amend` never amend commits that have been pushed to remote repositories
-  2.  For `git rebase` never rebase a repository that others may work off of 
-  3.  For `git reset` never reset commits thath have been pushed to remote repositories
-  4.  For `git push --force` only use it when appropriate, use it with caution, and preferably default to using `git push --force-with-lease`
+<span id='best-practices'></span>
+1.  If working on a team project make sure rewriting history is safe to do, and others know you're doing it.
+1.  Ideally stick to using these commands only on branches that you're working with by yourself.
+1.  Using the `-f` flag to force something should scare you, and you better have a really good reason for using it.
+1.  Don't push after every single commit, changing published history should be avoided when possible.
+1.  Regarding the specific commands we've covered:
+  1.  For `git amend` never amend commits that have been pushed to remote repositories.
+  1.  For `git rebase` never rebase a repository that others may work off of.
+  1.  For `git reset` never reset commits thath have been pushed to remote repositories.
+  1.  For `git push --force` only use it when appropriate, use it with caution, and preferably default to using `git push --force-with-lease`.
 
 ### Branches Are Pointers
 


### PR DESCRIPTION

-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [x] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

**1. Because:**
The Deeper Look at Git lesson did not adhere to the new Style Guide

**2. This PR:**
Updated the lesson stylistically to adhere to the Style Guide

**3. Additional Information:**
Two important changes were also made:
1.  the merge conflicts section was moved into being an Assignment, due to its use of outside links.
2.  the think-like-a-git resource was included in the Assignment section, due to the fact that it fits well in the lesson when compared to its current location in the [Using Git in the Real World lesson](https://www.theodinproject.com/paths/full-stack-ruby-on-rails/courses/ruby-programming/lessons/using-git-in-the-real-world)

