### PR TITLE
Chore: Update Heroku Free Plan Deadline

### DIFF
--- a/ruby_on_rails/introduction/preparing_for_deployment.md
+++ b/ruby_on_rails/introduction/preparing_for_deployment.md
@@ -4,9 +4,9 @@ We have one thing to attend to before progressing in our web development journey
 
 <div class="lesson-note" markdown="1">
 
-### Important! 
+### Important!
 
-Starting November 22, 2022, Heroku will stop offering their free product plans (which includes deployment). You can read more on [their blog post](https://blog.heroku.com/next-chapter).
+Starting November 28, 2022, Heroku will stop offering their free product plans (which includes deployment). You can read more on [their blog post](https://blog.heroku.com/next-chapter).
 
 We will be replacing the following instructions with an alternative soon.
 


### PR DESCRIPTION
Because:
* Heroku will stop providing their free plan on the 28th of November