### PR TITLE
CSS Foundations section: Block and Inline lesson: Replace web archive link with a speedier main link

### DIFF
--- a/foundations/html_css/block-and-inline.md
+++ b/foundations/html_css/block-and-inline.md
@@ -66,7 +66,7 @@ Span is an inline-level element by default. It can be used to group text content
 
 This section contains helpful links to related content. It isn’t required, so consider it supplemental.
 
-*   [This tutorial](http://web.archive.org/web/20210813033024/https://learnlayout.com/no-layout.html) is a little dated at this point, but its examples are clear. The first 6 slides cover the material we've seen so far.
+*   [This tutorial](https://learnlayout.com/no-layout.html) is a little dated at this point, but its examples are clear. The first 6 slides cover the material we've seen so far.
 
 ### Knowledge Check
 


### PR DESCRIPTION
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`

-   [x] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [ ] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

<hr>

**1. Because:**

Closes  #24213


**2. This PR:**
- Replaces [this web archive link](http://web.archive.org/web/20210813033024/https://learnlayout.com/no-layout.html) with [this speedier main link](https://learnlayout.com/no-layout.html)