### PR TITLE
Using Ruby On Rails For Your Back End: Fix link URLs

### DIFF
--- a/javascript/javascript_and_the_backend/using_rails_for_your_backend.md
+++ b/javascript/javascript_and_the_backend/using_rails_for_your_backend.md
@@ -24,7 +24,7 @@ Are you done? Good. Next, it's time to practice allowing your front end JavaScri
 
 1. [Check out "Using JavaScript in your Rails App" from Daniel Kehoe](http://railsapps.github.io/rails-javascript-include-external.html). It is long and covers a lot of ground, but it's got great content. Some of the stuff on dependencies can be skimmed, but pay attention to the `content_for` stuff at the bottom.
 
-2. [Refresh yourself on Rails AJAX from RailsGuides](http://edgeguides.rubyonrails.org/working_with_javascript_in_rails.html) (just skim the top few sections).
+2. [Refresh yourself on Rails AJAX from RailsGuides](https://guides.rubyonrails.org/v4.2/working_with_javascript_in_rails.html) (just skim the top few sections).
 
 3. Read [Bootstrapping JSON data into a Rails View](http://jfire.io/blog/2012/04/30/how-to-securely-bootstrap-json-in-a-rails-view) to learn about passing data to your front end.
 
@@ -40,6 +40,6 @@ This section contains helpful links to other content. It isn't required, so cons
 ### Knowledge Check
 
 * <a class="knowledge-check-link" href="https://railsapps.github.io/rails-javascript-include-external.html#locations" > How do you load custom JavaScript in a given Rails view page? </a>
-* <a class="knowledge-check-link" href="https://edgeguides.rubyonrails.org/working_with_javascript_in_rails.html#unobtrusive-javascript" >How does "unobtrusive JavaScript" work?</a>
+* <a class="knowledge-check-link" href="https://guides.rubyonrails.org/v4.2/working_with_javascript_in_rails.html#unobtrusive-javascript" >How does "unobtrusive JavaScript" work?</a>
 * <a class="knowledge-check-link" href="https://railsapps.github.io/rails-javascript-include-external.html#parameters" >How can you pass data from your Rails app to your JavaScript?</a>
-* <a class="knowledge-check-link" href="https://edgeguides.rubyonrails.org/working_with_javascript_in_rails.html#an-introduction-to-ajax" >Why would you want to use AJAX to load large batches of data?</a>
+* <a class="knowledge-check-link" href="https://guides.rubyonrails.org/v4.2/working_with_javascript_in_rails.html#an-introduction-to-ajax" >Why would you want to use AJAX to load large batches of data?</a>

--- a/javascript/javascript_and_the_backend/using_rails_for_your_backend.md
+++ b/javascript/javascript_and_the_backend/using_rails_for_your_backend.md
@@ -24,7 +24,7 @@ Are you done? Good. Next, it's time to practice allowing your front end JavaScri
 
 1. [Check out "Using JavaScript in your Rails App" from Daniel Kehoe](http://railsapps.github.io/rails-javascript-include-external.html). It is long and covers a lot of ground, but it's got great content. Some of the stuff on dependencies can be skimmed, but pay attention to the `content_for` stuff at the bottom.
 
-2. [Refresh yourself on Rails AJAX from RailsGuides](https://guides.rubyonrails.org/v4.2/working_with_javascript_in_rails.html) (just skim the top few sections).
+2. [Refresh yourself on Rails AJAX from RailsGuides](https://guides.rubyonrails.org/v6.1/working_with_javascript_in_rails.html) (just skim the top few sections).
 
 3. Read [Bootstrapping JSON data into a Rails View](http://jfire.io/blog/2012/04/30/how-to-securely-bootstrap-json-in-a-rails-view) to learn about passing data to your front end.
 
@@ -40,6 +40,6 @@ This section contains helpful links to other content. It isn't required, so cons
 ### Knowledge Check
 
 * <a class="knowledge-check-link" href="https://railsapps.github.io/rails-javascript-include-external.html#locations" > How do you load custom JavaScript in a given Rails view page? </a>
-* <a class="knowledge-check-link" href="https://guides.rubyonrails.org/v4.2/working_with_javascript_in_rails.html#unobtrusive-javascript" >How does "unobtrusive JavaScript" work?</a>
+* <a class="knowledge-check-link" href="https://guides.rubyonrails.org/v6.1/working_with_javascript_in_rails.html#unobtrusive-javascript" >How does "unobtrusive JavaScript" work?</a>
 * <a class="knowledge-check-link" href="https://railsapps.github.io/rails-javascript-include-external.html#parameters" >How can you pass data from your Rails app to your JavaScript?</a>
-* <a class="knowledge-check-link" href="https://guides.rubyonrails.org/v4.2/working_with_javascript_in_rails.html#an-introduction-to-ajax" >Why would you want to use AJAX to load large batches of data?</a>
+* <a class="knowledge-check-link" href="https://guides.rubyonrails.org/v6.1/working_with_javascript_in_rails.html#an-introduction-to-ajax" >Why would you want to use AJAX to load large batches of data?</a>


### PR DESCRIPTION
Complete the following REQUIRED checkboxes:
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`

-   [x] I have previewed all lesson files included in this PR with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure the Markdown content is formatted correctly
-   [x] I have ensured all lesson files included in this PR follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

<hr>

**1. Because:**
I believe the content at the current link (https://edgeguides.rubyonrails.org/working_with_javascript_in_rails.html) has been updated and no longer aligns with the exercise item "Refresh yourself on Rails AJAX from RailsGuide"

I found what I believe to be the original guide (https://guides.rubyonrails.org/v4.2/working_with_javascript_in_rails.html), which has headers that match up with the Knowledge Check Questions ("How does 'unobtrusive JavaScript' work?" and "Why would you want to use AJAX to load large batches of data?")

**2. This PR:**
- Update the exercise link for "Refresh yourself on Rails AJAX from RailsGuides"
- Update the associated Knowledge Check links


**3. Additional Information:**
N/A

