### PR TITLE
Objects and Object Constructors: Add section 'Prototypal Inheritance' to explain .__proto__ vs. .prototype

### DIFF
--- a/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
+++ b/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
@@ -182,8 +182,10 @@ Object.getPrototypeOf(player1) === Player.prototype
 Object.getPrototypeOf(player2) === Player.prototype
 ~~~
 
-Note: 
+Notes: 
+
 1. You might also find that `__proto__` is also referred to as `[[Prototype]]` which is from the JavaScript language specification.
+
 2. If you tried something like `Player.prototype.__proto__`, or you have a `__proto__` value which is equal to `null` and are confused, read on to find the explanation in the **Prototypal Inheritance** section!
 
 Now that you know that every object created by calling `new Player()` has its `__proto__` / `[[Prototype]]` special property set to refer to the `Player.prototype` value, let's move on!

--- a/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
+++ b/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
@@ -151,6 +151,43 @@ console.log(theHobbit.info());
 
 Before we go much further, there's something important you need to understand about JavaScript objects. All objects in JavaScript have a `prototype`. Stated simply, the prototype is another object that the original object _inherits_ from, which is to say, the original object has access to all of its prototype's methods and properties.
 
+To elaborate, there are two kinds of `prototype`, which are intertwined with each other. The _first_ kind is the one that exists on a **function**, which is referred to as `Player.prototype` in the case of the `Player` function in the previous example. 
+
+The _second_ kind is the one which exists on _all_ objects in JavaScript as a special property. This second `prototype` is referred to in a _non-standard_ way as, reusing our example, `player1.__proto__`, or `player2.__proto__`. This `__proto__` property comes into existence when an object is created, and is set to refer to the first kind of `prototype`. That is, in our example, `player1.__proto__` and `player2.__proto__` will have the value `Player.prototype`. You can test this in your browser console by defining `Player`, and creating the `player1` and `player2` objects.
+
+~~~javascript
+function Player(name, marker) {
+  this.name = name
+  this.marker = marker
+  this.sayName = function() {
+    console.log(name)
+  }
+}
+
+const player1 = new Player('steve', 'X')
+const player2 = new Player('also steve', 'O')
+
+// returns true for both player objects
+player1.__proto__ === Player.prototype
+player2.__proto__ === Player.prototype
+~~~
+
+However, you might have noticed that we mentioned `__proto__` is a non-standard way of referring to an object's `prototype` property. The MDN Docs [recommends](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) using [Object.getPrototypeOf()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf).
+
+So, our code above becomes:
+
+~~~javascript
+// returns true for both player objects
+Object.getPrototypeOf(player1) === Player.prototype
+Object.getPrototypeOf(player2) === Player.prototype
+~~~
+
+Note: 
+1. You might also find that `__proto__` is also referred to as `[[Prototype]]` which is from the JavaScript language specification.
+2. If you tried something like `Player.prototype.__proto__`, or you have a `__proto__` value which is equal to `null` and are confused, read on to find the explanation in the **Prototypal Inheritance** section!
+
+Now that you know that every object created by calling `new Player()` has its `__proto__` / `[[Prototype]]` special property set to refer to the `Player.prototype` value, let's move on!
+
 The concept of the prototype is an important one, so you’ve got some reading to do, which you'll find in the Assignment section below. Make sure you really get it before moving on!
 
 If you've understood the concept of the prototype, this next bit about constructors will not be confusing at all!

--- a/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
+++ b/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
@@ -190,9 +190,7 @@ Notes:
 
 Now that you know that every object created by calling `new Player()` has its `__proto__` / `[[Prototype]]` special property set to refer to the `Player.prototype` value, let's move on!
 
-The concept of the prototype is an important one, so you’ve got some reading to do, which you'll find in the Assignment section below. Make sure you really get it before moving on!
-
-If you've understood the concept of the prototype, this next bit about constructors will not be confusing at all!
+To expand on the first kind of `prototype`, that is, the one that exists on the `Player` object constructor as `Player.prototype`, it is best to define functions on this `prototype` property. To explain, let's take another example where we create `Student` objects by defining a `Student` object constructor:
 
 ~~~javascript
 function Student(name, grade) {
@@ -208,7 +206,22 @@ Student.prototype.goToProm = function() {
 }
 ~~~
 
-If you're using constructors to make your objects it is best to define functions on the `prototype` of that object. Doing so means that a single instance of each function will be shared between all of the Student objects. If we declare the function directly in the constructor, like we did when they were first introduced, that function would be duplicated every time a new Student is created. In this example, that wouldn't really matter much, but in a project that is creating thousands of objects, it really can make a difference.
+In the above code, defining functions of the object on the `prototype` means that a single instance of each function will be shared between all of the `Student` objects. If we declare the function directly in the constructor (like we did in the `Player` example) the `sayName` and `goToProm` functions would be duplicated _every_ time a new `Student` is created. In this example, that wouldn't really matter much, but in a project that is creating thousands of objects, it really can make a difference.
+
+To finally bring the concepts of `__proto__` / `[[Prototype]]` and `prototype` together - we can see from the following code that since the `Student` objects' `__proto__` values point to `Student.prototype`,  the `student1` and the `student2` objects both have access to the functions which were defined on `Student.prototype`.
+
+~~~javascript
+student1 = new Student("Harvey", 8);
+student2 = new Student("James", 4);
+
+student1.sayName(); // Harvey
+student1.goToProm(); // Eh.. go to prom?
+
+student2.sayName();  // James
+student2.goToProm(); // Eh.. go to prom?
+~~~
+
+The concept of the prototype is an important one, so you’ve got some reading to do, which you'll find in the Assignment section below. Make sure you really get it before moving on!
 
 #### Recommended Method for Prototypal Inheritance
 

--- a/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
+++ b/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
@@ -223,7 +223,48 @@ student2.goToProm(); // Eh.. go to prom?
 
 The concept of the prototype is an important one, so you’ve got some reading to do, which you'll find in the Assignment section below. Make sure you really get it before moving on!
 
+#### Prototypal Inheritance
+
+Phew. That was a lot. But buckle up, because there's a little more you need to read to understand it all! You may also now have a question - what's with the `__proto__` of an object pointing to `prototype`? OK, we define functions common among all objects on the `prototype` since it saves memory. Now is that the only thing it's for? Of course not, and we of course, come to the concept of **Prototypal Inheritance**.
+
+You see, we said this before in the intro to the prototype.
+
+> All objects in JavaScript have a `prototype`. Stated simply, the prototype is another object that the original object _inherits_ from, which is to say, the original object has access to all of its prototype's methods and properties.
+
+Hopefully, this makes sense now! If not, don't worry and read on to find out!
+
+Let's break it down - "the `prototype` is another **object** that the original object (i.e., the original object is the created object instance, like `player1` or `student1`) _inherits_ from."
+
+1. The `prototype` is another object - now since we also said every object has a `__proto__` (hidden) property, even the `prototype` has it! This also explains why `Player.prototype.__proto__` contained a value - which is what? We'll get to that in just a moment!
+
+2. The original object inherits from the `prototype` object - by inheriting, it just means that the created object's `__proto__` property is pointing to the `prototype` object.
+
+To finish up with an example, we can say that the `player1` or the `student1` objects thus _inherit_ from their respective `Player` or `Student` `prototype` objects.
+
+Let's now try to do the following with our previously created `student1` object:
+
+~~~javascript
+student1.valueOf() // Object { name: "Harvey", grade: 8 }
+~~~
+
+What's this `valueOf()` function, and where did it come from if we did not define it? The answer is that it comes as a result of `Student.prototype.__proto__` having the value of `Object.prototype`! This means that `Student.prototype` is inheriting from `Object.prototype` and that `valueOf()` is a function defined on `Object.prototype` just like how `goToProm()` is defined on `Student.prototype`.
+
+Essentially, this is how JavaScript makes use of `prototype` and `__proto__` - by having the `__proto__` values of objects point to `prototype`s and inheriting from those prototypes, and thus forming a chain. This kind of inheritance using prototypes is hence named as Prototypal inheritance. JavaScript figures out which properties exist (or do not exist) on the object and starts traversing the chain to find the property or function, like so:
+
+1. Is the `valueOf()` function part of the `student1` object? No, it is not. (Remember, only the `name` and the `grade` properties are part of the `Student` objects.)
+
+2. Is the function part of the `student1`'s prototype (the `student1.__proto__` value, i.e., `Student.prototype`)? No, only the `sayName()` and the `goToProm()` functions are part of it.
+
+3. Well, then, is it part of `Student.prototype.__proto__` (=== `Object.prototype`)? Yes, `valueOf()` is defined on `Object.prototype`!
+
+However, this chain does not go on forever, and if you have already tried logging the value of `Object.prototype.__proto__`, you would find that it is `null`, thus indicating the end of the chain. And it is at the end of this chain that if the specific property or function is not found, `undefined` is returned.
+
+Note: Every `prototype` object inherits from `Object.prototype` by default.
+
+
 #### Recommended Method for Prototypal Inheritance
+
+<!-- maybe have to include Animal.call(this) in the Cat constructor, along with setting Cat.prototype.constructor = Cat -->
 
 So far you have seen several ways of making an object inherit the prototype from another object. At this point in history, the recommended way of setting the prototype of an object is `Object.create` ([here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create) is the documentation for that method). `Object.create` very simply returns a new object with the specified prototype and any additional properties you want to add. For our purposes, you use it like so:
 


### PR DESCRIPTION
Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`

Complete the following checkboxes ONLY IF they are applicable to your PR. You can complete them later if they are not currently applicable:
-   [x] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [x] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

<hr>

**1. Because:**
Related to #24560 and #24563.

**2. This PR:**
* Attempts to further clarify and distinguish between `__proto__` (`[[Prototype]]`) and `prototype`.
* Explains how the prototype chain works.

**3. Additional Information:**
* Suggestions-Bugs [Forum discussion](https://discord.com/channels/505093832157691914/1010249197544538112) on Discord.
* [Discussion](https://github.com/mdn/content/pull/18880) on mdn/content.
* Previous PR: #24563
* Next PR: TBD, and to be based on the resolution of [this mdn/content PR](https://github.com/mdn/content/pull/20693)

