### PR TITLE
JavaScript Basics - Fundamentals 3: Warn against doing MDN exercises

### DIFF
--- a/foundations/javascript_basics/fundamentals-3.md
+++ b/foundations/javascript_basics/fundamentals-3.md
@@ -11,7 +11,7 @@ This section contains a general overview of topics that you will learn in this l
 -   What function scope is.
 
 ### Functions
-1.  [This lengthy MDN article](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Functions) is a good place to start. Don't worry as there may be some functions that can be beyond the reach of this particular lesson, but do pay special attention to the sections on 'Function Scope'. Scope is a topic that commonly trips up both beginner and intermediate coders, so it pays to spend some time with it upfront.
+1.  [This lengthy MDN article](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Functions) is a good place to start. Don't worry as there may be some functions that can be beyond the reach of this particular lesson, but do pay special attention to the sections on 'Function Scope'. Scope is a topic that commonly trips up both beginner and intermediate coders, so it pays to spend some time with it upfront. Note that this article also has its own exercises attached, which you should **not** do, as they involve knowledge we haven't touched yet.
 2.  Read this article about [return values](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Return_values).
 3.  Let's discuss parameters and arguments in the context of the following example function:
 


### PR DESCRIPTION
## Because
The article on MDN which we link also has its own exercises attached, which the student isn't ready for, as they involve DOM manipulation, which we won't touch upon until 7 lessons later. Twice this past weekend this had led to students seeking help on the Odin Discord because they got stuck on those exercises.


## This PR
* Adds a warning to not do those exercises


## Additional Information
Discussed on Discord at https://discord.com/channels/505093832157691914/1039272982150922240; see also the discussion starting at https://discord.com/channels/505093832157691914/505093832157691916/1041399180901486734 for an example of someone getting stuck


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
