### PR TITLE
Fixed href of the first question in the knowledge check section

### DIFF
--- a/foundations/javascript_basics/DOM_manipulation_and_events.md
+++ b/foundations/javascript_basics/DOM_manipulation_and_events.md
@@ -394,7 +394,7 @@ Manipulating web pages is the primary benefit of the JavaScript language! These 
 
 This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
 
-*   <a class="knowledge-check-link" href="#dom---document-object-model">What is the DOM?</a>
+*   <a class="knowledge-check-link" href="#dom-document-object-model">What is the DOM?</a>
 *   <a class="knowledge-check-link" href="#targeting-nodes-with-selectors">How do you target the nodes you want to work with?</a>
 *   <a class="knowledge-check-link" href="#element-creation">How do you create an element in the DOM?</a>
 *   <a class="knowledge-check-link" href="#append-elements">How do you add an element to the DOM?</a>


### PR DESCRIPTION
Fixed href of the first question in the knowledge check section in this page:
https://www.theodinproject.com/lessons/foundations-dom-manipulation-and-events#knowledge-check

-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide]
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
