### PR TITLE
React: Fix typo: Whats -> What's

### DIFF
--- a/react/class_components/class_based_components.md
+++ b/react/class_components/class_based_components.md
@@ -10,7 +10,7 @@ This section contains a general overview of topics that you will learn in this l
 - How to use props and state in class components.
 - Highlight the uses of `this` in class components.
 
-### The Whats And Whys
+### The What's And Whys
 
 In your previous lessons, you have already been introduced to functional components, and the basic patterns in which components get written now a days. However, React components did not look this way when React was introduced.
 


### PR DESCRIPTION
## Because
This apparently snuck in and is causing codespell to leave a annotation on every check it runs


## This PR
- fixes a codespell flagged typo



## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [X] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [X] The `Because` section summarizes the reason for this PR
-   [X] The `This PR` section has a bullet point list describing the changes in this PR
-   [X] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [X] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
