### PR TITLE
Objects and Object Constructors: Add explanation of defining properties on Constructor.prototype

### DIFF
--- a/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
+++ b/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
@@ -182,8 +182,10 @@ Object.getPrototypeOf(player1) === Player.prototype
 Object.getPrototypeOf(player2) === Player.prototype
 ~~~
 
-Note: 
+Notes: 
+
 1. You might also find that `__proto__` is also referred to as `[[Prototype]]` which is from the JavaScript language specification.
+
 2. If you tried something like `Player.prototype.__proto__`, or you have a `__proto__` value which is equal to `null` and are confused, read on to find the explanation in the **Prototypal Inheritance** section!
 
 Now that you know that every object created by calling `new Player()` has its `__proto__` / `[[Prototype]]` special property set to refer to the `Player.prototype` value, let's move on!

--- a/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
+++ b/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
@@ -151,6 +151,43 @@ console.log(theHobbit.info());
 
 Before we go much further, there's something important you need to understand about JavaScript objects. All objects in JavaScript have a `prototype`. Stated simply, the prototype is another object that the original object _inherits_ from, which is to say, the original object has access to all of its prototype's methods and properties.
 
+To elaborate, there are two kinds of `prototype`, which are intertwined with each other. The _first_ kind is the one that exists on a **function**, which is referred to as `Player.prototype` in the case of the `Player` function in the previous example. 
+
+The _second_ kind is the one which exists on _all_ objects in JavaScript as a special property. This second `prototype` is referred to in a _non-standard_ way as, reusing our example, `player1.__proto__`, or `player2.__proto__`. This `__proto__` property comes into existence when an object is created, and is set to refer to the first kind of `prototype`. That is, in our example, `player1.__proto__` and `player2.__proto__` will have the value `Player.prototype`. You can test this in your browser console by defining `Player`, and creating the `player1` and `player2` objects.
+
+~~~javascript
+function Player(name, marker) {
+  this.name = name
+  this.marker = marker
+  this.sayName = function() {
+    console.log(name)
+  }
+}
+
+const player1 = new Player('steve', 'X')
+const player2 = new Player('also steve', 'O')
+
+// returns true for both player objects
+player1.__proto__ === Player.prototype
+player2.__proto__ === Player.prototype
+~~~
+
+However, you might have noticed that we mentioned `__proto__` is a non-standard way of referring to an object's `prototype` property. The MDN Docs [recommends](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) using [Object.getPrototypeOf()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf).
+
+So, our code above becomes:
+
+~~~javascript
+// returns true for both player objects
+Object.getPrototypeOf(player1) === Player.prototype
+Object.getPrototypeOf(player2) === Player.prototype
+~~~
+
+Note: 
+1. You might also find that `__proto__` is also referred to as `[[Prototype]]` which is from the JavaScript language specification.
+2. If you tried something like `Player.prototype.__proto__`, or you have a `__proto__` value which is equal to `null` and are confused, read on to find the explanation in the **Prototypal Inheritance** section!
+
+Now that you know that every object created by calling `new Player()` has its `__proto__` / `[[Prototype]]` special property set to refer to the `Player.prototype` value, let's move on!
+
 The concept of the prototype is an important one, so you’ve got some reading to do, which you'll find in the Assignment section below. Make sure you really get it before moving on!
 
 If you've understood the concept of the prototype, this next bit about constructors will not be confusing at all!

--- a/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
+++ b/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
@@ -190,9 +190,7 @@ Notes:
 
 Now that you know that every object created by calling `new Player()` has its `__proto__` / `[[Prototype]]` special property set to refer to the `Player.prototype` value, let's move on!
 
-The concept of the prototype is an important one, so you’ve got some reading to do, which you'll find in the Assignment section below. Make sure you really get it before moving on!
-
-If you've understood the concept of the prototype, this next bit about constructors will not be confusing at all!
+To expand on the first kind of `prototype`, that is, the one that exists on the `Player` object constructor as `Player.prototype`, it is best to define functions on this `prototype` property. To explain, let's take another example where we create `Student` objects by defining a `Student` object constructor:
 
 ~~~javascript
 function Student(name, grade) {
@@ -208,7 +206,22 @@ Student.prototype.goToProm = function() {
 }
 ~~~
 
-If you're using constructors to make your objects it is best to define functions on the `prototype` of that object. Doing so means that a single instance of each function will be shared between all of the Student objects. If we declare the function directly in the constructor, like we did when they were first introduced, that function would be duplicated every time a new Student is created. In this example, that wouldn't really matter much, but in a project that is creating thousands of objects, it really can make a difference.
+In the above code, defining functions of the object on the `prototype` means that a single instance of each function will be shared between all of the `Student` objects. If we declare the function directly in the constructor (like we did in the `Player` example) the `sayName` and `goToProm` functions would be duplicated _every_ time a new `Student` is created. In this example, that wouldn't really matter much, but in a project that is creating thousands of objects, it really can make a difference.
+
+To finally bring the concepts of `__proto__` / `[[Prototype]]` and `prototype` together - we can see from the following code that since the `Student` objects' `__proto__` values point to `Student.prototype`,  the `student1` and the `student2` objects both have access to the functions which were defined on `Student.prototype`.
+
+~~~javascript
+student1 = new Student("Harvey", 8);
+student2 = new Student("James", 4);
+
+student1.sayName(); // Harvey
+student1.goToProm(); // Eh.. go to prom?
+
+student2.sayName();  // James
+student2.goToProm(); // Eh.. go to prom?
+~~~
+
+The concept of the prototype is an important one, so you’ve got some reading to do, which you'll find in the Assignment section below. Make sure you really get it before moving on!
 
 #### Recommended Method for Prototypal Inheritance
 


### PR DESCRIPTION
Complete the following REQUIRED checkboxes:
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`

Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete them later if they are not currently applicable:
-   [x] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [x] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

<hr>

**1. Because:**
Related to #24560.

**2. This PR:**
* Adds on to the previously explained concepts of `__proto__` vs. `Constructor.prototype` in [this commit](https://github.com/TheOdinProject/curriculum/commit/a2945b5767f1a771969c52b4e6e22750aa2c6408) -- basically this is the first mini-PR queued after #24560.
* Attempts to clarify the explanation of how `Constructor.prototype` is related to `__proto__` of created objects.

**3. Additional Information:**
* Suggestions-Bugs Forum discussion on Discord: https://discord.com/channels/505093832157691914/1010249197544538112
* Discussion on mdn/content: https://github.com/mdn/content/pull/18880
* Previous PR: #24560.
* Next PR: #24782.

