### PR TITLE
Getting Hired course: Preparing to Interview and Interviewing lesson: Replace broken link with archive link

### DIFF
--- a/getting_hired/applying_and_interviewing/preparing_to_interview_and_interviewing.md
+++ b/getting_hired/applying_and_interviewing/preparing_to_interview_and_interviewing.md
@@ -26,7 +26,7 @@ You'll probably be asked about some of the technical things you've listed on you
 
 FINAL NOTE -- this is not one-size-fits-all and many companies skip the light stuff and dive right into a technical screen so you've got to be prepared just in case!  The Coding Horror link below is more descriptive about that case.
 
-* [Mastering the phone screen by Monster](http://career-advice.monster.com/job-interview/interview-preparation/mastering-the-phone-interview/article.aspx)
+* [Mastering the phone screen by Monster](https://web.archive.org/web/20220512215006/https://www.monster.com/career-advice/article/mastering-the-phone-interview)
 * [7 Steps for Mastering the Telephone Interview](http://dorigan.com/how-to-interview/mastering-telephone-interview/)
 * [A much more technical phone screen from Coding Horror](http://www.codinghorror.com/blog/2008/01/getting-the-interview-phone-screen-right.html)
 


### PR DESCRIPTION
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`

-   [x] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [ ] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

<hr>

**1. Because:**

[This link](http://career-advice.monster.com/job-interview/interview-preparation/mastering-the-phone-interview/article.aspx) from the lesson is broken.


**2. This PR:**

- Replaces [this broken link](http://career-advice.monster.com/job-interview/interview-preparation/mastering-the-phone-interview/article.aspx) with [this web archive link](https://web.archive.org/web/20220512215006/https://www.monster.com/career-advice/article/mastering-the-phone-interview)


**3. Additional Information:**

The only outcome I can confirm is that it's broken on my side.
