### PR TITLE
Ruby on Rails: Stimulus: Fix a faulty example

### DIFF
--- a/ruby_on_rails/rails_sprinkles/stimulus_js.md
+++ b/ruby_on_rails/rails_sprinkles/stimulus_js.md
@@ -136,7 +136,7 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
     static targets = ["name", "output"]
     greet() {
-        this.outputTarget.innerHTML = "Hello " + this.nameTarget.value + "!"
+        this.outputTarget.innerHTML = `Hello ${this.nameTarget.value}!`
     }
 }
 ~~~

--- a/ruby_on_rails/rails_sprinkles/stimulus_js.md
+++ b/ruby_on_rails/rails_sprinkles/stimulus_js.md
@@ -122,11 +122,8 @@ Again Stimulus gives you a way to declare elements you want to select in the HTM
 
 ~~~html
 <div data-controller="greeter">
-  <input type="text" 
-         data-action="click->greeter#greet" 
-         data-greeter-target="name">
-    Alert me!
-  </input>
+  <input type="text" data-greeter-target="name">
+  <button data-action="click->greeter#greet">Greet me</button>
   <div data-greeter-target="output"></div>
 </div>
 ~~~
@@ -139,7 +136,7 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
     static targets = ["name", "output"]
     greet() {
-        this.nameTarget.html = this.outputTarget.value
+        this.outputTarget.innerHTML = "Hello " + this.nameTarget.value + "!"
     }
 }
 ~~~


### PR DESCRIPTION

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`

Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete them later if they are not currently applicable:
-   [x] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [x] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

<hr>

**1. Because:**

The example code for targets has several errors, switching target, having invalid closing input tags, it just plain won't work, when people try to copy it.

**2. This PR:**
<!--
A bullet point list of one or more items outlining what was done in this PR to solve the problem(s) or implement the feature/enhancement.
 -->
Puts correct code, that can be put into your application and will work.

**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->

example of a confused person: https://discord.com/channels/505093832157691914/514204607770001411/1015910188190011402 they were not the first person to be confused by this.
