### PR TITLE
Fix Grammar: Problem Solving

### DIFF
--- a/foundations/javascript_basics/problem_solving.md
+++ b/foundations/javascript_basics/problem_solving.md
@@ -6,7 +6,7 @@ Problem solving is the core thing software developers do. The programming langua
 
 V. Anton Spraul defines problem solving in programming as:
 
-> "Problem solving is writing an original program that performs a particular set of tasks and meets all stated constraints."
+> 'Problem solving is writing an original program that performs a particular set of tasks and meets all stated constraints.'
 - Think Like a Programmer
 
 The set of tasks can range from solving small coding exercises all the way up to building a social network site like Facebook or a search engine like Google. Each problem has its own set of constraints, for example, high performance and scalability may not matter too much in a coding exercise but it will be vital in apps like Google that need to service billions of search queries each day.

--- a/foundations/javascript_basics/problem_solving.md
+++ b/foundations/javascript_basics/problem_solving.md
@@ -6,8 +6,7 @@ Problem solving is the core thing software developers do. The programming langua
 
 V. Anton Spraul defines problem solving in programming as:
 
-> Problem solving is writing an original program that performs a particular set of tasks and meets all stated constraints.
-- Think Like a Programmer
+> 'Problem solving is writing an original program that performs a particular set of tasks and meets all stated constraints.' - Think Like a Programmer
 
 The set of tasks can range from solving small coding exercises all the way up to building a social network site like Facebook or a search engine like Google. Each problem has its own set of constraints, for example, high performance and scalability may not matter too much in a coding exercise but it will be vital in apps like Google that need to service billions of search queries each day.
 

--- a/foundations/javascript_basics/problem_solving.md
+++ b/foundations/javascript_basics/problem_solving.md
@@ -6,7 +6,7 @@ Problem solving is the core thing software developers do. The programming langua
 
 V. Anton Spraul defines problem solving in programming as:
 
-> 'Problem solving is writing an original program that performs a particular set of tasks and meets all stated constraints.'
+> Problem solving is writing an original program that performs a particular set of tasks and meets all stated constraints.
 - Think Like a Programmer
 
 The set of tasks can range from solving small coding exercises all the way up to building a social network site like Facebook or a search engine like Google. Each problem has its own set of constraints, for example, high performance and scalability may not matter too much in a coding exercise but it will be vital in apps like Google that need to service billions of search queries each day.

--- a/foundations/javascript_basics/problem_solving.md
+++ b/foundations/javascript_basics/problem_solving.md
@@ -6,7 +6,7 @@ Problem solving is the core thing software developers do. The programming langua
 
 V. Anton Spraul defines problem solving in programming as:
 
-> 'Problem solving is writing an original program that performs a particular set of tasks and meets all stated constraints.' - Think Like a Programmer
+> Problem solving is writing an original program that performs a particular set of tasks and meets all stated constraints. <br /> - Think Like a Programmer
 
 The set of tasks can range from solving small coding exercises all the way up to building a social network site like Facebook or a search engine like Google. Each problem has its own set of constraints, for example, high performance and scalability may not matter too much in a coding exercise but it will be vital in apps like Google that need to service billions of search queries each day.
 


### PR DESCRIPTION
Saw that we were using double quotes on double quotes for the beginning quote. Fixed by replacing inner double quotes with single quotes.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`

Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete them later if they are not currently applicable:
-   [ ] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [ ] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

<hr>

**1. Because:**
<!--
If this PR closes an open issue, replace the XXXXX below with the issue number, e.g. Closes #2013. Or if the issue is in another TOP repo replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

Otherwise, provide a clear and concise reason for your pull request, e.g. what problem it solves or what benefit it provides. If this PR is related to, but does not close, another issue or PR, you can also link it as above without the 'Closes' keyword, e.g. "Related to #2013".
 -->
Closes #XXXXX
Because ""Fiattarone's quote" -- Fiattarone" is incorrect, it should be:  "'Fiattarone's quote' -- Fiattarone"

It may not be obvious at first, but the " > " induces a quote line which includes the " "'s automatically. 

**2. This PR:**
<!--
A bullet point list of one or more items outlining what was done in this PR to solve the problem(s) or implement the feature/enhancement.
 -->
- Replaced inner double quotes with a set of single quotes


**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->

