### PR TITLE
React Hooks: changed confusing phrasing about 'useEffect' and ESLint

### DIFF
--- a/javascript/react_js/hooks.md
+++ b/javascript/react_js/hooks.md
@@ -107,7 +107,7 @@ The syntax is as follows:
 
 `useEffect(() => {}, [])`
 
-In the curly brackets you can write the code that will be executed. The dependency array at the end is optional, however, you will include it more often than not. A dependency is any state, prop, context that is used within the `useEffect` callback. You can also include state or props that are not. `useEffect` will trigger based on changes in the dependencies listed. ESLint will warn you if it expects a dependency, but one is not added, however, this is a warning and they are not **required**.
+In the curly brackets you can write the code that will be executed. The dependency array at the end is optional, however, you will include it more often than not. A dependency is any state, prop or context that is used within the `useEffect` callback, but you can also include state or props that are not. `useEffect` will trigger based on changes in the dependencies listed. ESLint will warn you if it expects a dependency, however, this is a warning and they are not **required**.
 
 You have three different options for the <span id='dependency'>dependency</span> array:
 


### PR DESCRIPTION
Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`

Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete them later if they are not currently applicable:
-   [x] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [ ] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

<hr>

**1. Because:**
Wording was confused and probably a result of a copy paste error.


**2. This PR:**
- The dependency array at the end is optional, however, you will include it more often than not. A dependency is any state, prop, context that is used within the `useEffect` callback. You can also include state or props that are not.
=== becomes ===
The dependency array at the end is optional, however, you will include it more often than not. A dependency is any state, prop or context that is used within the `useEffect` callback, but you can also include state or props that are not.
- `useEffect` will trigger based on changes in the dependencies listed. ESLint will warn you if it expects a dependency, but one is not added, however, this is a warning and they are not **required**. 
=== becomes ===
`useEffect` will trigger based on changes in the dependencies listed. ESLint will warn you if it expects a dependency, however, this is a warning and they are not **required**.


**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->

