### PR TITLE
Chore: Delete code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,0 @@
-The Odin Project's Code of Conduct is found in their main repository's `doc` folder. [LINK](https://github.com/TheOdinProject/theodinproject/blob/main/doc/code_of_conduct.md)


### PR DESCRIPTION
Because:
* It has been added to the org `.github` folder and will now automatically be added to this repo
