### PR TITLE
Inspecting HTML and CSS - Fix Chrome DevTools CSS link in Assignments

### DIFF
--- a/foundations/html_css/inspecting-html-and-css/inspecting-html-and-css.md
+++ b/foundations/html_css/inspecting-html-and-css/inspecting-html-and-css.md
@@ -42,7 +42,7 @@ In the below image, we have altered the value of `margin-bottom` in the `.hero__
 
 - [Overview](https://developer.chrome.com/docs/devtools/overview/): don't navigate to any other pages linked here; just get familiar with _what_ tools are available in the DevTools, rather than how to use all of them right now.
 - [Open Chrome DevTools](https://developer.chrome.com/docs/devtools/open/): similar to what we went over above, but with some nice extras.
-- [CSS](https://developer.chrome.com/docs/devtools/#css): be sure to follow along with any interactive instructions! Note that while you haven't used CSS Grid yet, you should still read the "Inspect CSS Grid" section to be familiar with how to inspect it in case you see it in the wild.
+- [CSS](https://developer.chrome.com/docs/devtools/css): be sure to follow along with any interactive instructions! Note that while you haven't used CSS Grid yet, you should still read the "Inspect CSS Grid" section to be familiar with how to inspect it in case you see it in the wild.
 - [Get Started With Viewing And Changing The DOM](https://developer.chrome.com/docs/devtools/dom/): skip through any part that uses the JavaScript console.
 </div>
 


### PR DESCRIPTION
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [x] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

<hr>

**1. Because:**
The CSS link in the Assignments points to a non-existent #css ID. When clicking the link, the user is taken to the top of the Chrome DevTools documentation page, instead of being taken to their CSS article.

**2. This PR:**
- Removes the # (hashtag) symbol from the CSS link in Assignments so it points to the actual CSS DevTools page, rather than to an ID that does not exist.

**3. Additional Information:**
Alternatively, the link could be changed to point to the [#elements ID](https://developer.chrome.com/docs/devtools/#elements), which includes various CSS DevTools topics.