### PR TITLE
Objects and Object Constructors: Add explanation to distinguish b/w Constructor.prototype vs obj.__proto__

### DIFF
--- a/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
+++ b/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
@@ -182,8 +182,10 @@ Object.getPrototypeOf(player1) === Player.prototype
 Object.getPrototypeOf(player2) === Player.prototype
 ~~~
 
-Note: 
+Notes: 
+
 1. You might also find that `__proto__` is also referred to as `[[Prototype]]` which is from the JavaScript language specification.
+
 2. If you tried something like `Player.prototype.__proto__`, or you have a `__proto__` value which is equal to `null` and are confused, read on to find the explanation in the **Prototypal Inheritance** section!
 
 Now that you know that every object created by calling `new Player()` has its `__proto__` / `[[Prototype]]` special property set to refer to the `Player.prototype` value, let's move on!

--- a/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
+++ b/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
@@ -151,6 +151,43 @@ console.log(theHobbit.info());
 
 Before we go much further, there's something important you need to understand about JavaScript objects. All objects in JavaScript have a `prototype`. Stated simply, the prototype is another object that the original object _inherits_ from, which is to say, the original object has access to all of its prototype's methods and properties.
 
+To elaborate, there are two kinds of `prototype`, which are intertwined with each other. The _first_ kind is the one that exists on a **function**, which is referred to as `Player.prototype` in the case of the `Player` function in the previous example. 
+
+The _second_ kind is the one which exists on _all_ objects in JavaScript as a special property. This second `prototype` is referred to in a _non-standard_ way as, reusing our example, `player1.__proto__`, or `player2.__proto__`. This `__proto__` property comes into existence when an object is created, and is set to refer to the first kind of `prototype`. That is, in our example, `player1.__proto__` and `player2.__proto__` will have the value `Player.prototype`. You can test this in your browser console by defining `Player`, and creating the `player1` and `player2` objects.
+
+~~~javascript
+function Player(name, marker) {
+  this.name = name
+  this.marker = marker
+  this.sayName = function() {
+    console.log(name)
+  }
+}
+
+const player1 = new Player('steve', 'X')
+const player2 = new Player('also steve', 'O')
+
+// returns true for both player objects
+player1.__proto__ === Player.prototype
+player2.__proto__ === Player.prototype
+~~~
+
+However, you might have noticed that we mentioned `__proto__` is a non-standard way of referring to an object's `prototype` property. The MDN Docs [recommends](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) using [Object.getPrototypeOf()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf).
+
+So, our code above becomes:
+
+~~~javascript
+// returns true for both player objects
+Object.getPrototypeOf(player1) === Player.prototype
+Object.getPrototypeOf(player2) === Player.prototype
+~~~
+
+Note: 
+1. You might also find that `__proto__` is also referred to as `[[Prototype]]` which is from the JavaScript language specification.
+2. If you tried something like `Player.prototype.__proto__`, or you have a `__proto__` value which is equal to `null` and are confused, read on to find the explanation in the **Prototypal Inheritance** section!
+
+Now that you know that every object created by calling `new Player()` has its `__proto__` / `[[Prototype]]` special property set to refer to the `Player.prototype` value, let's move on!
+
 The concept of the prototype is an important one, so you’ve got some reading to do, which you'll find in the Assignment section below. Make sure you really get it before moving on!
 
 If you've understood the concept of the prototype, this next bit about constructors will not be confusing at all!


### PR DESCRIPTION
Complete the following REQUIRED checkboxes:
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`

Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete them later if they are not currently applicable:
-   [x] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [x] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

<hr>

**1. Because:**

The primary aim of this PR was to update the lesson's **Recommended Method for Prototypal Inheritance** content from using `Object.create()` to the `Object.setPrototypeOf()` method.

However I realized that the lesson also would need to better explain the `prototype` function property vs. the `__proto__` /  `[[Prototype]]` property and prototypal inheritance in this lesson, as personally to me as a learner, it was confusing and I had to refer to quite a few resources to understand it.

This is the first PR in an upcoming set of PRs to make the review process easier as suggested in the Discord forum post.

**2. This PR:**

* Explains the slight differences between the `Object.prototype` and the `obj.__proto__` concepts
* It also identifies that the `__proto__` way of referring to the `.prototype` property is now done using `Object.getPrototypeOf()` method.
* Provides examples to illustrate that `obj.__proto__` (or) `Object.getPrototypeOf(obj)` refers to `Object.prototype`.
* Recognizes that `__proto__` is also referred to as `[[Prototype]]` in the specification for clarity.
* Puts forth the idea that `__proto__` can have a `null` value and will be explained further in the lesson, and the explanation will be brought in through further edits (and PRs).

**3. Additional Information:**

* Suggestions-Bugs Forum discussion on Discord: https://discord.com/channels/505093832157691914/1010249197544538112
* Discussion on mdn/content: https://github.com/mdn/content/pull/18880 
* Next PR: #24563.
