### PR TITLE
Node.js Getting Started: Node.js Learn Links Outdated

### DIFF
--- a/nodeJS/introduction_to_nodeJS/getting_started.md
+++ b/nodeJS/introduction_to_nodeJS/getting_started.md
@@ -18,25 +18,25 @@ By the end of this lesson, you should be able to do the following:
 
 <div class="lesson-content__panel" markdown="1">
 
-- Let's dive in and start looking at Node server-side code! We will be hopping around lessons in the [NodeJS.dev](https://nodejs.dev/learn) docs which you should follow along.
+- Let's dive in and start looking at Node server-side code! We will be hopping around lessons in the [NodeJS.dev](https://nodejs.dev/en/learn) docs which you should follow along.
   - Get Started
-    - Learn how to run Node.js scripts from the terminal in [this](https://nodejs.dev/learn/run-nodejs-scripts-from-the-command-line) lesson.
-    - Learn quickly about .env files and how we use them [here](https://nodejs.dev/learn/how-to-read-environment-variables-from-nodejs)! This will become very important in the future when working with databases and other sensitive credentials!
+    - Learn how to run Node.js scripts from the terminal in [this](https://nodejs.dev/en/learn/run-nodejs-scripts-from-the-command-line) lesson.
+    - Learn quickly about .env files and how we use them [here](https://nodejs.dev/en/learn/how-to-read-environment-variables-from-nodejs)! This will become very important in the future when working with databases and other sensitive credentials!
   - HTTP Module
-    - Learn how to [Build an HTTP server](https://nodejs.dev/learn/build-an-http-server), and then [how to make HTTP requests with Node](https://nodejs.dev/learn/making-http-requests-with-nodejs).
+    - Learn how to [Build an HTTP server](https://nodejs.dev/en/learn/build-an-http-server), and then [how to make HTTP requests with Node](https://nodejs.dev/en/learn/making-http-requests-with-nodejs).
   - File System
-    - First, take a look at the [fs module](https://nodejs.dev/learn/the-nodejs-fs-module) that we use heavily for working with files in Node.
-    - Then, let's start [writing files](https://nodejs.dev/learn/writing-files-with-nodejs) in Node.
-    - Finally, we'll learn how to [read files](https://nodejs.dev/learn/reading-files-with-nodejs).
+    - First, take a look at the [fs module](https://nodejs.dev/en/learn/the-nodejs-fs-module) that we use heavily for working with files in Node.
+    - Then, let's start [writing files](https://nodejs.dev/en/learn/writing-files-with-nodejs) in Node.
+    - Finally, we'll learn how to [read files](https://nodejs.dev/en/learn/reading-files-with-nodejs).
   - The URL Class
     - Check out this [documentation](https://nodejs.org/api/url.html#url_the_whatwg_url_api) on the URL class. Play with the code samples to see how it works!
   - NPM
-    - Let's get an [introduction](https://nodejs.dev/learn/an-introduction-to-the-npm-package-manager) to NPM.
-    - After that, it's time to quickly get introduced to the [package.json file](https://nodejs.dev/learn/the-packagejson-guide).
-    - And the differences between [NPM global and local packages](https://nodejs.dev/learn/npm-global-or-local-packages).
+    - Let's get an [introduction](https://nodejs.dev/en/learn/an-introduction-to-the-npm-package-manager) to NPM.
+    - After that, it's time to quickly get introduced to the [package.json file](https://nodejs.dev/en/learn/the-packagejson-guide).
+    - And the differences between [NPM global and local packages](https://nodejs.dev/en/learn/npm-global-or-local-packages).
   - Events
-    - Follow along the [Event Emitter](https://nodejs.dev/learn/the-nodejs-event-emitter) section.
-    - Look into [this](https://nodejs.dev/learn/the-nodejs-events-module) section to see the `events` module.
+    - Follow along the [Event Emitter](https://nodejs.dev/en/learn/the-nodejs-event-emitter) section.
+    - Look into [this](https://nodejs.dev/en/learn/the-nodejs-events-module) section to see the `events` module.
     
 - Optional Extra Credit!
   - Although a bit outdated, the W3 Schools introduction to Node.js is super useful!  Go to the [W3 Schools node tutorial](https://www.w3schools.com/nodejs/default.asp) and code along with the following lessons (which should be listed on the sidebar of their site). Specifically, work from the **Node.js Intro** through to **Node.js Events**. You can look at the **File Uploads** and **Email** sections if you're feeling particularly ambitious! **NOTE**: The URL module is very outdated. Refer to the earlier link if you run into issues in the Node.js URL Module from W3.
@@ -48,10 +48,10 @@ By the end of this lesson, you should be able to do the following:
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
 
-- <a class="knowledge-check-link" href="https://nodejs.dev/learn/the-nodejs-fs-module">What is a File System Module? How and why would you use it?</a>
-- <a class="knowledge-check-link" href="https://nodejs.dev/learn/npm-global-or-local-packages">What is the command for installing a package locally in with npm?</a>
-- <a class="knowledge-check-link" href="https://nodejs.dev/learn/npm-global-or-local-packages">What is the command for installing a package globally in with npm?</a>
-- <a class="knowledge-check-link" href="https://nodejs.dev/learn/npm-global-or-local-packages">What is the difference between a global and local package install with npm?</a>
+- <a class="knowledge-check-link" href="https://nodejs.dev/en/learn/the-nodejs-fs-module">What is a File System Module? How and why would you use it?</a>
+- <a class="knowledge-check-link" href="https://nodejs.dev/en/learn/npm-global-or-local-packages">What is the command for installing a package locally in with npm?</a>
+- <a class="knowledge-check-link" href="https://nodejs.dev/en/learn/npm-global-or-local-packages">What is the command for installing a package globally in with npm?</a>
+- <a class="knowledge-check-link" href="https://nodejs.dev/en/learn/npm-global-or-local-packages">What is the difference between a global and local package install with npm?</a>
 
 
 ### Additional Resources


### PR DESCRIPTION

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`

Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete them later if they are not currently applicable:
-   [X] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [X] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

<hr>

**1. Because:**
<!--
If this PR closes an open issue, replace the XXXXX below with the issue number, e.g. Closes #2013. Or if the issue is in another TOP repo replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

Otherwise, provide a clear and concise reason for your pull request, e.g. what problem it solves or what benefit it provides. If this PR is related to, but does not close, another issue or PR, you can also link it as above without the 'Closes' keyword, e.g. "Related to #2013".
 -->
All of the links to the Node.js Learn pages were outdated. The new URL path requires a language specification between "nodejs.dev" and "/learn". This outdated path format leads to a "page not found" error. My proposed change involves adding "/en/" in the URL path in order to link to the proper page.


**2. This PR:**
<!--
A bullet point list of one or more items outlining what was done in this PR to solve the problem(s) or implement the feature/enhancement.
 -->
-Added "/en/" to Node.js Learn Page URLs in order to match updated path format.


**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->

