### PR TITLE
Foundations Installations: Remove conflicting instruction

### DIFF
--- a/foundations/installations/installations.md
+++ b/foundations/installations/installations.md
@@ -126,7 +126,7 @@ While your VM is running, do the following steps:
   12. Let's take a look at the contents of the CD image we just mounted. If you see a File Manager window appear, then confirm the presence of a file named `VBoxLinuxAdditions.run`. If that file is present, you can move on to step 13. If you do _not_ see a File Manager window appear, then navigate to the desktop by minimizing all opened windows, and then double-click on the folder called Home on the VM desktop. Afterwards, click on a CD under Devices on the left side of the window called `VBox_GAs_x.x.x` where the x's are the version number.  Now you can confirm that the file `VBoxLinuxAdditions.run` is present. If you see that file, move on to step 13.
   13. In the window we opened in step 12, click File > **Open Terminal Here** - this should open a terminal with the prompt ending in something like `VBox_GAs_x.x.x` where the x's are the version number.
   14. In the newly opened terminal window, paste `sudo ./VBoxLinuxAdditions.run` and hit enter.
-  15. Once it finishes, close the terminal and the CD folder.
+  15. Once it finishes, close the terminal.
   16. Right-click CD under Devices in the File Manager window and click **Eject**. If you have closed that window in the meantime go back to point 12. to see how to bring it up again.
   17. Reboot your VM (which you can do by typing `reboot` and hitting enter in a terminal).
   18. You can now maximize the VM window, create additional displays, and use many other useful features. These options are available on the VM toolbar under **View** and **Device**.


### PR DESCRIPTION
Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`

Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete them later if they are not currently applicable:
-   [ ] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [ ] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

<hr>

**1. Because:**

Point 15. and point 16. are in conflict with each other - point 16. assumes that the window is still open, while point 15. tells you to close it. I forgot to test whether it is indeed required to close the directory for eject to work. You don't have to close the directory, but you have to close the terminal.

**2. This PR:**

Removes the bit about closing the `File Manager` window that is needed for the next step to eject the .iso.

**3. Additional Information:**

