### PR TITLE
APIs and Building Your Own lesson: Add to #as_json code example

### DIFF
--- a/ruby_on_rails/apis/apis_and_building_your_own.md
+++ b/ruby_on_rails/apis/apis_and_building_your_own.md
@@ -100,7 +100,6 @@ In our case, we'll do this by modifying `#as_json` in our model to return only t
     # Option 2: Working with the default #as_json method
     def as_json(options={})
       super({ only: [:name] }.merge(options))
-      super(options)
     end
     
   end

--- a/ruby_on_rails/apis/apis_and_building_your_own.md
+++ b/ruby_on_rails/apis/apis_and_building_your_own.md
@@ -99,7 +99,7 @@ In our case, we'll do this by modifying `#as_json` in our model to return only t
 
     # Option 2: Working with the default #as_json method
     def as_json(options={})
-      options = { only: [:name] }.merge(options)
+      super({ only: [:name] }.merge(options))
       super(options)
     end
     

--- a/ruby_on_rails/apis/apis_and_building_your_own.md
+++ b/ruby_on_rails/apis/apis_and_building_your_own.md
@@ -93,13 +93,14 @@ In our case, we'll do this by modifying `#as_json` in our model to return only t
   class User < ActiveRecord::Base
 
     # Option 1: Purely overriding the #as_json method
-    def as_json(options={})
+    def as_json(_options={})
       { :name => self.name }  # NOT including the email field
     end
 
     # Option 2: Working with the default #as_json method
     def as_json(options={})
-      super(:only => [:name])
+      options = { only: [:name] }.merge(options)
+      super(options)
     end
     
   end


### PR DESCRIPTION
## Because
The Ruby on Rails lesson "APIs and Building Your Own" has an example for how to specify the attributes to return by modifying the #as_json method, the following PR is a small suggestion I think could improve one of the code examples.

The solution which uses the default #as_json method could be improved (if desired) by merging the options hash with the attributes that we want to return by default and passing all of these to super. Otherwise, any additional options are disregarded.

While making the change I also updated the first example of purely overriding the #as_json method by prefixing 'options' with an '_' (as per https://github.com/rubocop/ruby-style-guide#underscore-unused-vars).

## This PR
- Adds to one of the code examples
- Fixes a small ruby style guide recommendation

## Issue
N/A

## Additional Information
N/A

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
