### PR TITLE
Rails Stimulus lesson: Fix references link to start at beginning

### DIFF
--- a/ruby_on_rails/rails_sprinkles/stimulus_js.md
+++ b/ruby_on_rails/rails_sprinkles/stimulus_js.md
@@ -281,7 +281,7 @@ with Stimulus
 * Watch this [Stimulus 2.0 Tutorial Video](https://www.driftingruby.com/episodes/the-stimulus-2-0-tutorial) it may give
 you a bit of a feel on how to work with Stimulus controllers. You can ignore the part about installation with Webpacker
 we will use the new rails standard of using import maps.
-* Make sure to also read the [reference section](https://stimulus.hotwired.dev/reference/lifecycle-callbacks), if you 
+* Make sure to also read the [reference section](https://stimulus.hotwired.dev/reference/controllers), if you 
 haven't already, don't worry if not everything sticks, but you should know where to look up these things.
 </div>
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [X] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`

Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete them later if they are not currently applicable:
-   [X] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [X] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

<hr>

**1. Because:**
<!--
If this PR closes an open issue, replace the XXXXX below with the issue number, e.g. Closes #2013. Or if the issue is in another TOP repo replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

Otherwise, provide a clear and concise reason for your pull request, e.g. what problem it solves or what benefit it provides. If this PR is related to, but does not close, another issue or PR, you can also link it as above without the 'Closes' keyword, e.g. "Related to #2013".
 -->
Closes #XXXXX

The third assignment in the Stimulus lesson links to the "Lifecycle Callbacks" part of the Stimulus handbook's references. I believe it should link to the beginning of the references section which starts with "Controllers". This PR fixes the link to start from the first section.


**2. This PR:**
<!--
A bullet point list of one or more items outlining what was done in this PR to solve the problem(s) or implement the feature/enhancement.
 -->

- Changes assignment link to go to Controllers section of the Stimulus reference guide instead of the Lifecycle Callbacks section


**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->

