### PR TITLE
Ruby on Rails / Turbo lesson:  Add missing 'do' in turbo block

### DIFF
--- a/ruby_on_rails/rails_sprinkles/turbo.md
+++ b/ruby_on_rails/rails_sprinkles/turbo.md
@@ -74,7 +74,7 @@ With the Turbo Frame helper, you can substitute the ID for a variable. For insta
 
 ~~~erb
 <% @articles.each do |article| %>
-  <%= turbo_frame_tag article %>
+  <%= turbo_frame_tag article do %>
     <%= article.title %>
   <% end %>
 <% end %>

--- a/ruby_on_rails/rails_sprinkles/turbo.md
+++ b/ruby_on_rails/rails_sprinkles/turbo.md
@@ -92,7 +92,7 @@ Let us replace the `/show` view with the `/edit` view on an article:
 # views/articles/show.html.erb
 
 ...
-<%= turbo_frame_tag @article %>
+<%= turbo_frame_tag @article do %>
   Content for our article!
   <%= link_to "Edit Article", edit_article_path(@article) %>
 <% end %>
@@ -103,7 +103,7 @@ Let us replace the `/show` view with the `/edit` view on an article:
 # views/articles/edit.html.erb
 
 ...
-<%= turbo_frame_tag @article %>
+<%= turbo_frame_tag @article do %>
   Form to edit the article
   <%= link_to "Return to Article", @article %>
 <% end %>


### PR DESCRIPTION
…a turbo block code

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`

Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete them later if they are not currently applicable:
-   [x] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

<hr>

**1. Because:**
<!--
If this PR closes an open issue, replace the XXXXX below with the issue number, e.g. Closes #2013. Or if the issue is in another TOP repo replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

Otherwise, provide a clear and concise reason for your pull request, e.g. what problem it solves or what benefit it provides. If this PR is related to, but does not close, another issue or PR, you can also link it as above without the 'Closes' keyword, e.g. "Related to #2013".
 -->
Fixes the simple syntax error.

**2. This PR:**
<!--
A bullet point list of one or more items outlining what was done in this PR to solve the problem(s) or implement the feature/enhancement.
 -->
* `turbo_frame_tag` block was missing a '`do`' , so I added it.


**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->
Posted my issue on DC, we quickly noticed that lesson had a minor syntax error, missing a `do` in a block. As soon as added `do` it worked as intended with no problems. Before that, I was having a syntax error and page won't load.
My message in `rails-help` channel: https://discord.com/channels/505093832157691914/514204607770001411/999287182655238174

