### PR TITLE
Advanced Selectors lesson: update CSS comments 

### DIFF
--- a/html_css/intermediate_css/selectors.md
+++ b/html_css/intermediate_css/selectors.md
@@ -135,13 +135,13 @@ Similarly [`:empty`](https://css-tricks.com/almanac/selectors/e/empty/) will mat
 For a more dynamic approach we can use <span id="second-child-knowledge-check">[`:nth-child`](https://css-tricks.com/almanac/selectors/n/nth-child/).</span> This is a flexible pseudo-class with a few different uses.
 
 ~~~css
-  .myList:nth-child(5) {/* Selects the 5th child of myList */}
+  .myList:nth-child(5) {/* Selects the 5th element with class myList */}
 
-  .myList:nth-child(3n) { /* Selects every 3rd child of myList */}
+  .myList:nth-child(3n) { /* Selects every 3rd element with class myList */}
 
-  .myList:nth-child(3n + 3) { /* Selects every 3rd child of myList, beginning with the 3rd */}
+  .myList:nth-child(3n + 3) { /* Selects every 3rd element with class myList, beginning with the 3rd */}
 
-  .myList:nth-child(even) {/* Selects every even child of myList */}
+  .myList:nth-child(even) {/* Selects every even element with class myList */}
 ~~~
 
 ### Pseudo-elements


### PR DESCRIPTION
The `:nth-child` pseudo-class is appended to a selector which targets that element, not its parent. The wording is updated to reflect this.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`

Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete them later if they are not currently applicable:
-   [x] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [ ] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

<hr>

**1. Because:**
<!--
If this PR closes an open issue, replace the XXXXX below with the issue number, e.g. Closes #2013. Or if the issue is in another TOP repo replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

Otherwise, provide a clear and concise reason for your pull request, e.g. what problem it solves or what benefit it provides. If this PR is related to, but does not close, another issue or PR, you can also link it as above without the 'Closes' keyword, e.g. "Related to #2013".
 -->

The wording in the comments implies that the selectors target a child of the element with a class of `myList`. The `:nth-child` pseudo-class is supposed to be appended to a selector which targets that element, not its parent.

**2. This PR:**
<!--
A bullet point list of one or more items outlining what was done in this PR to solve the problem(s) or implement the feature/enhancement.
 -->

The wording is updated to reflect this.

**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->

https://discord.com/channels/505093832157691914/540903304046182425/985739518483243038