### PR TITLE
JavaScript Advanced Concepts: Change link text

### DIFF
--- a/javascript/react_js/advanced_concepts.md
+++ b/javascript/react_js/advanced_concepts.md
@@ -44,7 +44,7 @@ The [Passing Data Deeply with Context webpage](https://beta.reactjs.org/learn/pa
 
 #### <span id="higher-order-components">5. Higher-order Components</span>
 
-Higher-order [components](https://reactjs.org/docs/higher-order-components.html) are components that consume another component and return a third component. This [article on HOC's by Smashing Magazine](https://www.smashingmagazine.com/2020/06/higher-order-components-react/) shows different use cases and provides some great comparisons to help you understand.
+[Higher-order components](https://reactjs.org/docs/higher-order-components.html) are components that consume another component and return a third component. This [article on HOC's by Smashing Magazine](https://www.smashingmagazine.com/2020/06/higher-order-components-react/) shows different use cases and provides some great comparisons to help you understand.
 
 #### <span id="more-hooks">6. More Hooks</span>
 


### PR DESCRIPTION
- In the Higher-order components section the link to the documentation originally highlighted only the word "components" instead of the full "Higher-order components" phrase.
- I have changed it to highlight all of the three words.

Complete the following REQUIRED checkboxes:
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`

Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete them later if they are not currently applicable:
-   [x] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [x] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

<hr>

**1. Because:**
- In the Advanced Concepts of the JavaScript lesson, there is a section on Higher-order components.
- The first three words of the section paragraph are "Higher-order components" but only the word "components" links to the Higher-order components documentation.
- I have changed it so that all the three words, when clicked, link to the documentation.
- Problem it solves: The text links in the paragraph now give clear indication of where the link leads to.


**2. This PR:**
- Includes all the the words "Higher-order", in addition to "components" as part of the text of the link to the Higher-order components documentation.
- Before: Higher-order [components](https://reactjs.org/docs/higher-order-components.html)
- After: [Higher-order components](https://reactjs.org/docs/higher-order-components.html) 

