### PR TITLE
Fix form-project to reflect turbo behavior

### DIFF
--- a/ruby_on_rails/forms_and_authentication/project_forms.md
+++ b/ruby_on_rails/forms_and_authentication/project_forms.md
@@ -31,15 +31,8 @@ The first form you build will be mostly HTML (remember that stuff at all?).  Bui
 
 1. Build a form for creating a new user.  See the [w3 docs for forms](http://www.w3schools.com/tags/tag_form.asp) if you've totally forgotten how they work.  Specify the `method` and the `action` attributes in your `<form>` tag (use `$ rails routes` to see which HTTP method and path are being expected based on the resource you created).  Include the attribute `accept-charset="UTF-8"` as well, which Rails naturally adds to its forms to specify Unicode character encoding.
 2. Create the proper input tags for your user's fields (email, username and password).  Use the proper password input for "password".  Be sure to specify the `name` attribute for these inputs.  Make label tags which correspond to each field.
-3. Submit your form and view the server output.  Oops, we don't have the right CSRF authenticity token (`ActionController::InvalidAuthenticityToken`) to protect against cross site scripting attacks and form hijacking. If you do not get an error, you used the wrong `method` from step 1.
-4. Include your own authenticity token by adding a special hidden input and using the `#form_authenticity_token` method.  This method actually checks the session token that Rails has stored for that user (behind the scenes) and puts it into the form so it's able to verify that it's actually you submitting the form.  It might look like:
-
-   ~~~html
-   # app/views/users/new.html.erb
-   <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>">
-   ~~~
-
-5. Submit the form again.  Great! Success!  We got a `Template is missing` error instead and that's A-OK because it means that we've successfully gotten through our blank `#create` action in the controller (and didn't specify what should happen next, which is why Rails is looking for a `app/views/users/create.html.erb` view by default).  Look at the server output above the error's stack trace.  It should include the parameters that were submitted, looking something like:
+3. Submit your form and view the server output. You will see nothing happening, no error message, nothing. If you look at the network tab in your inspector or at your server log, you can see that a request was issued, but a response of `204 No Content` is returned.
+4. That's A-OK because it means that we've successfully gotten through our blank `#create` action in the controller (and didn't specify what should happen next).  Look at the server output.  It should include the parameters that were submitted, looking something like:
 
    ~~~bash
    Started POST "/users" for 127.0.0.1 at 2013-12-12 13:04:19 -0800
@@ -47,7 +40,7 @@ The first form you build will be mostly HTML (remember that stuff at all?).  Bui
    Parameters: {"authenticity_token"=>"WUaJBOpLhFo3Mt2vlEmPQ93zMv53sDk6WFzZ2YJJQ0M=", "username"=>"foobar", "email"=>"foo@bar.com", "password"=>"[FILTERED]"}
    ~~~
 That looks a whole lot like what you normally see when Rails does it, right?
-6. Go into your UsersController and build out the `#create` action to take those parameters and create a new User from them.  If you successfully save the user, you should redirect back to the New User form (which will be blank) and if you don't, it should render the `:new` form again (but it will still have the existing information entered in it).  You should be able to use something like:
+5. Go into your UsersController and build out the `#create` action to take those parameters and create a new User from them.  If you successfully save the user, you should redirect back to the New User form (which will be blank) and if you don't, it should render the `:new` form again (but it will still have the existing information entered in it).  You should be able to use something like:
 
    ~~~ruby
    # app/controllers/users_controller.rb
@@ -62,19 +55,19 @@ That looks a whole lot like what you normally see when Rails does it, right?
    end
    ~~~
 
-7. Test this out -- can you now create users with your form? If so, you should see an INSERT SQL command in the server log.
-8. We're not done just yet... that looks too long and difficult to build a user with all those `params` calls.  It'd be a whole lot easier if we could just use a hash of the user's attributes so we could just say something like `User.new(user_params)`.  Let's build it... we need our form to submit a hash of attributes that will be used to create a user, just like we would with Rails' `form_with` method.  Remember, that method submits a top level `user` field which actually points to a hash of values.  This is simple to achieve, though -- just change the `name` attribute slightly.  Nest your three User fields inside the variable attribute using brackets in their names, e.g. `name="user[email]"`.
-9. Resubmit.  Now your user parameters should be nested under the `"user"` key like:
+6. Test this out -- can you now create users with your form? If so, you should see an INSERT SQL command in the server log.
+7. We're not done just yet... that looks too long and difficult to build a user with all those `params` calls.  It'd be a whole lot easier if we could just use a hash of the user's attributes so we could just say something like `User.new(user_params)`.  Let's build it... we need our form to submit a hash of attributes that will be used to create a user, just like we would with Rails' `form_with` method.  Remember, that method submits a top level `user` field which actually points to a hash of values.  This is simple to achieve, though -- just change the `name` attribute slightly.  Nest your three User fields inside the variable attribute using brackets in their names, e.g. `name="user[email]"`.
+8. Resubmit.  Now your user parameters should be nested under the `"user"` key like:
 
    ~~~bash
    Parameters: {"authenticity_token" => "WUaJBOpLhFo3Mt2vlEmPQ93zMv53sDk6WFzZ2YJJQ0M=", "user" =>{ "username" => "foobar", "email" => "foo@bar.com", "password" => "[FILTERED]" } }
    ~~~
 
-4. You'll get some errors because now your controller will need to change.  But recall that we're no longer allowed to just directly call `params[:user]` because that would return a hash and Rails' security features prevent us from doing that without first validating it.
-5. Go into your controller and comment out the line in your `#create` action where you instantiated a `::new` User (we'll use it later).
-6. Implement a private method at the bottom called `user_params` which will `permit` and `require` the proper fields (see the [Controllers Lesson](/paths/full-stack-ruby-on-rails/courses/ruby-on-rails/lessons/controllers) for a refresher).
-7. Add a new `::new` User line which makes use of that new whitelisting params method.
-5. Submit your form now.  It should work marvelously (once you debug your typos)!
+9. You'll get some errors because now your controller will need to change.  But recall that we're no longer allowed to just directly call `params[:user]` because that would return a hash and Rails' security features prevent us from doing that without first validating it.
+10. Go into your controller and comment out the line in your `#create` action where you instantiated a `::new` User (we'll use it later).
+11. Implement a private method at the bottom called `user_params` which will `permit` and `require` the proper fields (see the [Controllers Lesson](/paths/full-stack-ruby-on-rails/courses/ruby-on-rails/lessons/controllers) for a refresher).
+12. Add a new `::new` User line which makes use of that new whitelisting params method.
+13. Submit your form now.  It should work marvelously (once you debug your typos)!
 
 #### Railsy Forms with `#form_tag`
 


### PR DESCRIPTION
Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`

Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete them later if they are not currently applicable:
-   [x] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [x] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)


**1. Because:**

The forms project lesson does not correctly reflect the new turbo drive behaviour, what is described in the step is not what you see:

1. OK
2. OK
3. You don't get an error, turbo uses the authenticity token from the meta tag and submit that if there is not authenticity token in the form. So only if we opt out from turbo will you see that error. Instead nothing happens and you get back a 204 No Content
4. So if you do step 4 nothing changes
5. We still get a 204 No content response

From 6 on, it works again as expected
As described here @CouchofTomato  


**2. This PR:**

**IS NOT ONTO MAIN, but the turbo drive branch.**

And adjust the few steps that are incorrect, also renumbers the rest of the steps.

**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->

