### PR TITLE
curriculum/ruby_on_rails/rails_sprinkles/stimulus_js: fix typos

### DIFF
--- a/ruby_on_rails/rails_sprinkles/stimulus_js.md
+++ b/ruby_on_rails/rails_sprinkles/stimulus_js.md
@@ -325,7 +325,7 @@ the questions below on your own, clicking the small arrow to the left of the que
 * There are three aspects to it…
   * … add a `data-my-thing-target` to the html element
   * … declare it with `static targets = ["myThing"]` in your controller
-  * … use it in the controller with `this.myThingTarget` or `tis.myThingTargets`
+  * … use it in the controller with `this.myThingTarget` or `this.myThingTargets`
 </details>
 
 <details markdown="block">
@@ -340,5 +340,5 @@ the questions below on your own, clicking the small arrow to the left of the que
   <summary>How do you trigger actions on an event?</summary>
 
 * By using `data-action="click->some-controller#someAction"` on a HTML element
-* or`data-action="resize@window->gallery#layout"` for window events
+* or `data-action="resize@window->gallery#layout"` for window events
 </details>


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`

Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete them later if they are not currently applicable:
-   [x] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [x] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

<hr>

**1. Because:**
Typo in line 328, `tis.myThingTargets`;
missing space in line 343, `ordata-action=`.


**2. This PR:**
Fixed typo and added space.


**3. Additional Information:**

