### PR TITLE
React Router lesson: Fixed dead link for React router page

### DIFF
--- a/javascript/react_js/router.md
+++ b/javascript/react_js/router.md
@@ -11,7 +11,7 @@ By the end of this lesson, you should be able to:
 ### Client-Side Routing
 
 <span id="client-side-routing">Client-side routing is internal handling of routes inside the JS file that is rendered to the client (front-end). Client-side routing helps in building single-page applications (SPAs) without refreshing as the user navigates. For example when a user clicks a navbar element, the URL changes and the view of the page is modified accordingly, within the client.</span>
- 
+
 React Router is the standard routing library for React applications. By using React routers, we can specify which component can be rendered based on the route. From version 4, react router uses [dynamic routes](https://v5.reactrouter.com/web/guides/philosophy/dynamic-routing) (routing that takes place as your app is rendering).
 
 ### How To Use React Router
@@ -101,7 +101,7 @@ You should now have enough basics to get started with React routing. There are a
 
 <div class="lesson-content__panel" markdown="1">
 1. Go and add a few new routes to the application we created above; playing around with it is the best practice. Consider deleting it completely and rewriting it for practice.
-2. Browse a little bit through the React Router [documentation](https://reactrouter.com/docs/en/v6/getting-started/overview). You don't need to read through all of it, nor understand all of it. Just browse through the concepts we discussed here and re-read them. This is a great resource to refer back to.
+2. Browse a little bit through the React Router [documentation](https://reactrouter.com/en/main/start/overview). You don't need to read through all of it, nor understand all of it. Just browse through the concepts we discussed here and re-read them. This is a great resource to refer back to.
 3. Watch this [video on React Router by Dev Ed](https://www.youtube.com/watch?v=Law7wfdg_ls) for reviewing. You should already be familiar with those concepts.
     *  <div class="lesson-note" markdown="1">
 
@@ -124,4 +124,3 @@ This section contains questions for you to check your understanding of this less
 - <a class="knowledge-check-link" href="#react-router">How do you add page routing to a React project?</a>
 - <a class="knowledge-check-link" href="#components">What are the three core components of React Router?</a>
 - <a class="knowledge-check-link" href="#routing">How do you ensure that Router links are routed accurately?</a>
-


### PR DESCRIPTION
## Because
The current link goes to a 404. This new link should work better since it is set to always to go the documentation for the main branch of React Router (unless they change the way their documentation is laid out).

## This PR
- Updated the link for the router documentation
- Removed some unnecessary spacing at the bottom and in the middle of the Router page

## Issue
N/A

## Additional Information
N/A

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [X] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [X] The `Because` section summarizes the reason for this PR
-   [X] The `This PR` section has a bullet point list describing the changes in this PR
-   [X] If this PR addresses an open issue, it is linked in the `Issue` section
-   [X] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [X] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
