### PR TITLE
Javascript Asynchronous Code: Fix outdated link for Additional Resource #4

### DIFF
--- a/javascript/async-apis/promises-async.md
+++ b/javascript/async-apis/promises-async.md
@@ -80,7 +80,7 @@ This section contains helpful links to other content. It isn't required, so cons
 1. [This](https://www.sitepoint.com/demystifying-javascript-closures-callbacks-iifes/) is another useful article about Callback functions in JavaScript.
 2. The [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) for Promises.  It might not be the best resource for _learning_ all about them, but once you've read a more friendly article or tutorial, this will probably be the place you return to for a refresher.
 3. [This video](https://www.youtube.com/watch?v=vQ3MoXnKfuQ) and [this one too](https://www.youtube.com/watch?v=yswb4SkDoj0) are both nice introductions to Promises if you need more repetition.
-4. [This tutorial](https://scotch.io/tutorials/javascript-promises-for-dummies) is another good introduction.
+4. [This tutorial](https://www.digitalocean.com/community/tutorials/understanding-javascript-promises) is another good introduction.
 
 ### Knowledge Check
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`

Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete them later if they are not currently applicable:
-   [ ] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [ ] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

<hr>

**1. Because:**
<!--
If this PR closes an open issue, replace the XXXXX below with the issue number, e.g. Closes #2013. Or if the issue is in another TOP repo replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

Otherwise, provide a clear and concise reason for your pull request, e.g. what problem it solves or what benefit it provides. If this PR is related to, but does not close, another issue or PR, you can also link it as above without the 'Closes' keyword, e.g. "Related to #2013".
 -->
The link provided at the 4th point of the Additional Resources section leads to a 404.

**2. This PR:**
<!--
A bullet point list of one or more items outlining what was done in this PR to solve the problem(s) or implement the feature/enhancement.
 -->
- Verified that the old and new link correspond to the same lesson through Web Archive (the latter is slightly updated)
- Subtituted the old link (currently resulting in a 404) with the updated one


**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->
[This](https://web.archive.org/web/20200807012704/https://scotch.io/tutorials/javascript-promises-for-dummies) is the outdated link as seen from a 2020 snapshot on web archive. 
It redirects to [this](https://www.digitalocean.com/community/tutorials/javascript-promises-for-dummies) page on Digital Ocean, which used to be the new location of the lesson on Promises but now only returns a 404, as the lesson is now located at [this](https://www.digitalocean.com/community/tutorials/understanding-javascript-promises) link and the previous one does not auto redirect to it.






