### PR TITLE
Foundations, Introduction to HTML & CSS: Revert wayback machine link, style guide improvements

### DIFF
--- a/foundations/html_css/intro-to-html-css.md
+++ b/foundations/html_css/intro-to-html-css.md
@@ -18,7 +18,7 @@ Many great resources out there keep referring to HTML and CSS as _programming la
 
 <div class="lesson-content__panel" markdown="1">
 
-1.  Read [HTML vs CSS vs JavaScript](https://web.archive.org/web/20220814090513/https://brytdesigns.com/html-css-javascript-whats-the-difference/). It's a quick overview of the relationship between HTML, CSS, and JavaScript.
+1.  Read [HTML vs CSS vs JavaScript](https://brytdesigns.com/html-css-javascript-whats-the-difference/). It's a quick overview of the relationship between HTML, CSS, and JavaScript.
 
 </div>
 

--- a/foundations/html_css/intro-to-html-css.md
+++ b/foundations/html_css/intro-to-html-css.md
@@ -26,7 +26,7 @@ Many great resources out there keep referring to HTML and CSS as _programming la
 
 This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
 
--   [What do HTML and CSS stand for?](https://brytdesigns.com/html-css-javascript-whats-the-difference/#What_is_HTML")
+-   [What do HTML and CSS stand for?](https://brytdesigns.com/html-css-javascript-whats-the-difference/#What_is_HTML)
 -   [Between HTML and CSS, which would you use for putting paragraphs of text on a webpage?](#html-and-css)
 -   [Between HTML and CSS, which would you use for changing the font and background color of a button?](#html-and-css)
 -   [What is the difference between HTML, CSS and JavaScript?](https://brytdesigns.com/html-css-javascript-whats-the-difference/)

--- a/foundations/html_css/intro-to-html-css.md
+++ b/foundations/html_css/intro-to-html-css.md
@@ -6,7 +6,7 @@ So here it is: it's time to actually start _making things_. This section will te
 
 This section contains a general overview of topics that you will learn in this lesson.
 
-*   Get a basic overview of HTML, CSS and how they work together.
+-   Get a basic overview of HTML, CSS and how they work together.
 
 ### HTML and CSS
 
@@ -22,19 +22,19 @@ Many great resources out there keep referring to HTML and CSS as _programming la
 
 </div>
 
-### Additional Resources
-
-This section contains helpful links to related content. It isn’t required, so consider it supplemental.
-
-*   [This FreeCodeCamp article](https://www.freecodecamp.org/news/html-css-and-javascript-explained-for-beginners/) goes into a little more depth than the assigned one. It covers things we'll be teaching explicitly in later lessons though, so don't worry about memorizing any of the details.
-
-*   Bookmark [DevDocs.io](https://devdocs.io). Read the “Welcome” message. Massive API documentation collection that even works offline. An essential collection of reference material for everything covered and more. (Maintained by [FreeCodeCamp](https://freecodecamp.org))
-
 ### Knowledge Check
 
 This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
 
-*   <a class="knowledge-check-link" href="https://brytdesigns.com/html-css-javascript-whats-the-difference/#What_is_HTML">What do HTML and CSS stand for?</a>
-*   <a class="knowledge-check-link" href="#html-and-css">Between HTML and CSS, which would you use for putting paragraphs of text on a webpage?</a>
-*   <a class="knowledge-check-link" href="#html-and-css">Between HTML and CSS, which would you use for changing the font and background color of a button?</a>
-*   <a class="knowledge-check-link" href="https://brytdesigns.com/html-css-javascript-whats-the-difference/">What is the difference between HTML, CSS and JavaScript?</a>
+-   [What do HTML and CSS stand for?](https://brytdesigns.com/html-css-javascript-whats-the-difference/#What_is_HTML")
+-   [Between HTML and CSS, which would you use for putting paragraphs of text on a webpage?](#html-and-css)
+-   [Between HTML and CSS, which would you use for changing the font and background color of a button?](#html-and-css)
+-   [What is the difference between HTML, CSS and JavaScript?](https://brytdesigns.com/html-css-javascript-whats-the-difference/)
+
+### Additional Resources
+
+This section contains helpful links to related content. It isn’t required, so consider it supplemental.
+
+-   [This FreeCodeCamp article](https://www.freecodecamp.org/news/html-css-and-javascript-explained-for-beginners/) goes into a little more depth than the assigned one. It covers things we'll be teaching explicitly in later lessons though, so don't worry about memorizing any of the details.
+
+-   Bookmark [DevDocs.io](https://devdocs.io). Read the “Welcome” message. Massive API documentation collection that even works offline. An essential collection of reference material for everything covered and more. (Maintained by [FreeCodeCamp](https://freecodecamp.org))


### PR DESCRIPTION
## Because
The live site is back working correctly and some style needed fixing.


## This PR
- Changes the link to an external article back to a live one instead of a wayback machine one.
- Fixes some style guide issues.


## Issue

Related to #24806

## Additional Information

nil

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
