### PR TITLE
JavaScript Fundamentals Part 2: fix a typo in the very first paragraph

### DIFF
--- a/foundations/javascript_basics/fundamentals-2.md
+++ b/foundations/javascript_basics/fundamentals-2.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-There are a few extremely common types of data that you will encounter in JavaScript, and these fundamentals lessons will give us a really strong foundation in all of them.  Before we start digging deep, however, [this article](http://javascript.info/types) will give you a quick overview of the most common ones.
+There are a few extremely common types of data that you will encounter in JavaScript, and these fundamental lessons will give us a really strong foundation in all of them.  Before we start digging deep, however, [this article](http://javascript.info/types) will give you a quick overview of the most common ones.
 
 ### Lesson Overview
 

--- a/foundations/javascript_basics/fundamentals-2.md
+++ b/foundations/javascript_basics/fundamentals-2.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-There are a few extremely common types of data that you will encounter in JavaScript, and these fundamental lessons will give us a really strong foundation in all of them.  Before we start digging deep, however, [this article](http://javascript.info/types) will give you a quick overview of the most common ones.
+There are a few extremely common types of data that you will encounter in JavaScript, and these lessons on fundamentals will give us a really strong foundation in all of them.  Before we start digging deep, however, [this article](http://javascript.info/types) will give you a quick overview of the most common ones.
 
 ### Lesson Overview
 


### PR DESCRIPTION
"these fundamental lessons" rather than "these fundamentals lessons"

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
To fix a grammatical typo.

## This PR
Same as above.

## Issue
Not related to other issues.

## Additional Information
This minor change is pretty self-explanatory with a look at the diff

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
