### PR TITLE
Rails Turbo lesson: Remove unnecessary and distracting exclamation marks

### DIFF
--- a/ruby_on_rails/rails_sprinkles/turbo.md
+++ b/ruby_on_rails/rails_sprinkles/turbo.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-When a user makes a request to your application, your controller is the part of MVC that receives it and responds with the `.html.erb` view file. As you've been working on your applications so far, you may have been creating views with similar features and layouts. What if there was a way to only change the parts of our views that are different and not have to bother with updating content that we don't intend to change in the first place? We could cut down on loading times for the user and the amount of data our application has to send out!
+When a user makes a request to your application, your controller is the part of MVC that receives it and responds with the `.html.erb` view file. As you've been working on your applications so far, you may have been creating views with similar features and layouts. What if there was a way to only change the parts of our views that are different and not have to bother with updating content that we don't intend to change in the first place? We could cut down on loading times for the user and the amount of data our application has to send out.
 
 That's where the concept of a **single page application** comes in. This section will be about how we can use a framework known as **Turbo** to implement single page application behaviour in our very own Rails application. This section covers a lot of tools and you may not fully understand them as you read through the first time. That's okay, consider this lesson to be a resource that you can refer back to when you actually begin using the  tools mentioned and get more of a visual as to what exactly is going on in your views.
 
@@ -22,7 +22,7 @@ implementation for web applications that loads only a single web document. Rathe
 
 #### Creating a Single Page Application in Rails
 
-There are various Javascript frameworks to help developers implement SPA functionality. You have possibly heard of some of them, such as AngularJS or ReactJS. However, Rails has its own solution to creating the experience of a SPA without writing Javascript. This solution is a collection of libraries that are under the umbrella of Hotwire!
+There are various Javascript frameworks to help developers implement SPA functionality. You have possibly heard of some of them, such as AngularJS or ReactJS. However, Rails has its own solution to creating the experience of a SPA without writing Javascript. This solution is a collection of libraries that are under the umbrella of Hotwire.
 
 #### Hotwire
 
@@ -32,11 +32,11 @@ In Rails 7, all new applications include Hotwire by default. Hotwire is actually
 2.  Stimulus
 3.  Strada
 
-The lesson you are reading now is all about Turbo! We will cover Stimulus in another lesson. Strada is a currently unreleased framework that aims to work alongside Turbo to deliver responsive mobile applications. You don't need to worry about Strada for the scope of this course, just be familiar with the name as you will see it mentioned from time-to-time.
+The lesson you are reading now is all about Turbo. We will cover Stimulus in another lesson. Strada is a currently unreleased framework that aims to work alongside Turbo to deliver responsive mobile applications. You don't need to worry about Strada for the scope of this course, just be familiar with the name as you will see it mentioned from time-to-time.
 
 ### Turbo
 
-Turbo is the heart of the Hotwire umbrella. The goal of Turbo is to use four different techniques to create the experience of a speedy SPA without having to write any Javascript!
+Turbo is the heart of the Hotwire umbrella. The goal of Turbo is to use four different techniques to create the experience of a speedy SPA without having to write any Javascript.
 
 Here is a quick summary of the four Turbo techniques together. As you continue to read this lesson, we will look at each piece more in-depth
 
@@ -49,7 +49,7 @@ Here is a quick summary of the four Turbo techniques together. As you continue t
 
 #### Creating a Frame
 
-Imagine a piece of paper and cutting out a small square hole in it. You could change what you see through the hole by swapping out another piece of paper behind it, but the rest of the paper will always look the same. That's the idea of Turbo Frames! Turbo Frames allow us to predefine a portion of our page to be replaced during a request. Any links or forms inside of our frame will make a special request that results in only changing the frame. A page can also have multiple Turbo Frames!
+Imagine a piece of paper and cutting out a small square hole in it. You could change what you see through the hole by swapping out another piece of paper behind it, but the rest of the paper will always look the same. That's the idea of Turbo Frames. Turbo Frames allow us to predefine a portion of our page to be replaced during a request. Any links or forms inside of our frame will make a special request that results in only changing the frame. A page can also have multiple Turbo Frames.
 
 A frame is designated by wrapping a region inside of a `<turbo-frame>` element. Rails has a special helper for this, `<%= turbo_frame_tag %>`.
 
@@ -80,7 +80,7 @@ With the Turbo Frame helper, you can substitute the ID for a variable. For insta
 <% end %>
 ~~~
 
-The above example will generate a turbo frame for every article. Each frame will have a unique id like `article_1` or `article_2` and all we had to include was our article variable! 
+The above example will generate a turbo frame for every article. Each frame will have a unique id like `article_1` or `article_2` and all we had to include was our article variable. 
 
 #### Connecting to Other Frames
 
@@ -110,9 +110,9 @@ Let us replace the `/show` view with the `/edit` view on an article:
 ...
 ~~~
 
-That's all we have to do! Turbo will recognize that our destination URL, the `/show` or `/edit` page, has a matching Turbo Frame and will replace the frame region with the content from the new page's frame! Something else to note is that this does work with forms as well. In our controller, if the `update` action contains `redirect_to @article`, then our Turbo Frame will be updated when we submit our form just like if we clicked a link.
+That's all we have to do! Turbo will recognize that our destination URL, the `/show` or `/edit` page, has a matching Turbo Frame and will replace the frame region with the content from the new page's frame. Something else to note is that this does work with forms as well. In our controller, if the `update` action contains `redirect_to @article`, then our Turbo Frame will be updated when we submit our form just like if we clicked a link.
 
-Now that we have our matching frames that can replace their content, what about the content located outside of the frame? Anything outside of the frame does not change. If we were going from `/show` to `/edit`, then the content outside of the frame would still be the same content of the `/show` page and we would not receive any content from outside of the `/edit` frame either. We did not navigate to a new page, we only requested new html from another route and inserted it into our current page! The current `url` also does not change. We will stay on the `/show` path, and if we refresh, we would still see the `/show` view. (Note that it is possible to change this default behaviour by making use of Turbo Drive's `data-turbo-action` to advance the browser history and update the current `url`.)
+Now that we have our matching frames that can replace their content, what about the content located outside of the frame? Anything outside of the frame does not change. If we were going from `/show` to `/edit`, then the content outside of the frame would still be the same content of the `/show` page and we would not receive any content from outside of the `/edit` frame either. We did not navigate to a new page, we only requested new html from another route and inserted it into our current page. The current `url` also does not change. We will stay on the `/show` path, and if we refresh, we would still see the `/show` view. (Note that it is possible to change this default behaviour by making use of Turbo Drive's `data-turbo-action` to advance the browser history and update the current `url`.)
 
 #### Breaking out of a Turbo Frame
 
@@ -124,7 +124,7 @@ Sometimes you may have a link inside of the Turbo Frame that you want to act as 
 
 #### Targeting a Turbo Frame from Outside
 
-We can also do the opposite! We can make a link that exists outside of our Turbo Frame act as if it was inside of the Frame and update it. This time, we set the `turbo-frame` data attribute to point to the ID of the specific frame. Lets say we want to designate a turbo frame to show either a list of posts or a list of images:
+We can also do the opposite. We can make a link that exists outside of our Turbo Frame act as if it was inside of the Frame and update it. This time, we set the `turbo-frame` data attribute to point to the ID of the specific frame. Lets say we want to designate a turbo frame to show either a list of posts or a list of images:
 
 ~~~erb
 <%= link_to "Show Posts", posts_path, data: { turbo_frame: "list-region" } %>
@@ -165,7 +165,7 @@ We can also make our frames **lazy loaded**. A lazy loaded frame will only fetch
 
 ### Turbo Stream
 
-Now we know how to set up our views to use Turbo Frames, but what about content that is being changed by our users? We can't put a Turbo Frame around something that doesn't exist yet! That's where Turbo Stream comes in. Turbo Streams send page changes as HTML wrapped in `<turbo-stream>` elements. Turbo Streams specify an action to perform and the target ID of the DOM element to update with this action. For instance, a Turbo Stream where `action="replace"` and `target="body"` would replace the HTML element where `id="body"` with the new element being delivered over Turbo Stream. These streams can be sent in response to either a direct browser request, or by broadcasting over a websocket connection. This lesson will stick to the browser request implementation. Turbo Streams can take the form of 7 different actions:
+Now we know how to set up our views to use Turbo Frames, but what about content that is being changed by our users? We can't put a Turbo Frame around something that doesn't exist yet. That's where Turbo Stream comes in. Turbo Streams send page changes as HTML wrapped in `<turbo-stream>` elements. Turbo Streams specify an action to perform and the target ID of the DOM element to update with this action. For instance, a Turbo Stream where `action="replace"` and `target="body"` would replace the HTML element where `id="body"` with the new element being delivered over Turbo Stream. These streams can be sent in response to either a direct browser request, or by broadcasting over a websocket connection. This lesson will stick to the browser request implementation. Turbo Streams can take the form of 7 different actions:
 
 *  Append
 *  Prepend
@@ -175,12 +175,12 @@ Now we know how to set up our views to use Turbo Frames, but what about content 
 *  Update
 *  Remove
 
-Turbo Streams are delivered by use of our controller. Just like how your users make `html` requests and receive `view.html.erb` files, your users can receive `view.turbo_stream.erb` files! These are not standalone view files as you know them, they only contain a few lines and are a way of sending the user a Stream response instead of a new page.
+Turbo Streams are delivered by use of our controller. Just like how your users make `html` requests and receive `view.html.erb` files, your users can receive `view.turbo_stream.erb` files. These are not standalone view files as you know them, they only contain a few lines and are a way of sending the user a Stream response instead of a new page.
 
 
 #### Our First Turbo Stream
 
-Let's say that we have made a website where users can create posts. By adding a `turbo_frame` with a `src:` attribute that points to our `new_post_path`, and our `new` post view being wrapped in a `turbo_frame_tag` with a matching `id`, we can include our `new` action form on the same page as our `index` feed! It may look something like this.
+Let's say that we have made a website where users can create posts. By adding a `turbo_frame` with a `src:` attribute that points to our `new_post_path`, and our `new` post view being wrapped in a `turbo_frame_tag` with a matching `id`, we can include our `new` action form on the same page as our `index` feed. It may look something like this.
 
 Our `index` view:
 
@@ -250,9 +250,9 @@ end
 
 This will result in only the `posts#index` page loading initially and *then* another request being made to the `posts#new` action of our controller to insert the form! This also keeps our code DRY because if instead opted to add the form by use of a partial on the index page, we would still have to repeat the `posts#new` controller action during the `posts#index` action.
 
-However, if a user is to submit a post right now, something weird happens! The form window goes away, but there's no error. Where did the post go?? When we refresh the page, we see that the post did submit. What's happening here is that Rails doesn't know you are going to want a Turbo Stream so it can't automatically add your post yet. Instead it tries to redirect you to the page you are already on. **Turbo Drive** intercepts this and loads a cached version of the page, which does not have our form content in it, so the form goes away!
+However, if a user is to submit a post right now, something weird happens! The form window goes away, but there's no error. Where did the post go? When we refresh the page, we see that the post did submit. What's happening here is that Rails doesn't know you are going to want a Turbo Stream so it can't automatically add your post yet. Instead it tries to redirect you to the page you are already on. **Turbo Drive** intercepts this and loads a cached version of the page, which does not have our form content in it, so the form goes away.
 
-All of this looks very scary and like something is wrong, but it's fine. All we have to do is set up our Turbo Stream and the pieces will all begin to work together again!
+All of this looks very scary and like something is wrong, but it's fine. All we have to do is set up our Turbo Stream and the pieces will all begin to work together again.
 
 
 #### Turbo Stream in the Controller
@@ -277,9 +277,9 @@ For starters, we tell our controller that we want to accept a Turbo Stream forma
 
 What's going on here? Well, the `respond_to do |format|` block is our way of telling the controller to do more than just `html` format requests. If our post saves, we would like the format we respond with to be a `create.turbo_stream.erb` format. If it does not save, we would like to respond with the `new.html.erb` file being rendered. Notice the difference in the formats is the file extension that is after the name and before the `.erb`.
 
-We include the `422 Unprocessable Entity` error code with our response upon an unsaved post so that Turbo Drive knows what to do with it and our form window won't disappear anymore!
+We include the `422 Unprocessable Entity` error code with our response upon an unsaved post so that Turbo Drive knows what to do with it and our form window won't disappear anymore.
 
-Now all we have to do is create our `create.turbo_stream.erb` file to respond with!
+Now all we have to do is create our `create.turbo_stream.erb` file to respond with.
 
 #### Turbo Stream Template
 
@@ -289,9 +289,9 @@ You create your Turbo Stream file inside of your `views` folder the same way as 
 <%= turbo_stream.append "posts", @post %>
 ~~~
 
-That line is all we need! What this does is create a Turbo Stream packet with the `append` action. The target of the action is `"posts"`. This is the `<div>` with the `id="posts"` that contains all of our posts. Turbo Stream will locate the `<div>` and append our brand new `@post` to the bottom! Our newly created `@post` will even use the `_post.html.erb` partial to be in the proper layout as all of our other posts. For that, you can thank the Rails naming convention. If you are breaking from Rails convention, you can specify a partial to use inside of your `turbo_stream` template.
+That line is all we need! What this does is create a Turbo Stream packet with the `append` action. The target of the action is `"posts"`. This is the `<div>` with the `id="posts"` that contains all of our posts. Turbo Stream will locate the `<div>` and append our brand new `@post` to the bottom. Our newly created `@post` will even use the `_post.html.erb` partial to be in the proper layout as all of our other posts. For that, you can thank the Rails naming convention. If you are breaking from Rails convention, you can specify a partial to use inside of your `turbo_stream` template.
 
-Now that we have added the `format.turbo_stream` response to our controller and our `create.turbo_stream.erb` file, we can now create a post and watch it append to the list!
+Now that we have added the `format.turbo_stream` response to our controller and our `create.turbo_stream.erb` file, we can now create a post and watch it append to the list.
 
 #### Additional Turbo Stream Tips
 
@@ -309,7 +309,7 @@ if you would like to learn more:
 
     However, [you shouldn't do this for anything complex or chained](https://github.com/hotwired/turbo-rails/issues/77#issuecomment-757349251).
 
-3.  You may have noticed that when you submit a new Post, the text box doesn't clear out! You need to reset the submission element in order for it to be empty again. Hotwire has a remedy for this problem by including Stimulus, a light JavaScript framework. Don't worry about Stimulus for this example though, the next lesson will cover how to write and make use of Stimulus Controllers.
+3.  You may have noticed that when you submit a new Post, the text box doesn't clear out. You need to reset the submission element in order for it to be empty again. Hotwire has a remedy for this problem by including Stimulus, a light JavaScript framework. Don't worry about Stimulus for this example though, the next lesson will cover how to write and make use of Stimulus Controllers.
 
 ### Turbo Native
 
@@ -333,7 +333,7 @@ The final piece of Turbo is something that you don't need to know much about for
       and use this demo to watch how Turbo Drive, Frames, & Streams come together visually.
 2. Skim through sections 1-4 of the [Turbo Handbook](https://turbo.hotwired.dev/handbook/introduction)
     * This Handbook is written to be backend-agnostic, meaning that the code you will see is pure HTML and not Rails tags, but it still
-      is a useful resource for referencing how Turbo works!
+      is a useful resource for referencing how Turbo works.
 3. Take a quick glance at the Turbo-Rails gem [RubyDoc info page](https://www.rubydoc.info/gems/turbo-rails/1.0.0)
     * This resource covers the Rails-specific syntaxes and tags you can use for Turbo. You don't need to read anything now, just know that
       it exists so you can come back to it when you need to figure out how to use a specific piece of Turbo in your applications.
@@ -346,7 +346,7 @@ The final piece of Turbo is something that you don't need to know much about for
 
 * [Turbo Reference Information](https://turbo.hotwired.dev/reference/drive)
 * [Official Hotwire Forums](https://discuss.hotwired.dev/)
-* Remember you can use your browser developer tools to [watch network activity](https://developer.chrome.com/docs/devtools/network/) and see what is happening with your Turbo requests and responses. If something doesn't work, check to see if your browser received a Rails error message. Look for a red font!
+* Remember you can use your browser developer tools to [watch network activity](https://developer.chrome.com/docs/devtools/network/) and see what is happening with your Turbo requests and responses. If something doesn't work, check to see if your browser received a Rails error message. Look for a red font.
 
 ### Knowledge Check
 
@@ -385,6 +385,6 @@ The final piece of Turbo is something that you don't need to know much about for
   <summary>How do we set up Turbo Streams?</summary>
 
   *   First, we tell our controller to respond with a `turbo_stream` format, rather than a `html` format. 
-  *   Second, we create a `turbo_stream.erb` file in our views folder with the same name as the controller action (Rails conventions!) that contains the Turbo Stream's action and target destination.
+  *   Second, we create a `turbo_stream.erb` file in our views folder with the same name as the controller action (Rails conventions) that contains the Turbo Stream's action and target destination.
 
 </details>


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`

Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete them later if they are not currently applicable:
-   [x] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [x] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

<hr>

**1. Because:**

As I read through this lesson, I noticed a large number of exclamation marks which I found very distracting and unnecessary. The lesson contained 31 exclamation marks in total.

Closes #XXXXX


**2. This PR:**

Changed most of the 31 exclamation marks to periods, and also changed one instance of "??" to "?".



**3. Additional Information:**

Hopefully others will also find this a welcome change. I actually had a hard time reading it as it was originally written. Of course if others feel the exclamation marks are warranted then they can be kept. 
Thanks!

