### PR TITLE
Chore: Markdown Knowledge Links

### DIFF
--- a/LAYOUT_STYLE_GUIDE.md
+++ b/LAYOUT_STYLE_GUIDE.md
@@ -70,7 +70,7 @@ CUSTOM SECTION CONTENT.
 
 This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
 
--   <a class="knowledge-check-link" href="A KNOWLEDGE CHECK URL">A KNOWLEDGE CHECK QUESTION.</a>
+- [A-KNOWLEDGE-CHECK-URL](A KNOWLEDGE CHECK QUESTION)
 
 ### Additional Resources
 
@@ -104,9 +104,9 @@ This section contains helpful links to related content. It isn’t required, so 
 
     Replace the `A KNOWLEDGE CHECK URL` text with the actual link to the section/resource and the `A KNOWLEDGE CHECK QUESTION.` text with your own question/problem that the user should be able to answer/solve. Then add any additional bulleted knowledge check items. The lesson should ideally have no more than 7 knowledge checks, but this number might vary by lesson. **If the lesson does not have a knowledge check, remove this entire section from the lesson.**
 
-    In order to link to a Heading 3 `###` or Heading 4 `####` within the lesson, replace the `href` value for the knowledge check link with a hashtag `#` followed immediately by the section title in lowercase and any spaces replaced with a hyphen `-`. For example, a Heading 3 section titled `### Creating a Method` would be linked to with `href="#creating-a-method"`.
+    In order to link to a Heading 3 `###` or Heading 4 `####` within the lesson, replace the value within the square brackets for the knowledge check link with a hashtag `#` followed immediately by the section title in lowercase and any spaces replaced with a hyphen `-`. For example, a Heading 3 section titled `### Creating a Method` would be linked to with `[#creating-a-method]`.
     
-    In order to link to a `<span>` element within the lesson, replace the `href` value with the exact `id` attribute of the `<span>` element (this will be case sensitive).  For example, a `<span id="Knowledge-Check-3">` element would be linked to with `href="#Knowledge-Check-3"`.
+    In order to link to a `<span>` element within the lesson, replace the value within the square brackets with the exact `id` attribute of the `<span>` element (this will be case sensitive).  For example, a `<span id="Knowledge-Check-3">` element would be linked to with `[#Knowledge-Check-3]`.
 
 6.  `### Additional Resources`: A bulleted list of optional resources for the user to read. Additional resources should be related to the content of the lesson in some way, without being necessary to gain an understanding of the lesson content. An additional resource should include brief text that further informs the user on why it is included or what purpose it serves.
 


### PR DESCRIPTION
Because:
* We don't need to use html <a> tags for knowledge links anymore. Markdown links are preferable as they will handle opening external links in a new tab on the site.
