### PR TITLE
Project: Recipes lesson: Capitalize Google in the Iteration 3 section

### DIFF
--- a/foundations/html_css/html-foundations/project-recipes.md
+++ b/foundations/html_css/html-foundations/project-recipes.md
@@ -54,7 +54,7 @@ Okay, that's enough Git for the moment -- time to actually build stuff!
 
 The recipe page should have the following content:
 
-1. An image of the finished dish under the h1 heading that you added earlier. You can find images of the dish on google or the site [recipe site](https://www.allrecipes.com/) we linked to earlier.
+1. An image of the finished dish under the h1 heading that you added earlier. You can find images of the dish on Google or the site [recipe site](https://www.allrecipes.com/) we linked to earlier.
 2. Under the image, it should have an appropriately sized "Description" heading followed by a paragraph or two describing the recipe.
 3.  Under the description, add an "Ingredients" heading followed by an **unordered list** of the ingredients needed for the recipe.
 4. Finally, under the ingredients list, add a "Steps" heading followed by an **ordered list** of the steps needed for making the dish.


### PR DESCRIPTION
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [x] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

<hr>

**1. Because:**
Fixes the capitalization of the proper noun 'Google' in the Project: Recipes lesson.


**2. This PR:**
- Capitalizes the word Google in the Iteration 3 section of this lesson. It was spelled as 'google'.


**3. Additional Information:**
N/A