### PR TITLE
Ruby Project Event Manager: Fixed  typo in lesson

### DIFF
--- a/ruby/files_and_serialization/project_event_manager.md
+++ b/ruby/files_and_serialization/project_event_manager.md
@@ -1,20 +1,19 @@
 ### Introduction
-
 Please note this tutorial has been adapted from The Turing School's and Jump Start Lab's [Event Manager](http://tutorials.jumpstartlab.com/projects/eventmanager.html) and updated to use GoogleCivic API
 
 ### Learning Goals
 
 After completing this tutorial, you will be able to:
 
-- manipulate [file](http://rubydoc.info/stdlib/core/File) input and output
-- read content from a [CSV](http://rubydoc.info/stdlib/csv/file/README.rdoc) (Comma Separated Value) file
-- transform it into a standardized format
-- utilize the data to contact a remote service
-- populate a template with user data
-- manipulate [strings](http://rubydoc.info/stdlib/core/String)
-- access [Google's Civic Information API](https://developers.google.com/civic-information/) through
+* manipulate [file](http://rubydoc.info/stdlib/core/File) input and output
+* read content from a [CSV](http://rubydoc.info/stdlib/csv/file/README.rdoc) (Comma Separated Value) file
+* transform it into a standardized format
+* utilize the data to contact a remote service
+* populate a template with user data
+* manipulate [strings](http://rubydoc.info/stdlib/core/String)
+* access [Google's Civic Information API](https://developers.google.com/civic-information/) through
   the [Google API Client Gem](https://github.com/google/google-api-ruby-client)
-- use [ERB](http://rubydoc.info/stdlib/erb/ERB) (Embedded Ruby) for templating
+* use [ERB](http://rubydoc.info/stdlib/erb/ERB) (Embedded Ruby) for templating
 
 <div class="lesson-note" markdown="1">
   This tutorial is open source. If you notice errors, typos, or have questions/suggestions, please [submit them to the project on GitHub](https://github.com/TheOdinProject/curriculum/blob/main/ruby/files_and_serialization/project_event_manager.md).
@@ -34,12 +33,12 @@ your project. In the project directory, create another folder named `lib` and in
 that folder create a plain text file named `event_manager.rb`. Using your command-line
 interface (CLI), you can enter the following commands:
 
-```bash
+~~~bash
 $ mkdir event_manager
 $ cd event_manager
 $ mkdir lib
 $ touch lib/event_manager.rb
-```
+~~~
 
 Creating and placing your `event_manager.rb` file in `lib` directory is entirely
 optional; however, it adheres to a common convention within most ruby applications.
@@ -48,58 +47,62 @@ file within the `lib` directory.
 
 Ruby source file names should be written all in lower-case characters and
 instead of camel-casing multiple words together, they are instead separated by an
-underscore (often called _snake_case_).
+underscore (often called *snake_case*).
 
 Open `lib/event_manager.rb` in your text editor and add the line:
 
-```ruby
+~~~ruby
 puts 'Event Manager Initialized!'
-```
+~~~
 
 Validate that ruby is installed correctly and you have created the file correctly by running it from the root of your `event_manager` directory:
 
-```bash
+
+~~~bash
 $ ruby lib/event_manager.rb
 Event Manager Initialized!
-```
+~~~
 
 If ruby is not installed and available on your environment path then you will be presented with the following message:
 
-```bash
+
+~~~bash
 $ ruby lib/event_manager.rb
 -bash: ruby: command not found
-```
+~~~
 
 If this happens, see [the instructions for installing Ruby](https://www.theodinproject.com/lessons/ruby-installing-ruby).
 
 If the file was not created then you will be presented with the following error
 message:
 
-```bash
+
+~~~bash
 $ ruby lib/event_manager.rb
 ruby: No such file or directory -- lib/event_manager.rb (LoadError)
-```
+~~~
 
 If this happens, make sure the correct directory exists and try creating the file again.
 
 For this project we are going to use the following sample data:
 
-- [Small Sample](https://github.com/TheOdinProject/curriculum/tree/main/ruby/files_and_serialization/event_attendees.csv)
-- [Large Sample](https://github.com/TheOdinProject/curriculum/tree/main/ruby/files_and_serialization/event_attendees_full.csv)
+* [Small Sample](https://github.com/TheOdinProject/curriculum/tree/main/ruby/files_and_serialization/event_attendees.csv)
+* [Large Sample](https://github.com/TheOdinProject/curriculum/tree/main/ruby/files_and_serialization/event_attendees_full.csv)
 
-Download the _[small sample](https://raw.githubusercontent.com/TheOdinProject/curriculum/main/ruby/files_and_serialization/event_attendees.csv)_ csv file and save it in the root of the project directory, `event_manager`. Using your CLI, confirm that you are in the right directory and enter the following command:
+Download the *[small sample](https://raw.githubusercontent.com/TheOdinProject/curriculum/main/ruby/files_and_serialization/event_attendees.csv)* csv file and save it in the root of the project directory, `event_manager`. Using your CLI, confirm that you are in the right directory and enter the following command:
 
-```bash
+~~~bash
 $ curl -o event_attendees.csv https://raw.githubusercontent.com/TheOdinProject/curriculum/main/ruby/files_and_serialization/event_attendees.csv
-```
+~~~
 
 After the file is downloaded, you should see something like:
 
-```bash
+~~~bash
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100  2125  100  2125    0     0   3269      0 --:--:-- --:--:-- --:--:-- 12073
-```
+~~~
+
 
 ### Iteration 0: Loading a File
 
@@ -112,13 +115,13 @@ database or spreadsheet applications.
 
 The first few rows of the CSV file you downloaded look like this:
 
-```bash
+~~~bash
 ,RegDate,first_Name,last_Name,Email_Address,HomePhone,Street,City,State,Zipcode
 1,11/12/08 10:47,Allison,Nguyen,arannon@jumpstartlab.com,6154385000,3155 19th St NW,Washington,DC,20010
 2,11/12/08 13:23,SArah,Hankins,pinalevitsky@jumpstartlab.com,414-520-5000,2022 15th Street NW,Washington,DC,20009
 3,11/12/08 13:30,Sarah,Xx,lqrm4462@jumpstartlab.com,(941)979-2000,4175 3rd Street North,Saint Petersburg,FL,33703
 4,11/25/08 19:21,David,Thomas,gdlia.lepping@jumpstartlab.com,650-799-0000,9 garrison ave,Jersey City,NJ,7306
-```
+~~~
 
 #### Read the File Contents
 
@@ -126,12 +129,12 @@ The first few rows of the CSV file you downloaded look like this:
 you to perform a large number of operations on files on your filesystem. The
 most straightforward is `File.read`.
 
-```ruby
+~~~ruby
 puts 'EventManager initialized.'
 
 contents = File.read('event_attendees.csv')
 puts contents
-```
+~~~
 
 In this example, it does not matter whether you use single quotes or double quotes.
 There are differences, but they are essentially the same when representing a string
@@ -141,6 +144,7 @@ We are assuming the file is present here. However, it is a good practice to conf
 that a file exists. File has the ability to check if a file exists at the specified
 filepath on the filesystem through `File.exist? "event_attendees.csv"`.
 
+
 #### Read the File Line By Line
 
 Reading and displaying the entire contents of the file showed us how to quickly
@@ -149,14 +153,14 @@ There are numerous [String](http://rubydoc.info/stdlib/core/String) methods
 that would allow us to manipulate this large string. Using `File.readlines` will
 save each line as a separate item in an array.
 
-```ruby
+~~~ruby
 puts 'EventManager initialized.'
 
 lines = File.readlines('event_attendees.csv')
 lines.each do |line|
   puts line
 end
-```
+~~~
 
 First, we read the entire contents of the file as an array of lines. Second, we
 iterate over the array of lines and output the contents of each line.
@@ -167,26 +171,26 @@ Instead of outputting the entire contents of each line we want to show only the
 first name. That requires us to look at the current contents of our Event
 Attendees file.
 
-```ruby
+~~~ruby
 ID,RegDate,first_Name,last_Name,Email_Address,HomePhone,Street,City,State,Zipcode
 1,11/12/08 10:47,Allison,Nguyen,arannon@jumpstartlab.com,6154385000,3155 19th St NW,Washington,DC,20010
-```
+~~~
 
 The first row contains header information. This row provides descriptive text
 for each column of data. It tells us the data columns are laid out as follows
 from left-to-right:
 
-- `ID` - the empty column represents a unique identifier or row number of all
+* `ID` - the empty column represents a unique identifier or row number of all
   the subsequent rows
-- `RegDate` - the date the user registered for the event
-- `first_Name` - their first name
-- `last_Name` - their last name
-- `Email_Address` - their email address
-- `HomePhone` - their home phone number
-- `Street` - their street address
-- `City` - their city
-- `State` - their state
-- `Zipcode` - their zipcode
+* `RegDate` - the date the user registered for the event
+* `first_Name` - their first name
+* `last_Name` - their last name
+* `Email_Address` - their email address
+* `HomePhone` - their home phone number
+* `Street` - their street address
+* `City` - their city
+* `State` - their state
+* `Zipcode` - their zipcode
 
 The lack of consistent formatting of these headers is not ideal when
 choosing to model your own data. These column names are our extreme
@@ -205,7 +209,7 @@ By default when you send the split message to the String without a parameter it
 will break the string apart along each space `" "` character. Therefore, we need to
 specify the comma `","` character to separate the columns.
 
-```ruby
+~~~ruby
 puts 'EventManager initialized.'
 
 lines = File.readlines('event_attendees.csv')
@@ -213,14 +217,14 @@ lines.each do |line|
   columns = line.split(",")
   p columns
 end
-```
+~~~
 
 Within our array of columns we want to access our 'first_Name'. This would be
 the third column or third element at the array's second index `columns[2]`.
 Remember, arrays start counting at 0 instead of 1, so `columns[0]` is how we
 would access the array's first element, and `columns[2]` will give us the third.
 
-```ruby
+~~~ruby
 puts 'EventManager initialized.'
 
 lines = File.readlines('event_attendees.csv')
@@ -229,7 +233,7 @@ lines.each do |line|
   name = columns[2]
   puts name
 end
-```
+~~~
 
 ### Skipping the Header Row
 
@@ -246,7 +250,7 @@ which one is the header row.
 One way to solve this problem would be to skip the line when it exactly matches
 our current header row.
 
-```ruby
+~~~ruby
 puts 'EventManager initialized.'
 
 lines = File.readlines('event_attendees.csv')
@@ -256,7 +260,7 @@ lines.each do |line|
   name = columns[2]
   puts name
 end
-```
+~~~
 
 When this program is run, the `next if` line checks every line to see if it matches the provided string. If so, it skips that line from the rest of the loop.
 
@@ -267,7 +271,7 @@ updated.
 A second way to solve this problem is for us to track the index of the current
 line.
 
-```ruby
+~~~ruby
 puts 'EventManager initialized.'
 
 lines = File.readlines('event_attendees.csv')
@@ -279,12 +283,12 @@ lines.each do |line|
   name = columns[2]
   puts name
 end
-```
+~~~
 
 This is a such a common operation that Array defines
 [Array#each_with_index](http://rubydoc.info/stdlib/core/Enumerable#each_with_index-instance_method).
 
-```ruby
+~~~ruby
 puts 'EventManager initialized.'
 
 lines = File.readlines('event_attendees.csv')
@@ -294,14 +298,15 @@ lines.each_with_index do |line,index|
   name = columns[2]
   puts name
 end
-```
+~~~
 
 This solves the problem if the header row were to change in the future. It
 assumes that the header row is the first row in the file.
 
+
 #### Look for a Solution before Building a Solution
 
-Either of these solutions would be _OK_ given our current attendees file.
+Either of these solutions would be *OK* given our current attendees file.
 Problems may arise if we are given a new CSV file that is generated or
 manipulated by another source. This is because the CSV parser that we have
 started to create does not take into account a number of other features
@@ -309,8 +314,8 @@ supported by the CSV file format.
 
 Two important ones:
 
-- CSV files often contain comments which are lines that start with a pound (#) character
-- A column is unable to support a value which contains a comma (,) character
+* CSV files often contain comments which are lines that start with a pound (#) character
+* A column is unable to support a value which contains a comma (,) character
 
 Our goal is to get in contact with our event attendees. It is not to define a
 CSV parser. This is often a hard concept to let go of when initially solving a
@@ -341,7 +346,7 @@ slower start up times.
 
 You can browse the many libraries available through the [documentation](http://rubydoc.info/stdlib).
 
-```ruby
+~~~ruby
 require 'csv'
 puts 'EventManager initialized.'
 
@@ -350,7 +355,7 @@ contents.each do |row|
   name = row[2]
   puts name
 end
-```
+~~~
 
 First we need to tell Ruby that we want it to load the CSV library. This is done
 through the `require` method which accepts a parameter of the functionality to
@@ -378,7 +383,7 @@ Converting the headers to symbols will make our column names more uniform and
 easier to remember. The header "first_Name" will be converted to `:first_name`
 and "HomePhone" will be converted to `:homephone`.
 
-```ruby
+~~~ruby
 require 'csv'
 puts 'EventManager initialized.'
 
@@ -392,13 +397,13 @@ contents.each do |row|
   name = row[:first_name]
   puts name
 end
-```
+~~~
 
 #### Displaying the Zip Codes of All Attendees
 
 Accessing the zipcode is very easy using the new header name, `:zipcode`.
 
-```ruby
+~~~ruby
 require 'csv'
 puts 'EventManager initialized.'
 
@@ -413,7 +418,7 @@ contents.each do |row|
   zipcode = row[:zipcode]
   puts "#{name} #{zipcode}"
 end
-```
+~~~
 
 We now are able to output the name of the individual and their zipcode.
 
@@ -424,14 +429,14 @@ have a problem....
 
 The zip codes in our small sample show us:
 
-- Most zip codes are correctly expressed as a five-digit number
-- Some zip codes are represented with fewer than five digits
-- Some zip codes are missing
+* Most zip codes are correctly expressed as a five-digit number
+* Some zip codes are represented with fewer than five digits
+* Some zip codes are missing
 
 Before we are able to figure out our attendees' representatives, we need to
 solve the second issue and the third issue.
 
-- Some zip codes are represented with fewer than five digits
+* Some zip codes are represented with fewer than five digits
 
 If we looked at the [larger sample of data](https://raw.githubusercontent.com/TheOdinProject/curriculum/main/ruby/files_and_serialization/event_attendees_full.csv), we would
 see that the majority of the shorter zip codes are from states in the
@@ -442,7 +447,7 @@ caused the leading zeros to be removed.
 So in the case of zip codes of fewer than five digits, we will assume that we can
 pad missing zeros to the front.
 
-- Some zip codes are missing
+* Some zip codes are missing
 
 Some of our attendees are missing a zip code. It is likely that they forgot to
 enter the data when they filled out the form. The zip code data was not likely
@@ -458,7 +463,7 @@ bad zip code of "00000".
 Before we start to explore a solution with Ruby code it is often helpful to
 express what we are hoping to accomplish in English words.
 
-```ruby
+~~~ruby
 require 'csv'
 puts 'EventManager initialized.'
 
@@ -478,38 +483,38 @@ contents.each do |row|
 
   puts "#{name} #{zipcode}"
  end
-```
+~~~
 
-- if the zip code is exactly five digits, assume that it is ok
+* if the zip code is exactly five digits, assume that it is ok
 
 In the case when the zip code is five digits in length we have it easy. We
 simply want to do nothing.
 
-- if the zip code is more than five digits, truncate it to the first five digits
+* if the zip code is more than five digits, truncate it to the first five digits
 
 While zip codes can be expressed with additional resolution (more digits after
 a dash), we are only interested in the first five digits.
 
-- if the zip code is less than five digits, add zeros to the front until it
+* if the zip code is less than five digits, add zeros to the front until it
   becomes five digits
 
 There are many possible ways that we can solve this issue. These are a few
 paths:
 
-- Use a `while` or `until` loop to prepend zeros until the length is five
-- Calculate the length of the current zip code and add missing zeros to the front
-- Add five zeros to the front of the current zip code and then trim the last five digits
-- Use [String#rjust](http://rubydoc.info/stdlib/core/String#rjust-instance_method) to append zeros to the front of the string.
+  * Use a `while` or `until` loop to prepend zeros until the length is five
+  * Calculate the length of the current zip code and add missing zeros to the front
+  * Add five zeros to the front of the current zip code and then trim the last five digits
+  * Use [String#rjust](http://rubydoc.info/stdlib/core/String#rjust-instance_method) to append zeros to the front of the string.
 
 #### Handling Bad and Good Zip Codes
 
 The following solution employs:
 
-- [String#length](http://rubydoc.info/stdlib/core/String#length-instance_method) - returns the length of the string.
-- [String#rjust](http://rubydoc.info/stdlib/core/String#rjust-instance_method) - to pad the string with zeros.
-- [String#slice](http://rubydoc.info/stdlib/core/String#slice-instance_method) - to create sub-strings either through the `slice` method or the array-like notation `[]`
+* [String#length](http://rubydoc.info/stdlib/core/String#length-instance_method) - returns the length of the string.
+* [String#rjust](http://rubydoc.info/stdlib/core/String#rjust-instance_method) - to pad the string with zeros.
+* [String#slice](http://rubydoc.info/stdlib/core/String#slice-instance_method) - to create sub-strings either through the `slice` method or the array-like notation `[]`
 
-```ruby
+~~~ruby
 require 'csv'
 
 puts 'EventManager initialized.'
@@ -532,12 +537,13 @@ contents.each do |row|
 
   puts "#{name} #{zipcode}"
 end
-```
+~~~
 
 When we run our application, we see the first few lines output correctly and then the
 application terminates.
 
-```bash
+
+~~~bash
 $ ruby lib/event_manager.rb
 EventManager initialized.
 Allison 20010
@@ -547,9 +553,9 @@ David 07306
 lib/event_manager.rb:11:in `block in <main>': undefined method `length' for nil:NilClass (NoMethodError)
 	from /Users/burtlo/.rvm/rubies/ruby-1.9.3-p374/lib/ruby/1.9.1/csv.rb:1792:in `each'
 	from lib/event_manager.rb:7:in `<main>'
-```
+~~~
 
-- What is the error message "undefined method 'length' for nil:NilClass (NoMethodError)" saying?
+* What is the error message "undefined method 'length' for nil:NilClass (NoMethodError)" saying?
 
 Reviewing our CSV data, we notice that the next row specifies no value. An empty
 field translates into a nil instead of an empty string. This is a choice made by
@@ -565,7 +571,7 @@ except for a `nil`.
 We can update our implementation to handle this new case by simply adding a
 check for `nil?`.
 
-```ruby
+~~~ruby
 require 'csv'
 
 puts 'EventManager initialized.'
@@ -590,9 +596,10 @@ contents.each do |row|
 
   puts "#{name} #{zipcode}"
 end
-```
+~~~
 
-```bash
+
+~~~bash
 $ ruby lib/event_manager.rb
 EventManager initialized.
 Allison 20010
@@ -614,21 +621,21 @@ Shannon 03082
 Shannon 98122
 Nash 98122
 Amanda 14841
-```
+~~~
 
 #### Moving Clean Zip Codes to a Method
 
 It is important for us to take a look at our implementation. During this
 examination we should ask ourselves:
 
-- Does the code clearly express what it is trying to accomplish?
+* Does the code clearly express what it is trying to accomplish?
 
 The implementation does a decent job at expressing what it accomplishes. The
 biggest problem is that it is expressing this near so many other concepts. To
 make this implementation clearer we should move this logic into its own method
 named `clean_zipcode`.
 
-```ruby
+~~~ruby
 require 'csv'
 
 def clean_zipcode(zipcode)
@@ -658,7 +665,7 @@ contents.each do |row|
 
   puts "#{name} #{zipcode}"
 end
-```
+~~~
 
 This may feel like a very small, inconsequential change, but small changes
 like these help make your code cleaner and your intent clearer.
@@ -668,7 +675,7 @@ like these help make your code cleaner and your intent clearer.
 With our clean zip code logic tucked away in our `clean_zipcode` method, we can
 examine it further to see if we can make it even more succinct.
 
-- Coercion over Questions
+* Coercion over Questions
 
 A good rule when developing in Ruby is to favor coercing values into similar
 values so that they will behave the same. We have a special case to deal
@@ -676,10 +683,10 @@ specifically with a `nil` value. It would be much easier if instead of checking
 for a nil value, we convert the `nil` into a string with
 [NilClass#to_s](http://rubydoc.info/stdlib/core/NilClass#to_s-instance_method).
 
-```ruby
+~~~ruby
 $ nil.to_s
 => ""
-```
+~~~
 
 Examining
 [String#rjust](http://rubydoc.info/stdlib/core/String#rjust-instance_method) in
@@ -687,10 +694,10 @@ irb, we can see that when we provide a string with a length greater than five,
 it performs no work. This means we can apply it in both cases, as it will have the
 same intended effect.
 
-```ruby
+~~~ruby
 $ "123456".rjust(5, '0')
 => "123456"
-```
+~~~
 
 Lastly, examining
 [String#slice](http://rubydoc.info/stdlib/core/String#slice-instance_method) in
@@ -698,19 +705,19 @@ irb, we can see that for a number that is exactly five digits in length, it has 
 effect. This also means we can apply it in cases when the zip code is five or more
 digits, and it will have the same effect.
 
-```ruby
+~~~ruby
 $ "12345"[0..4]
 => "12345"
-```
+~~~
 
 Combining all of these steps together, we can write a more succinct
 `clean_zipcode` method:
 
-```ruby
+~~~ruby
 def clean_zipcode(zipcode)
   zipcode.to_s.rjust(5, '0')[0..4]
 end
-```
+~~~
 
 ### Iteration 3: Using Google's Civic Information
 
@@ -733,16 +740,16 @@ Take a close look at this sample URL for accessing the Civic Information API:
 
 Here's how it breaks down:
 
-- `https://` : Use the Secure HTTP protocol
-- `www.googleapis.com/civicinfo/v2/` : The API server address on the internet
-- `representatives` : The method called on that server
-- `?` : Parameters to the method
-  - `&` : The parameter separator
-  - `address=80203` : The zipcode we want to lookup
-  - `levels=country` : The level of government we want to select
-  - `roles=legislatorUpperBody` : Return the representatives from the Senate
-  - `roles=legislatorLowerBody` : Returns the representatives from the House
-  - `key=AIzaSyClRzDqDh5MsXwnCWi0kOiiBivP6JsSyBw` : A registered API Key to authenticate our requests
+* `https://` : Use the Secure HTTP protocol
+* `www.googleapis.com/civicinfo/v2/` : The API server address on the internet
+* `representatives` : The method called on that server
+* `?` : Parameters to the method
+  * `&` : The parameter separator
+  * `address=80203` : The zipcode we want to lookup
+  * `levels=country` : The level of government we want to select
+  * `roles=legislatorUpperBody` : Return the representatives from the Senate
+  * `roles=legislatorLowerBody` : Returns the representatives from the House
+  * `key=AIzaSyClRzDqDh5MsXwnCWi0kOiiBivP6JsSyBw` : A registered API Key to authenticate our requests
 
 When we're accessing the `representatives` method of their API, we're sending in a `key` which is the string that identifies JumpstartLab as the accessor of
 the API, then we're selecting the data we want returned to us using the `address`, `levels`, and `roles` criteria. Try modifying the address with your own zipcode and load the page.
@@ -756,11 +763,12 @@ Let's look for a solution before we attempt to build a solution.
 Ruby comes packaged with the `gem` command. This tool allows you to download
 libraries by simply knowing the name of the library you want to install.
 
-```bash
+
+~~~bash
 $ gem install google-api-client
 Successfully installed google-api-client-0.15.0
 1 gem installed
-```
+~~~
 
 If you receive a signet error when installing the Google API gem, it is due to modern Ruby updates requiring an updated version of signet that is not compatible with the API. To fix, please [downgrade your version of signet](https://github.com/googleapis/google-api-ruby-client/issues/833) before installing the gem.
 
@@ -772,13 +780,13 @@ available online with their [source code](https://github.com/google/google-api-r
 Reading through the documentation on how to set up and use the
 google-api-client gem, we find that we need to perform the following steps:
 
-- Set the API Key
-- Send the query with the given criteria
-- Parse the response for the names of your legislators.
+* Set the API Key
+* Send the query with the given criteria
+* Parse the response for the names of your legislators.
 
 Exploration of data is easy using irb:
 
-```ruby
+~~~ruby
 $ require 'google/apis/civicinfo_v2'
 => true
 
@@ -790,11 +798,11 @@ $ civic_info.key = 'AIzaSyClRzDqDh5MsXwnCWi0kOiiBivP6JsSyBw'
 
 $ response = civic_info.representative_info_by_address(address: 80202, levels: 'country', roles: ['legislatorUpperBody', 'legislatorLowerBody'])
 => #<Google::Apis::CivicinfoV2::RepresentativeInfoResponse:0x007faf2d9088d0 @divisions={"ocd-division/country:us/state:co"=>#<Google::Apis::CivicinfoV2::GeographicDivision:0x007faf2e55ea80 @name="Colorado", @office_indices=[0]> } > ...continues...
-```
+~~~
 
-Whoa. That's a lot of information. Buried in there are the names of our legislators. We can access them by calling the `.officials` method on the `response`. Now that we know how to access the information we want, we can focus our attention back on our program.
+Whoa. That's a lot of information.  Buried in there are the names of our legislators.  We can access them by calling the `.officials` method on the `response`.  Now that we know how to access the information we want, we can focus our attention back on our program.
 
-```ruby
+~~~ruby
 require 'csv'
 require 'google/apis/civicinfo_v2'
 
@@ -827,18 +835,19 @@ contents.each do |row|
 
   puts "#{name} #{zipcode} #{legislators}"
 end
-```
+~~~
 
 Running our application, we find an error.
 
-```bash
+
+~~~bash
 $ ruby lib/event_manager.rb
 /ruby-2.4.0/gems/google-api-client-0.15.0/lib/google/apis/core/http_command.rb:218:in 'check_status': parseError: Failed to parse address (Google::Apis::ClientError)
-```
+~~~
 
-What does this mean? It means that the Google API was unable to use an address we gave it. When we dig further, we see that right before this error the information from David with a zip code of 07306 is printed. Looking at the data we can now see that the attendee after David did not enter a zip code. Data missing like this is common, so we have to have a way of dealing with it. Luckily, Ruby makes that easy with its [Exception Class](https://ruby-doc.org/core/Exception.html). We can add a `begin` and `rescue` clause to the API search to handle any errors.
+What does this mean?  It means that the Google API was unable to use an address we gave it.  When we dig further, we see that right before this error the information from David with a zip code of 07306 is printed. Looking at the data we can now see that the attendee after David did not enter a zip code.  Data missing like this is common, so we have to have a way of dealing with it. Luckily, Ruby makes that easy with its [Exception Class](https://ruby-doc.org/core/Exception.html).  We can add a `begin` and `rescue` clause to the API search to handle any errors.
 
-```ruby
+~~~ruby
 require 'csv'
 require 'google/apis/civicinfo_v2'
 
@@ -875,11 +884,11 @@ contents.each do |row|
 
   puts "#{name} #{zipcode} #{legislators}"
 end
-```
+~~~
 
 The **legislators** that we are displaying is an array. In turn, the array is
 sending the `to_s` message to each of the objects within the array, each
-legislator. The output that we are seeing is the _raw_ legislator object.
+legislator. The output that we are seeing is the *raw* legislator object.
 
 We really want to capture the first name and last name of each legislator.
 
@@ -888,36 +897,36 @@ We really want to capture the first name and last name of each legislator.
 Instead of outputting each raw legislator we want to print only their first
 name and last name. We will need to complete the following steps:
 
-- For each zip code, iterate over the array of legislators.
-- For each legislator, we want to find the representative's name.
-- Add the name to a new collection of names.
+* For each zip code, iterate over the array of legislators.
+* For each legislator, we want to find the representative's name.
+* Add the name to a new collection of names.
 
-To do this, we can use the [map](https://ruby-doc.org/core/Array.html#method-i-map) function built into ruby. It works just like `.each` but returns a new array of the data we want to include.
+To do this, we can use the [map](https://ruby-doc.org/core/Array.html#method-i-map) function built into ruby.  It works just like `.each` but returns a new array of the data we want to include.
 
-```ruby
+~~~ruby
 legislator_names = legislators.map do |legislator|
     legislator.name
   end
-```
+~~~
 
 We can further simplify this into its final form:
 
-```ruby
+~~~ruby
 legislator_names = legislators.map(&:name)
-```
+~~~
 
 #### Cleanly Displaying Legislators
 
-If we were to replace `legislators` with `legislator_names` in our output, we would be presented with a _slightly_ better output.
+If we were to replace `legislators` with `legislator_names` in our output, we would be presented with a *slightly* better output.
 
-```bash
+~~~bash
 $ ruby lib/event_manager.rb
 EventManager initialized.
 Allison 20010 ["Eleanor Norton"]
 SArah 20009 ["Eleanor Norton"]
 Sarah 33703 ["Marco Rubio", "Bill Nelson", "C. Young"]
 ...
-```
+~~~
 
 The problem now is that when using string interpolation, Ruby is converting our new array of legislator names into a string, but Ruby does not know exactly how _you_ want to display the contents.
 
@@ -925,7 +934,7 @@ We need to explicitly convert our array of legislator names to a string. This wa
 
 [Array#join](http://rubydoc.info/stdlib/core/Array#join-instance_method) allows the specification of a separator string. We want to create a comma-separated list of legislator names with `legislator_names.join(", ")`
 
-```ruby
+~~~ruby
 contents.each do |row|
   name = row[:first_name]
 
@@ -948,26 +957,27 @@ contents.each do |row|
 
   puts "#{name} #{zipcode} #{legislators_string}"
 end
-```
+~~~
 
 Running our application this time should give us a much more pleasant looking
 output:
 
-```bash
+
+~~~bash
 $ ruby lib/event_manager.rb
 EventManager initialized.
 Allison 20010 Eleanor Norton
 SArah 20009 Eleanor Norton
 Sarah 33703 Marco Rubio, Bill Nelson, C. Young
 ...
-```
+~~~
 
 #### Moving Displaying Legislators to a Method
 
 Similar to before, with this step complete, we want to look at our
 implementation and ask ourselves:
 
-- Does the code clearly express what it is trying to accomplish?
+* Does the code clearly express what it is trying to accomplish?
 
 This code is fairly clear in its understanding. It is simply expressing its
 intent near so many other things. It is also expressing itself differently from
@@ -978,7 +988,7 @@ We want to extract our legislator names into a new method named
 `legislators_by_zipcode`, which accepts a single zip code as a parameter
 and returns a comma-separated string of legislator names.
 
-```ruby
+~~~ruby
 require 'csv'
 require 'google/apis/civicinfo_v2'
 
@@ -1022,7 +1032,7 @@ contents.each do |row|
 
   puts "#{name} #{zipcode} #{legislators}"
 end
-```
+~~~
 
 An additional benefit of this implementation is that it encapsulates how we
 actually retrieve the names of the legislators. This will be of benefit later if we
@@ -1038,41 +1048,34 @@ For each attendee we want to include a customized letter that thanks them for
 attending the conference and provides a list of their representatives.
 Something that looks like:
 
-```html
+~~~html
 <html>
-  <head>
-    <meta charset="UTF-8" />
-    <title>Thank You!</title>
-  </head>
-  <body>
-    <h1>Thanks FIRST_NAME!</h1>
-    <p>
-      Thanks for coming to our conference. We couldn't have done it without you!
-    </p>
+<head>
+  <meta charset='UTF-8'>
+  <title>Thank You!</title>
+</head>
+<body>
+  <h1>Thanks FIRST_NAME!</h1>
+  <p>Thanks for coming to our conference.  We couldn't have done it without you!</p>
 
-    <p>
-      Political activism is at the heart of any democracy and your voice needs
-      to be heard. Please consider reaching out to your following
-      representatives:
-    </p>
+  <p>
+    Political activism is at the heart of any democracy and your voice needs to be heard.
+    Please consider reaching out to your following representatives:
+  </p>
 
-    <table>
-      <tr>
-        <th>Legislators</th>
-      </tr>
-      <tr>
-        <td>LEGISLATORS</td>
-      </tr>
-    </table>
-  </body>
+  <table>
+    <tr><th>Legislators</th></tr>
+    <tr><td>LEGISLATORS</td></tr>
+  </table>
+</body>
 </html>
-```
+~~~
 
 #### Storing our template to a file
 
 We could define this template as a large string within our current application.
 
-```ruby
+~~~ruby
 form_letter = %{
   <html>
   <head>
@@ -1094,9 +1097,10 @@ form_letter = %{
   </body>
   </html>
 }
-```
+~~~
 
-Ruby has quite a few ways that we can define strings. This format `%{ String Contents }` is one choice when defining a string that spans multiple lines.
+Ruby has quite a few ways that we can define strings. This format `%{ String
+Contents }` is one choice when defining a string that spans multiple lines.
 
 However, placing this large blob of text, this template, within our application
 will make it much more difficult to understand the template and the application
@@ -1106,14 +1110,14 @@ code.
 Instead of including the template within our application, we will instead load
 the template using the same File tools we used at the beginning of the exercise.
 
-- Create a file named 'form_letter.html' in the root of your project directory.
-- Copy the html template defined above into that file and save it.
+* Create a file named 'form_letter.html' in the root of your project directory.
+* Copy the html template defined above into that file and save it.
 
 Within our application we will load our template:
 
-```ruby
+~~~ruby
 template_letter = File.read('form_letter.html')
-```
+~~~
 
 It is important to define the `form_letter.html` file in the root of project
 directory and not in the lib directory. This is because when the application
@@ -1121,12 +1125,13 @@ runs it assumes the place that you started the application is where all file
 references will be located. Later, we move the file to a new location and are
 more explicit on defining the location of the template.
 
+
 #### Replacing with `gsub` and `gsub!`
 
 For each of our attendees we want to replace the `FIRST_NAME` and `LEGISLATORS` with their respective values.
 
-- We need to find all instances of `FIRST_NAME` and replace them with the individual's first name.
-- We need to find all instances of `LEGISLATORS` and replace them with the individual's representatives.
+* We need to find all instances of `FIRST_NAME` and replace them with the individual's first name.
+* We need to find all instances of `LEGISLATORS` and replace them with the individual's representatives.
 
 Our template is a String of text which has two methods for replacing text:
 [String#gsub](http://rubydoc.info/stdlib/core/String#gsub-instance_method) and
@@ -1141,7 +1146,7 @@ important that we create a new copy of this letter for each attendee. If we
 change the original template, they'd all have the same name! By making a copy
 and then changing the copy, we're sure everyone's name is unique.
 
-```ruby
+~~~ruby
 template_letter = File.read('form_letter.html')
 
 contents.each do |row|
@@ -1156,7 +1161,7 @@ contents.each do |row|
 
   puts personal_letter
 end
-```
+~~~
 
 We replace the first name in the template letter and return a new copy (Thanks
 [String#gsub](http://rubydoc.info/stdlib/core/String#gsub-instance_method)). We
@@ -1169,24 +1174,24 @@ Methods like `gsub` and `gsub!` can often be confusing and when to use one over
 the other may not be immediately clear. The above template manipulation could
 have been written with just `gsub`:
 
-```ruby
+~~~ruby
 personal_letter = template_letter.gsub('FIRST_NAME', name)
 personal_letter = personal_letter.gsub('LEGISLATORS', legislators)
-```
+~~~
 
 #### Our Template System has Problems
 
 It is a treacherous road we start to walk, defining our own templating language.
 Our current system has some flaws:
 
-- Using FIRST_NAME and LEGISLATORS to find and replace might cause us problems if later somehow this text appears in any of our templates.
+* Using FIRST_NAME and LEGISLATORS to find and replace might cause us problems if later somehow this text appears in any of our templates.
 
 Though not likely, imagine if a person's name contained the word 'LEGISLATORS'.
 When we perform the second replacement operation, that part of the person's name
 would also be replaced. This is unlikely in our simple template, but as our
 template grows, we may invite such disasters.
 
-- We cannot represent multiple items very easily if they are surrounded by HTML.
+* We cannot represent multiple items very easily if they are surrounded by HTML.
 
 Currently we copied our legislators string into a single table column. We would
 have a hard time inserting our legislators as individual rows in the table
@@ -1210,16 +1215,16 @@ variables, methods or ruby code we want to execute.
 ERB defines several different escape sequence tags that we can use. The most
 common are:
 
-```ruby
+~~~ruby
 <%= ruby code will execute and show output %>
 <% ruby code will execute but not show output %>
-```
+~~~
 
 We can define our ERB escape tags within any string. The ruby defined within
 the contents of the ERB tags will not be evaluated until we ask the template to
 give us the results.
 
-```ruby
+~~~ruby
 require 'erb'
 
 meaning_of_life = 42
@@ -1229,14 +1234,14 @@ template = ERB.new question
 
 results = template.result(binding)
 puts results
-```
+~~~
 
 The code above loads the ERB library, then creates a new ERB template with the
 `question` string. The question string contains ERB tags that will show the
 results of the variable `meaning_of_life`. We send the `result` message to the
 template with `binding`.
 
-- What is `binding`?
+* What is `binding`?
 
 The method
 [binding](http://rubydoc.info/stdlib/core/Kernel#binding-instance_method)
@@ -1253,15 +1258,15 @@ different binding.
 
 To use ERB we need to update our current template **form_letter.html**.
 
-- Save a new template as **form_letter.erb**
+* Save a new template as **form_letter.erb**
 
 The convention is to save ERB template files with the extension **erb**. This
 is not a requirement. It is a benefit to yourself and other users when they
 return to the application.
 
-- Update our existing keywords with the ERB escape sequences
+* Update our existing keywords with the ERB escape sequences
 
-```erb
+~~~erb
 <html>
 <head>
   <meta charset='UTF-8'>
@@ -1292,7 +1297,7 @@ return to the application.
   </table>
 </body>
 </html>
-```
+~~~
 
 The use of the ERB tags to display the attendee's name is familiar from our previous example. The second use, when we display the legislators, is different. We are using the ERB tag that does not output the results `<% %>` to check if the legislators variable is an Array.
 
@@ -1300,15 +1305,16 @@ If it is an array, we output the name and website url of each legislator. This i
 
 If `legislators` is not an array, it means that the `legislators_by_zipcode` method entered the rescue clause, which outputs a string. We simply want to display that string.
 
+
 #### Using ERB
 
 We now need to update our application to:
 
-- Require the ERB library
-- Create the ERB template from the contents of the template file
-- Simplify our `legislators_by_zipcode` to return the original array of legislators
+* Require the ERB library
+* Create the ERB template from the contents of the template file
+* Simplify our `legislators_by_zipcode` to return the original array of legislators
 
-```ruby
+~~~ruby
 require 'csv'
 require 'google/apis/civicinfo_v2'
 require 'erb'
@@ -1353,28 +1359,28 @@ contents.each do |row|
   form_letter = erb_template.result(binding)
   puts form_letter
 end
-```
+~~~
 
-- Require the ERB library
+* Require the ERB library
 
 First we need to tell Ruby that we want it to load the ERB library. This is done
 through the `require` method which accepts a parameter of the functionality to
 load.
 
-- Create the ERB template from the contents of the template file
+* Create the ERB template from the contents of the template file
 
 Creating our template from our new template file requires us to load the file
 contents as a string and provide them as a parameter when creating the new ERB
 template.
 
-```ruby
+~~~ruby
 template_letter = File.read('form_letter.erb')
 erb_template = ERB.new template_letter
-```
+~~~
 
-- Simplify our `legislators_by_zipcode` to return the original array of legislators
+* Simplify our `legislators_by_zipcode` to return the original array of legislators
 
-```ruby
+~~~ruby
 def legislators_by_zipcode(zip)
   civic_info = Google::Apis::CivicinfoV2::CivicInfoService.new
   civic_info.key = 'AIzaSyClRzDqDh5MsXwnCWi0kOiiBivP6JsSyBw'
@@ -1389,7 +1395,7 @@ def legislators_by_zipcode(zip)
     'You can find your representatives by visiting www.commoncause.org/take-action/find-elected-officials'
   end
 end
-```
+~~~
 
 #### Outputting form letters to a file
 
@@ -1399,11 +1405,12 @@ looked correct. It is time to save each form letter to a file.
 Each file should be uniquely named. Fortunately, each of our attendees has a
 unique id—the first column, or row number.
 
-- Assign an ID for the attendee
-- Create an output folder
-- Save each form letter to a file based on the id of the attendee
+* Assign an ID for the attendee
+* Create an output folder
+* Save each form letter to a file based on the id of the attendee
 
-```ruby
+
+~~~ruby
 contents.each do |row|
   id = row[0]
   name = row[:first_name]
@@ -1423,23 +1430,23 @@ contents.each do |row|
   end
 
 end
-```
+~~~
 
-- Assign an ID for the attendee
+* Assign an ID for the attendee
 
 The first column does not have a name like the other columns, so we fall back
 to using the index value.
 
-- Create an output folder
+* Create an output folder
 
 We make a directory named "output" if a directory named "output" does not
 already exist.
 
-```ruby
+~~~ruby
 Dir.mkdir('output') unless Dir.exist?('output')
-```
+~~~
 
-- Save each form letter to a file based on the id of the attendee
+* Save each form letter to a file based on the id of the attendee
 
 [File#open](http://rubydoc.info/stdlib/core/File#open-class_method) allows us
 to open a file for reading and writing. The first parameter is the name of the
@@ -1450,7 +1457,7 @@ it will be destroyed.
 Afterwards we actually send the entire form letter content to the file
 object. The `file` object responds to the message `puts`. The method
 [IO#puts](http://rubydoc.info/stdlib/core/IO#puts-instance_method), from which the `file` object inherits, is similar to
-[Kernel#puts](http://rubydoc.info/stdlib/core/Kernel#puts-instance_method)
+ [Kernel#puts](http://rubydoc.info/stdlib/core/Kernel#puts-instance_method)
 which we have been using up to this point.
 
 #### Moving Form Letter Generation to a Method
@@ -1458,7 +1465,7 @@ which we have been using up to this point.
 Again, for the sake of writing clean and clear code, we want to move the
 operation of saving the form letter to its own method:
 
-```ruby
+~~~ruby
 require 'csv'
 require 'google/apis/civicinfo_v2'
 require 'erb'
@@ -1513,7 +1520,7 @@ contents.each do |row|
 
   save_thank_you_letter(id,form_letter)
 end
-```
+~~~
 
 The method `save_thank_you_letter` requires the id of the attendee and the form letter
 output.
@@ -1525,11 +1532,11 @@ inconsistencies. If we wanted to allow individuals to sign up for mobile alerts
 with the phone numbers, we would need to make sure all of the numbers are valid
 and well-formed.
 
-- If the phone number is less than 10 digits, assume that it is a bad number
-- If the phone number is 10 digits, assume that it is good
-- If the phone number is 11 digits and the first number is 1, trim the 1 and use the remaining 10 digits
-- If the phone number is 11 digits and the first number is not 1, then it is a bad number
-- If the phone number is more than 11 digits, assume that it is a bad number
+* If the phone number is less than 10 digits, assume that it is a bad number
+* If the phone number is 10 digits, assume that it is good
+* If the phone number is 11 digits and the first number is 1, trim the 1 and use the remaining 10 digits
+* If the phone number is 11 digits and the first number is not 1, then it is a bad number
+* If the phone number is more than 11 digits, assume that it is a bad number
 
 ### Assignment: Time Targeting
 
@@ -1540,11 +1547,11 @@ Interesting!
 
 Using the registration date and time we want to find out what the peak registration hours are.
 
-- Ruby has [Date](https://rubyapi.org/3.1/o/date) and [Time](https://rubyapi.org/3.1/o/time) classes that will be very useful for this task.
+* Ruby has [Date](https://rubyapi.org/3.1/o/date) and [Time](https://rubyapi.org/3.1/o/time) classes that will be very useful for this task.
 
-- For a quick overview, check out this [Ruby Guides](https://www.rubyguides.com/2015/12/ruby-time/) article.
+* For a quick overview, check out this [Ruby Guides](https://www.rubyguides.com/2015/12/ruby-time/) article.
 
-- Explore the documentation to become familiar with the available methods, especially `#strptime`, `#strftime`, and `#hour`.
+* Explore the documentation to become familiar with the available methods, especially `#strptime`, `#strftime`, and `#hour`.
 
 ### Assignment: Day of the Week Targeting
 
@@ -1553,4 +1560,5 @@ looks like there are some hours that are clearly more important than others.
 But now, tantalized, she wants to know "What days of the week did most people
 register?"
 
-- Use [Date#wday](https://rubyapi.org/3.1/o/date#method-i-wday) to find out the day of the week.
+* Use [Date#wday](https://rubyapi.org/3.1/o/date#method-i-wday) to find out the day of the week.
+

--- a/ruby/files_and_serialization/project_event_manager.md
+++ b/ruby/files_and_serialization/project_event_manager.md
@@ -1,19 +1,20 @@
 ### Introduction
+
 Please note this tutorial has been adapted from The Turing School's and Jump Start Lab's [Event Manager](http://tutorials.jumpstartlab.com/projects/eventmanager.html) and updated to use GoogleCivic API
 
 ### Learning Goals
 
 After completing this tutorial, you will be able to:
 
-* manipulate [file](http://rubydoc.info/stdlib/core/File) input and output
-* read content from a [CSV](http://rubydoc.info/stdlib/csv/file/README.rdoc) (Comma Separated Value) file
-* transform it into a standardized format
-* utilize the data to contact a remote service
-* populate a template with user data
-* manipulate [strings](http://rubydoc.info/stdlib/core/String)
-* access [Google's Civic Information API](https://developers.google.com/civic-information/) through
+- manipulate [file](http://rubydoc.info/stdlib/core/File) input and output
+- read content from a [CSV](http://rubydoc.info/stdlib/csv/file/README.rdoc) (Comma Separated Value) file
+- transform it into a standardized format
+- utilize the data to contact a remote service
+- populate a template with user data
+- manipulate [strings](http://rubydoc.info/stdlib/core/String)
+- access [Google's Civic Information API](https://developers.google.com/civic-information/) through
   the [Google API Client Gem](https://github.com/google/google-api-ruby-client)
-* use [ERB](http://rubydoc.info/stdlib/erb/ERB) (Embedded Ruby) for templating
+- use [ERB](http://rubydoc.info/stdlib/erb/ERB) (Embedded Ruby) for templating
 
 <div class="lesson-note" markdown="1">
   This tutorial is open source. If you notice errors, typos, or have questions/suggestions, please [submit them to the project on GitHub](https://github.com/TheOdinProject/curriculum/blob/main/ruby/files_and_serialization/project_event_manager.md).
@@ -33,12 +34,12 @@ your project. In the project directory, create another folder named `lib` and in
 that folder create a plain text file named `event_manager.rb`. Using your command-line
 interface (CLI), you can enter the following commands:
 
-~~~bash
+```bash
 $ mkdir event_manager
 $ cd event_manager
 $ mkdir lib
 $ touch lib/event_manager.rb
-~~~
+```
 
 Creating and placing your `event_manager.rb` file in `lib` directory is entirely
 optional; however, it adheres to a common convention within most ruby applications.
@@ -47,62 +48,58 @@ file within the `lib` directory.
 
 Ruby source file names should be written all in lower-case characters and
 instead of camel-casing multiple words together, they are instead separated by an
-underscore (often called *snake_case*).
+underscore (often called _snake_case_).
 
 Open `lib/event_manager.rb` in your text editor and add the line:
 
-~~~ruby
+```ruby
 puts 'Event Manager Initialized!'
-~~~
+```
 
 Validate that ruby is installed correctly and you have created the file correctly by running it from the root of your `event_manager` directory:
 
-
-~~~bash
+```bash
 $ ruby lib/event_manager.rb
 Event Manager Initialized!
-~~~
+```
 
 If ruby is not installed and available on your environment path then you will be presented with the following message:
 
-
-~~~bash
+```bash
 $ ruby lib/event_manager.rb
 -bash: ruby: command not found
-~~~
+```
 
 If this happens, see [the instructions for installing Ruby](https://www.theodinproject.com/lessons/ruby-installing-ruby).
 
 If the file was not created then you will be presented with the following error
 message:
 
-
-~~~bash
+```bash
 $ ruby lib/event_manager.rb
 ruby: No such file or directory -- lib/event_manager.rb (LoadError)
-~~~
+```
 
 If this happens, make sure the correct directory exists and try creating the file again.
 
 For this project we are going to use the following sample data:
 
-* [Small Sample](https://github.com/TheOdinProject/curriculum/tree/main/ruby/files_and_serialization/event_attendees.csv)
-* [Large Sample](https://github.com/TheOdinProject/curriculum/tree/main/ruby/files_and_serialization/event_attendees_full.csv)
+- [Small Sample](https://github.com/TheOdinProject/curriculum/tree/main/ruby/files_and_serialization/event_attendees.csv)
+- [Large Sample](https://github.com/TheOdinProject/curriculum/tree/main/ruby/files_and_serialization/event_attendees_full.csv)
 
-Download the *[small sample](https://raw.githubusercontent.com/TheOdinProject/curriculum/main/ruby/files_and_serialization/event_attendees.csv)* csv file and save it in the root of the project directory, `event_manager`. Using your CLI, confirm that you are in the right directory and enter the following command:
+Download the _[small sample](https://raw.githubusercontent.com/TheOdinProject/curriculum/main/ruby/files_and_serialization/event_attendees.csv)_ csv file and save it in the root of the project directory, `event_manager`. Using your CLI, confirm that you are in the right directory and enter the following command:
 
-~~~bash
+```bash
 $ curl -o event_attendees.csv https://raw.githubusercontent.com/TheOdinProject/curriculum/main/ruby/files_and_serialization/event_attendees.csv
-~~~
+```
 
 After the file is downloaded, you should see something like:
 
-~~~bash
+```bash
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100  2125  100  2125    0     0   3269      0 --:--:-- --:--:-- --:--:-- 12073
-~~~
-
+```
 
 ### Iteration 0: Loading a File
 
@@ -115,13 +112,13 @@ database or spreadsheet applications.
 
 The first few rows of the CSV file you downloaded look like this:
 
-~~~bash
+```bash
 ,RegDate,first_Name,last_Name,Email_Address,HomePhone,Street,City,State,Zipcode
 1,11/12/08 10:47,Allison,Nguyen,arannon@jumpstartlab.com,6154385000,3155 19th St NW,Washington,DC,20010
 2,11/12/08 13:23,SArah,Hankins,pinalevitsky@jumpstartlab.com,414-520-5000,2022 15th Street NW,Washington,DC,20009
 3,11/12/08 13:30,Sarah,Xx,lqrm4462@jumpstartlab.com,(941)979-2000,4175 3rd Street North,Saint Petersburg,FL,33703
 4,11/25/08 19:21,David,Thomas,gdlia.lepping@jumpstartlab.com,650-799-0000,9 garrison ave,Jersey City,NJ,7306
-~~~
+```
 
 #### Read the File Contents
 
@@ -129,12 +126,12 @@ The first few rows of the CSV file you downloaded look like this:
 you to perform a large number of operations on files on your filesystem. The
 most straightforward is `File.read`.
 
-~~~ruby
+```ruby
 puts 'EventManager initialized.'
 
 contents = File.read('event_attendees.csv')
 puts contents
-~~~
+```
 
 In this example, it does not matter whether you use single quotes or double quotes.
 There are differences, but they are essentially the same when representing a string
@@ -144,7 +141,6 @@ We are assuming the file is present here. However, it is a good practice to conf
 that a file exists. File has the ability to check if a file exists at the specified
 filepath on the filesystem through `File.exist? "event_attendees.csv"`.
 
-
 #### Read the File Line By Line
 
 Reading and displaying the entire contents of the file showed us how to quickly
@@ -153,14 +149,14 @@ There are numerous [String](http://rubydoc.info/stdlib/core/String) methods
 that would allow us to manipulate this large string. Using `File.readlines` will
 save each line as a separate item in an array.
 
-~~~ruby
+```ruby
 puts 'EventManager initialized.'
 
 lines = File.readlines('event_attendees.csv')
 lines.each do |line|
   puts line
 end
-~~~
+```
 
 First, we read the entire contents of the file as an array of lines. Second, we
 iterate over the array of lines and output the contents of each line.
@@ -171,26 +167,26 @@ Instead of outputting the entire contents of each line we want to show only the
 first name. That requires us to look at the current contents of our Event
 Attendees file.
 
-~~~ruby
+```ruby
 ID,RegDate,first_Name,last_Name,Email_Address,HomePhone,Street,City,State,Zipcode
 1,11/12/08 10:47,Allison,Nguyen,arannon@jumpstartlab.com,6154385000,3155 19th St NW,Washington,DC,20010
-~~~
+```
 
-The first row contains header information. This row provides descriptional text
+The first row contains header information. This row provides descriptive text
 for each column of data. It tells us the data columns are laid out as follows
 from left-to-right:
 
-* `ID` - the empty column represents a unique identifier or row number of all
+- `ID` - the empty column represents a unique identifier or row number of all
   the subsequent rows
-* `RegDate` - the date the user registered for the event
-* `first_Name` - their first name
-* `last_Name` - their last name
-* `Email_Address` - their email address
-* `HomePhone` - their home phone number
-* `Street` - their street address
-* `City` - their city
-* `State` - their state
-* `Zipcode` - their zipcode
+- `RegDate` - the date the user registered for the event
+- `first_Name` - their first name
+- `last_Name` - their last name
+- `Email_Address` - their email address
+- `HomePhone` - their home phone number
+- `Street` - their street address
+- `City` - their city
+- `State` - their state
+- `Zipcode` - their zipcode
 
 The lack of consistent formatting of these headers is not ideal when
 choosing to model your own data. These column names are our extreme
@@ -209,7 +205,7 @@ By default when you send the split message to the String without a parameter it
 will break the string apart along each space `" "` character. Therefore, we need to
 specify the comma `","` character to separate the columns.
 
-~~~ruby
+```ruby
 puts 'EventManager initialized.'
 
 lines = File.readlines('event_attendees.csv')
@@ -217,14 +213,14 @@ lines.each do |line|
   columns = line.split(",")
   p columns
 end
-~~~
+```
 
 Within our array of columns we want to access our 'first_Name'. This would be
 the third column or third element at the array's second index `columns[2]`.
 Remember, arrays start counting at 0 instead of 1, so `columns[0]` is how we
 would access the array's first element, and `columns[2]` will give us the third.
 
-~~~ruby
+```ruby
 puts 'EventManager initialized.'
 
 lines = File.readlines('event_attendees.csv')
@@ -233,7 +229,7 @@ lines.each do |line|
   name = columns[2]
   puts name
 end
-~~~
+```
 
 ### Skipping the Header Row
 
@@ -250,7 +246,7 @@ which one is the header row.
 One way to solve this problem would be to skip the line when it exactly matches
 our current header row.
 
-~~~ruby
+```ruby
 puts 'EventManager initialized.'
 
 lines = File.readlines('event_attendees.csv')
@@ -260,7 +256,7 @@ lines.each do |line|
   name = columns[2]
   puts name
 end
-~~~
+```
 
 When this program is run, the `next if` line checks every line to see if it matches the provided string. If so, it skips that line from the rest of the loop.
 
@@ -271,7 +267,7 @@ updated.
 A second way to solve this problem is for us to track the index of the current
 line.
 
-~~~ruby
+```ruby
 puts 'EventManager initialized.'
 
 lines = File.readlines('event_attendees.csv')
@@ -283,12 +279,12 @@ lines.each do |line|
   name = columns[2]
   puts name
 end
-~~~
+```
 
 This is a such a common operation that Array defines
 [Array#each_with_index](http://rubydoc.info/stdlib/core/Enumerable#each_with_index-instance_method).
 
-~~~ruby
+```ruby
 puts 'EventManager initialized.'
 
 lines = File.readlines('event_attendees.csv')
@@ -298,15 +294,14 @@ lines.each_with_index do |line,index|
   name = columns[2]
   puts name
 end
-~~~
+```
 
 This solves the problem if the header row were to change in the future. It
 assumes that the header row is the first row in the file.
 
-
 #### Look for a Solution before Building a Solution
 
-Either of these solutions would be *OK* given our current attendees file.
+Either of these solutions would be _OK_ given our current attendees file.
 Problems may arise if we are given a new CSV file that is generated or
 manipulated by another source. This is because the CSV parser that we have
 started to create does not take into account a number of other features
@@ -314,8 +309,8 @@ supported by the CSV file format.
 
 Two important ones:
 
-* CSV files often contain comments which are lines that start with a pound (#) character
-* A column is unable to support a value which contains a comma (,) character
+- CSV files often contain comments which are lines that start with a pound (#) character
+- A column is unable to support a value which contains a comma (,) character
 
 Our goal is to get in contact with our event attendees. It is not to define a
 CSV parser. This is often a hard concept to let go of when initially solving a
@@ -346,7 +341,7 @@ slower start up times.
 
 You can browse the many libraries available through the [documentation](http://rubydoc.info/stdlib).
 
-~~~ruby
+```ruby
 require 'csv'
 puts 'EventManager initialized.'
 
@@ -355,7 +350,7 @@ contents.each do |row|
   name = row[2]
   puts name
 end
-~~~
+```
 
 First we need to tell Ruby that we want it to load the CSV library. This is done
 through the `require` method which accepts a parameter of the functionality to
@@ -383,7 +378,7 @@ Converting the headers to symbols will make our column names more uniform and
 easier to remember. The header "first_Name" will be converted to `:first_name`
 and "HomePhone" will be converted to `:homephone`.
 
-~~~ruby
+```ruby
 require 'csv'
 puts 'EventManager initialized.'
 
@@ -397,13 +392,13 @@ contents.each do |row|
   name = row[:first_name]
   puts name
 end
-~~~
+```
 
 #### Displaying the Zip Codes of All Attendees
 
 Accessing the zipcode is very easy using the new header name, `:zipcode`.
 
-~~~ruby
+```ruby
 require 'csv'
 puts 'EventManager initialized.'
 
@@ -418,7 +413,7 @@ contents.each do |row|
   zipcode = row[:zipcode]
   puts "#{name} #{zipcode}"
 end
-~~~
+```
 
 We now are able to output the name of the individual and their zipcode.
 
@@ -429,14 +424,14 @@ have a problem....
 
 The zip codes in our small sample show us:
 
-* Most zip codes are correctly expressed as a five-digit number
-* Some zip codes are represented with fewer than five digits
-* Some zip codes are missing
+- Most zip codes are correctly expressed as a five-digit number
+- Some zip codes are represented with fewer than five digits
+- Some zip codes are missing
 
 Before we are able to figure out our attendees' representatives, we need to
 solve the second issue and the third issue.
 
-* Some zip codes are represented with fewer than five digits
+- Some zip codes are represented with fewer than five digits
 
 If we looked at the [larger sample of data](https://raw.githubusercontent.com/TheOdinProject/curriculum/main/ruby/files_and_serialization/event_attendees_full.csv), we would
 see that the majority of the shorter zip codes are from states in the
@@ -447,7 +442,7 @@ caused the leading zeros to be removed.
 So in the case of zip codes of fewer than five digits, we will assume that we can
 pad missing zeros to the front.
 
-* Some zip codes are missing
+- Some zip codes are missing
 
 Some of our attendees are missing a zip code. It is likely that they forgot to
 enter the data when they filled out the form. The zip code data was not likely
@@ -463,7 +458,7 @@ bad zip code of "00000".
 Before we start to explore a solution with Ruby code it is often helpful to
 express what we are hoping to accomplish in English words.
 
-~~~ruby
+```ruby
 require 'csv'
 puts 'EventManager initialized.'
 
@@ -483,38 +478,38 @@ contents.each do |row|
 
   puts "#{name} #{zipcode}"
  end
-~~~
+```
 
-* if the zip code is exactly five digits, assume that it is ok
+- if the zip code is exactly five digits, assume that it is ok
 
 In the case when the zip code is five digits in length we have it easy. We
 simply want to do nothing.
 
-* if the zip code is more than five digits, truncate it to the first five digits
+- if the zip code is more than five digits, truncate it to the first five digits
 
 While zip codes can be expressed with additional resolution (more digits after
 a dash), we are only interested in the first five digits.
 
-* if the zip code is less than five digits, add zeros to the front until it
+- if the zip code is less than five digits, add zeros to the front until it
   becomes five digits
 
 There are many possible ways that we can solve this issue. These are a few
 paths:
 
-  * Use a `while` or `until` loop to prepend zeros until the length is five
-  * Calculate the length of the current zip code and add missing zeros to the front
-  * Add five zeros to the front of the current zip code and then trim the last five digits
-  * Use [String#rjust](http://rubydoc.info/stdlib/core/String#rjust-instance_method) to append zeros to the front of the string.
+- Use a `while` or `until` loop to prepend zeros until the length is five
+- Calculate the length of the current zip code and add missing zeros to the front
+- Add five zeros to the front of the current zip code and then trim the last five digits
+- Use [String#rjust](http://rubydoc.info/stdlib/core/String#rjust-instance_method) to append zeros to the front of the string.
 
 #### Handling Bad and Good Zip Codes
 
 The following solution employs:
 
-* [String#length](http://rubydoc.info/stdlib/core/String#length-instance_method) - returns the length of the string.
-* [String#rjust](http://rubydoc.info/stdlib/core/String#rjust-instance_method) - to pad the string with zeros.
-* [String#slice](http://rubydoc.info/stdlib/core/String#slice-instance_method) - to create sub-strings either through the `slice` method or the array-like notation `[]`
+- [String#length](http://rubydoc.info/stdlib/core/String#length-instance_method) - returns the length of the string.
+- [String#rjust](http://rubydoc.info/stdlib/core/String#rjust-instance_method) - to pad the string with zeros.
+- [String#slice](http://rubydoc.info/stdlib/core/String#slice-instance_method) - to create sub-strings either through the `slice` method or the array-like notation `[]`
 
-~~~ruby
+```ruby
 require 'csv'
 
 puts 'EventManager initialized.'
@@ -537,13 +532,12 @@ contents.each do |row|
 
   puts "#{name} #{zipcode}"
 end
-~~~
+```
 
 When we run our application, we see the first few lines output correctly and then the
 application terminates.
 
-
-~~~bash
+```bash
 $ ruby lib/event_manager.rb
 EventManager initialized.
 Allison 20010
@@ -553,9 +547,9 @@ David 07306
 lib/event_manager.rb:11:in `block in <main>': undefined method `length' for nil:NilClass (NoMethodError)
 	from /Users/burtlo/.rvm/rubies/ruby-1.9.3-p374/lib/ruby/1.9.1/csv.rb:1792:in `each'
 	from lib/event_manager.rb:7:in `<main>'
-~~~
+```
 
-* What is the error message "undefined method 'length' for nil:NilClass (NoMethodError)" saying?
+- What is the error message "undefined method 'length' for nil:NilClass (NoMethodError)" saying?
 
 Reviewing our CSV data, we notice that the next row specifies no value. An empty
 field translates into a nil instead of an empty string. This is a choice made by
@@ -571,7 +565,7 @@ except for a `nil`.
 We can update our implementation to handle this new case by simply adding a
 check for `nil?`.
 
-~~~ruby
+```ruby
 require 'csv'
 
 puts 'EventManager initialized.'
@@ -596,10 +590,9 @@ contents.each do |row|
 
   puts "#{name} #{zipcode}"
 end
-~~~
+```
 
-
-~~~bash
+```bash
 $ ruby lib/event_manager.rb
 EventManager initialized.
 Allison 20010
@@ -621,21 +614,21 @@ Shannon 03082
 Shannon 98122
 Nash 98122
 Amanda 14841
-~~~
+```
 
 #### Moving Clean Zip Codes to a Method
 
 It is important for us to take a look at our implementation. During this
 examination we should ask ourselves:
 
-* Does the code clearly express what it is trying to accomplish?
+- Does the code clearly express what it is trying to accomplish?
 
 The implementation does a decent job at expressing what it accomplishes. The
 biggest problem is that it is expressing this near so many other concepts. To
 make this implementation clearer we should move this logic into its own method
 named `clean_zipcode`.
 
-~~~ruby
+```ruby
 require 'csv'
 
 def clean_zipcode(zipcode)
@@ -665,7 +658,7 @@ contents.each do |row|
 
   puts "#{name} #{zipcode}"
 end
-~~~
+```
 
 This may feel like a very small, inconsequential change, but small changes
 like these help make your code cleaner and your intent clearer.
@@ -675,7 +668,7 @@ like these help make your code cleaner and your intent clearer.
 With our clean zip code logic tucked away in our `clean_zipcode` method, we can
 examine it further to see if we can make it even more succinct.
 
-* Coercion over Questions
+- Coercion over Questions
 
 A good rule when developing in Ruby is to favor coercing values into similar
 values so that they will behave the same. We have a special case to deal
@@ -683,10 +676,10 @@ specifically with a `nil` value. It would be much easier if instead of checking
 for a nil value, we convert the `nil` into a string with
 [NilClass#to_s](http://rubydoc.info/stdlib/core/NilClass#to_s-instance_method).
 
-~~~ruby
+```ruby
 $ nil.to_s
 => ""
-~~~
+```
 
 Examining
 [String#rjust](http://rubydoc.info/stdlib/core/String#rjust-instance_method) in
@@ -694,10 +687,10 @@ irb, we can see that when we provide a string with a length greater than five,
 it performs no work. This means we can apply it in both cases, as it will have the
 same intended effect.
 
-~~~ruby
+```ruby
 $ "123456".rjust(5, '0')
 => "123456"
-~~~
+```
 
 Lastly, examining
 [String#slice](http://rubydoc.info/stdlib/core/String#slice-instance_method) in
@@ -705,19 +698,19 @@ irb, we can see that for a number that is exactly five digits in length, it has 
 effect. This also means we can apply it in cases when the zip code is five or more
 digits, and it will have the same effect.
 
-~~~ruby
+```ruby
 $ "12345"[0..4]
 => "12345"
-~~~
+```
 
 Combining all of these steps together, we can write a more succinct
 `clean_zipcode` method:
 
-~~~ruby
+```ruby
 def clean_zipcode(zipcode)
   zipcode.to_s.rjust(5, '0')[0..4]
 end
-~~~
+```
 
 ### Iteration 3: Using Google's Civic Information
 
@@ -740,16 +733,16 @@ Take a close look at this sample URL for accessing the Civic Information API:
 
 Here's how it breaks down:
 
-* `https://` : Use the Secure HTTP protocol
-* `www.googleapis.com/civicinfo/v2/` : The API server address on the internet
-* `representatives` : The method called on that server
-* `?` : Parameters to the method
-  * `&` : The parameter separator
-  * `address=80203` : The zipcode we want to lookup
-  * `levels=country` : The level of government we want to select
-  * `roles=legislatorUpperBody` : Return the representatives from the Senate
-  * `roles=legislatorLowerBody` : Returns the representatives from the House
-  * `key=AIzaSyClRzDqDh5MsXwnCWi0kOiiBivP6JsSyBw` : A registered API Key to authenticate our requests
+- `https://` : Use the Secure HTTP protocol
+- `www.googleapis.com/civicinfo/v2/` : The API server address on the internet
+- `representatives` : The method called on that server
+- `?` : Parameters to the method
+  - `&` : The parameter separator
+  - `address=80203` : The zipcode we want to lookup
+  - `levels=country` : The level of government we want to select
+  - `roles=legislatorUpperBody` : Return the representatives from the Senate
+  - `roles=legislatorLowerBody` : Returns the representatives from the House
+  - `key=AIzaSyClRzDqDh5MsXwnCWi0kOiiBivP6JsSyBw` : A registered API Key to authenticate our requests
 
 When we're accessing the `representatives` method of their API, we're sending in a `key` which is the string that identifies JumpstartLab as the accessor of
 the API, then we're selecting the data we want returned to us using the `address`, `levels`, and `roles` criteria. Try modifying the address with your own zipcode and load the page.
@@ -763,12 +756,11 @@ Let's look for a solution before we attempt to build a solution.
 Ruby comes packaged with the `gem` command. This tool allows you to download
 libraries by simply knowing the name of the library you want to install.
 
-
-~~~bash
+```bash
 $ gem install google-api-client
 Successfully installed google-api-client-0.15.0
 1 gem installed
-~~~
+```
 
 If you receive a signet error when installing the Google API gem, it is due to modern Ruby updates requiring an updated version of signet that is not compatible with the API. To fix, please [downgrade your version of signet](https://github.com/googleapis/google-api-ruby-client/issues/833) before installing the gem.
 
@@ -780,13 +772,13 @@ available online with their [source code](https://github.com/google/google-api-r
 Reading through the documentation on how to set up and use the
 google-api-client gem, we find that we need to perform the following steps:
 
-* Set the API Key
-* Send the query with the given criteria
-* Parse the response for the names of your legislators.
+- Set the API Key
+- Send the query with the given criteria
+- Parse the response for the names of your legislators.
 
 Exploration of data is easy using irb:
 
-~~~ruby
+```ruby
 $ require 'google/apis/civicinfo_v2'
 => true
 
@@ -798,11 +790,11 @@ $ civic_info.key = 'AIzaSyClRzDqDh5MsXwnCWi0kOiiBivP6JsSyBw'
 
 $ response = civic_info.representative_info_by_address(address: 80202, levels: 'country', roles: ['legislatorUpperBody', 'legislatorLowerBody'])
 => #<Google::Apis::CivicinfoV2::RepresentativeInfoResponse:0x007faf2d9088d0 @divisions={"ocd-division/country:us/state:co"=>#<Google::Apis::CivicinfoV2::GeographicDivision:0x007faf2e55ea80 @name="Colorado", @office_indices=[0]> } > ...continues...
-~~~
+```
 
-Whoa. That's a lot of information.  Buried in there are the names of our legislators.  We can access them by calling the `.officials` method on the `response`.  Now that we know how to access the information we want, we can focus our attention back on our program.
+Whoa. That's a lot of information. Buried in there are the names of our legislators. We can access them by calling the `.officials` method on the `response`. Now that we know how to access the information we want, we can focus our attention back on our program.
 
-~~~ruby
+```ruby
 require 'csv'
 require 'google/apis/civicinfo_v2'
 
@@ -835,19 +827,18 @@ contents.each do |row|
 
   puts "#{name} #{zipcode} #{legislators}"
 end
-~~~
+```
 
 Running our application, we find an error.
 
-
-~~~bash
+```bash
 $ ruby lib/event_manager.rb
 /ruby-2.4.0/gems/google-api-client-0.15.0/lib/google/apis/core/http_command.rb:218:in 'check_status': parseError: Failed to parse address (Google::Apis::ClientError)
-~~~
+```
 
-What does this mean?  It means that the Google API was unable to use an address we gave it.  When we dig further, we see that right before this error the information from David with a zip code of 07306 is printed. Looking at the data we can now see that the attendee after David did not enter a zip code.  Data missing like this is common, so we have to have a way of dealing with it. Luckily, Ruby makes that easy with its [Exception Class](https://ruby-doc.org/core/Exception.html).  We can add a `begin` and `rescue` clause to the API search to handle any errors.
+What does this mean? It means that the Google API was unable to use an address we gave it. When we dig further, we see that right before this error the information from David with a zip code of 07306 is printed. Looking at the data we can now see that the attendee after David did not enter a zip code. Data missing like this is common, so we have to have a way of dealing with it. Luckily, Ruby makes that easy with its [Exception Class](https://ruby-doc.org/core/Exception.html). We can add a `begin` and `rescue` clause to the API search to handle any errors.
 
-~~~ruby
+```ruby
 require 'csv'
 require 'google/apis/civicinfo_v2'
 
@@ -884,11 +875,11 @@ contents.each do |row|
 
   puts "#{name} #{zipcode} #{legislators}"
 end
-~~~
+```
 
 The **legislators** that we are displaying is an array. In turn, the array is
 sending the `to_s` message to each of the objects within the array, each
-legislator. The output that we are seeing is the *raw* legislator object.
+legislator. The output that we are seeing is the _raw_ legislator object.
 
 We really want to capture the first name and last name of each legislator.
 
@@ -897,36 +888,36 @@ We really want to capture the first name and last name of each legislator.
 Instead of outputting each raw legislator we want to print only their first
 name and last name. We will need to complete the following steps:
 
-* For each zip code, iterate over the array of legislators.
-* For each legislator, we want to find the representative's name.
-* Add the name to a new collection of names.
+- For each zip code, iterate over the array of legislators.
+- For each legislator, we want to find the representative's name.
+- Add the name to a new collection of names.
 
-To do this, we can use the [map](https://ruby-doc.org/core/Array.html#method-i-map) function built into ruby.  It works just like `.each` but returns a new array of the data we want to include.
+To do this, we can use the [map](https://ruby-doc.org/core/Array.html#method-i-map) function built into ruby. It works just like `.each` but returns a new array of the data we want to include.
 
-~~~ruby
+```ruby
 legislator_names = legislators.map do |legislator|
     legislator.name
   end
-~~~
+```
 
 We can further simplify this into its final form:
 
-~~~ruby
+```ruby
 legislator_names = legislators.map(&:name)
-~~~
+```
 
 #### Cleanly Displaying Legislators
 
-If we were to replace `legislators` with `legislator_names` in our output, we would be presented with a *slightly* better output.
+If we were to replace `legislators` with `legislator_names` in our output, we would be presented with a _slightly_ better output.
 
-~~~bash
+```bash
 $ ruby lib/event_manager.rb
 EventManager initialized.
 Allison 20010 ["Eleanor Norton"]
 SArah 20009 ["Eleanor Norton"]
 Sarah 33703 ["Marco Rubio", "Bill Nelson", "C. Young"]
 ...
-~~~
+```
 
 The problem now is that when using string interpolation, Ruby is converting our new array of legislator names into a string, but Ruby does not know exactly how _you_ want to display the contents.
 
@@ -934,7 +925,7 @@ We need to explicitly convert our array of legislator names to a string. This wa
 
 [Array#join](http://rubydoc.info/stdlib/core/Array#join-instance_method) allows the specification of a separator string. We want to create a comma-separated list of legislator names with `legislator_names.join(", ")`
 
-~~~ruby
+```ruby
 contents.each do |row|
   name = row[:first_name]
 
@@ -957,27 +948,26 @@ contents.each do |row|
 
   puts "#{name} #{zipcode} #{legislators_string}"
 end
-~~~
+```
 
 Running our application this time should give us a much more pleasant looking
 output:
 
-
-~~~bash
+```bash
 $ ruby lib/event_manager.rb
 EventManager initialized.
 Allison 20010 Eleanor Norton
 SArah 20009 Eleanor Norton
 Sarah 33703 Marco Rubio, Bill Nelson, C. Young
 ...
-~~~
+```
 
 #### Moving Displaying Legislators to a Method
 
 Similar to before, with this step complete, we want to look at our
 implementation and ask ourselves:
 
-* Does the code clearly express what it is trying to accomplish?
+- Does the code clearly express what it is trying to accomplish?
 
 This code is fairly clear in its understanding. It is simply expressing its
 intent near so many other things. It is also expressing itself differently from
@@ -988,7 +978,7 @@ We want to extract our legislator names into a new method named
 `legislators_by_zipcode`, which accepts a single zip code as a parameter
 and returns a comma-separated string of legislator names.
 
-~~~ruby
+```ruby
 require 'csv'
 require 'google/apis/civicinfo_v2'
 
@@ -1032,7 +1022,7 @@ contents.each do |row|
 
   puts "#{name} #{zipcode} #{legislators}"
 end
-~~~
+```
 
 An additional benefit of this implementation is that it encapsulates how we
 actually retrieve the names of the legislators. This will be of benefit later if we
@@ -1048,34 +1038,41 @@ For each attendee we want to include a customized letter that thanks them for
 attending the conference and provides a list of their representatives.
 Something that looks like:
 
-~~~html
+```html
 <html>
-<head>
-  <meta charset='UTF-8'>
-  <title>Thank You!</title>
-</head>
-<body>
-  <h1>Thanks FIRST_NAME!</h1>
-  <p>Thanks for coming to our conference.  We couldn't have done it without you!</p>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Thank You!</title>
+  </head>
+  <body>
+    <h1>Thanks FIRST_NAME!</h1>
+    <p>
+      Thanks for coming to our conference. We couldn't have done it without you!
+    </p>
 
-  <p>
-    Political activism is at the heart of any democracy and your voice needs to be heard.
-    Please consider reaching out to your following representatives:
-  </p>
+    <p>
+      Political activism is at the heart of any democracy and your voice needs
+      to be heard. Please consider reaching out to your following
+      representatives:
+    </p>
 
-  <table>
-    <tr><th>Legislators</th></tr>
-    <tr><td>LEGISLATORS</td></tr>
-  </table>
-</body>
+    <table>
+      <tr>
+        <th>Legislators</th>
+      </tr>
+      <tr>
+        <td>LEGISLATORS</td>
+      </tr>
+    </table>
+  </body>
 </html>
-~~~
+```
 
 #### Storing our template to a file
 
 We could define this template as a large string within our current application.
 
-~~~ruby
+```ruby
 form_letter = %{
   <html>
   <head>
@@ -1097,10 +1094,9 @@ form_letter = %{
   </body>
   </html>
 }
-~~~
+```
 
-Ruby has quite a few ways that we can define strings. This format `%{ String
-Contents }` is one choice when defining a string that spans multiple lines.
+Ruby has quite a few ways that we can define strings. This format `%{ String Contents }` is one choice when defining a string that spans multiple lines.
 
 However, placing this large blob of text, this template, within our application
 will make it much more difficult to understand the template and the application
@@ -1110,14 +1106,14 @@ code.
 Instead of including the template within our application, we will instead load
 the template using the same File tools we used at the beginning of the exercise.
 
-* Create a file named 'form_letter.html' in the root of your project directory.
-* Copy the html template defined above into that file and save it.
+- Create a file named 'form_letter.html' in the root of your project directory.
+- Copy the html template defined above into that file and save it.
 
 Within our application we will load our template:
 
-~~~ruby
+```ruby
 template_letter = File.read('form_letter.html')
-~~~
+```
 
 It is important to define the `form_letter.html` file in the root of project
 directory and not in the lib directory. This is because when the application
@@ -1125,13 +1121,12 @@ runs it assumes the place that you started the application is where all file
 references will be located. Later, we move the file to a new location and are
 more explicit on defining the location of the template.
 
-
 #### Replacing with `gsub` and `gsub!`
 
 For each of our attendees we want to replace the `FIRST_NAME` and `LEGISLATORS` with their respective values.
 
-* We need to find all instances of `FIRST_NAME` and replace them with the individual's first name.
-* We need to find all instances of `LEGISLATORS` and replace them with the individual's representatives.
+- We need to find all instances of `FIRST_NAME` and replace them with the individual's first name.
+- We need to find all instances of `LEGISLATORS` and replace them with the individual's representatives.
 
 Our template is a String of text which has two methods for replacing text:
 [String#gsub](http://rubydoc.info/stdlib/core/String#gsub-instance_method) and
@@ -1146,7 +1141,7 @@ important that we create a new copy of this letter for each attendee. If we
 change the original template, they'd all have the same name! By making a copy
 and then changing the copy, we're sure everyone's name is unique.
 
-~~~ruby
+```ruby
 template_letter = File.read('form_letter.html')
 
 contents.each do |row|
@@ -1161,7 +1156,7 @@ contents.each do |row|
 
   puts personal_letter
 end
-~~~
+```
 
 We replace the first name in the template letter and return a new copy (Thanks
 [String#gsub](http://rubydoc.info/stdlib/core/String#gsub-instance_method)). We
@@ -1174,24 +1169,24 @@ Methods like `gsub` and `gsub!` can often be confusing and when to use one over
 the other may not be immediately clear. The above template manipulation could
 have been written with just `gsub`:
 
-~~~ruby
+```ruby
 personal_letter = template_letter.gsub('FIRST_NAME', name)
 personal_letter = personal_letter.gsub('LEGISLATORS', legislators)
-~~~
+```
 
 #### Our Template System has Problems
 
 It is a treacherous road we start to walk, defining our own templating language.
 Our current system has some flaws:
 
-* Using FIRST_NAME and LEGISLATORS to find and replace might cause us problems if later somehow this text appears in any of our templates.
+- Using FIRST_NAME and LEGISLATORS to find and replace might cause us problems if later somehow this text appears in any of our templates.
 
 Though not likely, imagine if a person's name contained the word 'LEGISLATORS'.
 When we perform the second replacement operation, that part of the person's name
 would also be replaced. This is unlikely in our simple template, but as our
 template grows, we may invite such disasters.
 
-* We cannot represent multiple items very easily if they are surrounded by HTML.
+- We cannot represent multiple items very easily if they are surrounded by HTML.
 
 Currently we copied our legislators string into a single table column. We would
 have a hard time inserting our legislators as individual rows in the table
@@ -1215,16 +1210,16 @@ variables, methods or ruby code we want to execute.
 ERB defines several different escape sequence tags that we can use. The most
 common are:
 
-~~~ruby
+```ruby
 <%= ruby code will execute and show output %>
 <% ruby code will execute but not show output %>
-~~~
+```
 
 We can define our ERB escape tags within any string. The ruby defined within
 the contents of the ERB tags will not be evaluated until we ask the template to
 give us the results.
 
-~~~ruby
+```ruby
 require 'erb'
 
 meaning_of_life = 42
@@ -1234,14 +1229,14 @@ template = ERB.new question
 
 results = template.result(binding)
 puts results
-~~~
+```
 
 The code above loads the ERB library, then creates a new ERB template with the
 `question` string. The question string contains ERB tags that will show the
 results of the variable `meaning_of_life`. We send the `result` message to the
 template with `binding`.
 
-* What is `binding`?
+- What is `binding`?
 
 The method
 [binding](http://rubydoc.info/stdlib/core/Kernel#binding-instance_method)
@@ -1258,15 +1253,15 @@ different binding.
 
 To use ERB we need to update our current template **form_letter.html**.
 
-* Save a new template as **form_letter.erb**
+- Save a new template as **form_letter.erb**
 
 The convention is to save ERB template files with the extension **erb**. This
 is not a requirement. It is a benefit to yourself and other users when they
 return to the application.
 
-* Update our existing keywords with the ERB escape sequences
+- Update our existing keywords with the ERB escape sequences
 
-~~~erb
+```erb
 <html>
 <head>
   <meta charset='UTF-8'>
@@ -1297,7 +1292,7 @@ return to the application.
   </table>
 </body>
 </html>
-~~~
+```
 
 The use of the ERB tags to display the attendee's name is familiar from our previous example. The second use, when we display the legislators, is different. We are using the ERB tag that does not output the results `<% %>` to check if the legislators variable is an Array.
 
@@ -1305,16 +1300,15 @@ If it is an array, we output the name and website url of each legislator. This i
 
 If `legislators` is not an array, it means that the `legislators_by_zipcode` method entered the rescue clause, which outputs a string. We simply want to display that string.
 
-
 #### Using ERB
 
 We now need to update our application to:
 
-* Require the ERB library
-* Create the ERB template from the contents of the template file
-* Simplify our `legislators_by_zipcode` to return the original array of legislators
+- Require the ERB library
+- Create the ERB template from the contents of the template file
+- Simplify our `legislators_by_zipcode` to return the original array of legislators
 
-~~~ruby
+```ruby
 require 'csv'
 require 'google/apis/civicinfo_v2'
 require 'erb'
@@ -1359,28 +1353,28 @@ contents.each do |row|
   form_letter = erb_template.result(binding)
   puts form_letter
 end
-~~~
+```
 
-* Require the ERB library
+- Require the ERB library
 
 First we need to tell Ruby that we want it to load the ERB library. This is done
 through the `require` method which accepts a parameter of the functionality to
 load.
 
-* Create the ERB template from the contents of the template file
+- Create the ERB template from the contents of the template file
 
 Creating our template from our new template file requires us to load the file
 contents as a string and provide them as a parameter when creating the new ERB
 template.
 
-~~~ruby
+```ruby
 template_letter = File.read('form_letter.erb')
 erb_template = ERB.new template_letter
-~~~
+```
 
-* Simplify our `legislators_by_zipcode` to return the original array of legislators
+- Simplify our `legislators_by_zipcode` to return the original array of legislators
 
-~~~ruby
+```ruby
 def legislators_by_zipcode(zip)
   civic_info = Google::Apis::CivicinfoV2::CivicInfoService.new
   civic_info.key = 'AIzaSyClRzDqDh5MsXwnCWi0kOiiBivP6JsSyBw'
@@ -1395,7 +1389,7 @@ def legislators_by_zipcode(zip)
     'You can find your representatives by visiting www.commoncause.org/take-action/find-elected-officials'
   end
 end
-~~~
+```
 
 #### Outputting form letters to a file
 
@@ -1405,12 +1399,11 @@ looked correct. It is time to save each form letter to a file.
 Each file should be uniquely named. Fortunately, each of our attendees has a
 unique id—the first column, or row number.
 
-* Assign an ID for the attendee
-* Create an output folder
-* Save each form letter to a file based on the id of the attendee
+- Assign an ID for the attendee
+- Create an output folder
+- Save each form letter to a file based on the id of the attendee
 
-
-~~~ruby
+```ruby
 contents.each do |row|
   id = row[0]
   name = row[:first_name]
@@ -1430,23 +1423,23 @@ contents.each do |row|
   end
 
 end
-~~~
+```
 
-* Assign an ID for the attendee
+- Assign an ID for the attendee
 
 The first column does not have a name like the other columns, so we fall back
 to using the index value.
 
-* Create an output folder
+- Create an output folder
 
 We make a directory named "output" if a directory named "output" does not
 already exist.
 
-~~~ruby
+```ruby
 Dir.mkdir('output') unless Dir.exist?('output')
-~~~
+```
 
-* Save each form letter to a file based on the id of the attendee
+- Save each form letter to a file based on the id of the attendee
 
 [File#open](http://rubydoc.info/stdlib/core/File#open-class_method) allows us
 to open a file for reading and writing. The first parameter is the name of the
@@ -1457,7 +1450,7 @@ it will be destroyed.
 Afterwards we actually send the entire form letter content to the file
 object. The `file` object responds to the message `puts`. The method
 [IO#puts](http://rubydoc.info/stdlib/core/IO#puts-instance_method), from which the `file` object inherits, is similar to
- [Kernel#puts](http://rubydoc.info/stdlib/core/Kernel#puts-instance_method)
+[Kernel#puts](http://rubydoc.info/stdlib/core/Kernel#puts-instance_method)
 which we have been using up to this point.
 
 #### Moving Form Letter Generation to a Method
@@ -1465,7 +1458,7 @@ which we have been using up to this point.
 Again, for the sake of writing clean and clear code, we want to move the
 operation of saving the form letter to its own method:
 
-~~~ruby
+```ruby
 require 'csv'
 require 'google/apis/civicinfo_v2'
 require 'erb'
@@ -1520,7 +1513,7 @@ contents.each do |row|
 
   save_thank_you_letter(id,form_letter)
 end
-~~~
+```
 
 The method `save_thank_you_letter` requires the id of the attendee and the form letter
 output.
@@ -1532,11 +1525,11 @@ inconsistencies. If we wanted to allow individuals to sign up for mobile alerts
 with the phone numbers, we would need to make sure all of the numbers are valid
 and well-formed.
 
-* If the phone number is less than 10 digits, assume that it is a bad number
-* If the phone number is 10 digits, assume that it is good
-* If the phone number is 11 digits and the first number is 1, trim the 1 and use the remaining 10 digits
-* If the phone number is 11 digits and the first number is not 1, then it is a bad number
-* If the phone number is more than 11 digits, assume that it is a bad number
+- If the phone number is less than 10 digits, assume that it is a bad number
+- If the phone number is 10 digits, assume that it is good
+- If the phone number is 11 digits and the first number is 1, trim the 1 and use the remaining 10 digits
+- If the phone number is 11 digits and the first number is not 1, then it is a bad number
+- If the phone number is more than 11 digits, assume that it is a bad number
 
 ### Assignment: Time Targeting
 
@@ -1547,11 +1540,11 @@ Interesting!
 
 Using the registration date and time we want to find out what the peak registration hours are.
 
-* Ruby has [Date](https://rubyapi.org/3.1/o/date) and [Time](https://rubyapi.org/3.1/o/time) classes that will be very useful for this task.
+- Ruby has [Date](https://rubyapi.org/3.1/o/date) and [Time](https://rubyapi.org/3.1/o/time) classes that will be very useful for this task.
 
-* For a quick overview, check out this [Ruby Guides](https://www.rubyguides.com/2015/12/ruby-time/) article.
+- For a quick overview, check out this [Ruby Guides](https://www.rubyguides.com/2015/12/ruby-time/) article.
 
-* Explore the documentation to become familiar with the available methods, especially `#strptime`, `#strftime`, and `#hour`.
+- Explore the documentation to become familiar with the available methods, especially `#strptime`, `#strftime`, and `#hour`.
 
 ### Assignment: Day of the Week Targeting
 
@@ -1560,4 +1553,4 @@ looks like there are some hours that are clearly more important than others.
 But now, tantalized, she wants to know "What days of the week did most people
 register?"
 
-* Use [Date#wday](https://rubyapi.org/3.1/o/date#method-i-wday) to find out the day of the week.
+- Use [Date#wday](https://rubyapi.org/3.1/o/date#method-i-wday) to find out the day of the week.


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
I got to the lesson "Using Git in the Real World" and wanted to complete the lesson. I found a typo on the page /lessons/ruby-event-manager and wanted to apply a fix for it.


## This PR
Applies a fix for a single typo


## Issue
There was no issue open, this is simply a typo I had found

## Additional Information


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
