### PR TITLE
Update project_event_manager.md: Fix space between legislators urls

### DIFF
--- a/ruby/files_and_serialization/project_event_manager.md
+++ b/ruby/files_and_serialization/project_event_manager.md
@@ -1287,7 +1287,7 @@ return to the application.
         <% legislators.each do |legislator| %>
         <tr>
           <td><%= "#{legislator.name}" %></td>
-          <td><%= "#{legislator.urls.join}" unless legislator.urls.nil? %></td>
+          <td><%= "#{legislator.urls.join(" ")}" unless legislator.urls.nil? %></td>
         </tr>
         <% end %>
     <% else %>


### PR DESCRIPTION
Without the separator when we create the "thanks letters" the urls of the legislators are together

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`

Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete them later if they are not currently applicable:
-   [ ] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [ ] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

<hr>

**1. Because:**
<!--
If this PR closes an open issue, replace the XXXXX below with the issue number, e.g. Closes #2013. Or if the issue is in another TOP repo replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

Otherwise, provide a clear and concise reason for your pull request, e.g. what problem it solves or what benefit it provides. If this PR is related to, but does not close, another issue or PR, you can also link it as above without the 'Closes' keyword, e.g. "Related to #2013".
 -->
The legislator's urls on the erb template appeared together when the "form letters" were created. So adding the separator (" ") to join solve the issue.


**2. This PR:**
<!--
* Added the separator (" ") to <td><%= "#{legislator.urls.join(" ")}" unless legislator.urls.nil? %></td>
 -->


**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->

