### PR TITLE
Feature: Add Stale Auto-labeler

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+
+name: Label inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: -1
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Because:**
* We should use automation to perform these useful but time consuming tasks to improve organisation

**This PR:**
* Adds a github action to auto label issues with stale after 30 days of inactivity.
* Will automatically remove the label if the issue is updated

For more information see the repo [here](https://github.com/actions/stale) or the docs [here](https://github.com/actions/stale). While this can be configured with a lot of different options, including automatically closing PRs / issues, I've gone for a simple and conservative approach at first to see if this has value.

Once a day this will run, labelling issues with 30 days of inactivity with `stale`. The label will be removed if there is activity on the issue again. At this stage there is no auto-closing.

