### PR TITLE
Advanced Forms: Fix numbered list

### DIFF
--- a/ruby_on_rails/advanced_forms_and_activerecord/forms_advanced.md
+++ b/ruby_on_rails/advanced_forms_and_activerecord/forms_advanced.md
@@ -104,15 +104,15 @@ As you can imagine, it's important to get the names and parameters properly list
 
 We'll do a broad overview of the process here:
 
-<span id='accepts_nested_attributes_for'>1. You will need to prepare the User model so that it knows to create one or more ShippingAddress objects if it receives their attributes when creating a normal User.  This is done by adding a method to your User model called `#accepts_nested_attributes_for` which accepts the name of an association, e.g:<span>
+1. {: #accepts_nested_attributes_for}You will need to prepare the User model so that it knows to create one or more ShippingAddress objects if it receives their attributes when creating a normal User.  This is done by adding a method to your User model called `#accepts_nested_attributes_for` which accepts the name of an association, e.g:
 
-~~~ruby
-  # app/models/user.rb
-  class User < ActiveRecord::Base
-    has_many :shipping_addresses
-    accepts_nested_attributes_for :shipping_addresses
-  end
-~~~
+   ~~~ruby
+     # app/models/user.rb
+     class User < ActiveRecord::Base
+       has_many :shipping_addresses
+       accepts_nested_attributes_for :shipping_addresses
+     end
+   ~~~
 
 2. Make sure you've allowed your `params` to include the nested attributes by appropriately including them in your Strong Parameters controller method.  See the reading for examples of how to do this.
 3. Build the form in the view.  Use the `#fields_for` method to effectively create a `#form_with` inside your existing `#form_with` form.


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The [numbered list](https://www.theodinproject.com/lessons/ruby-on-rails-advanced-forms#accepts_nested_attributes_for) in the Nested Forms section is currently broken.

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/87665329/210016831-0a13c446-431c-4226-acb9-0edcfaa49d18.png)
[Lesson Preview](https://www.theodinproject.com/lessons/preview?uuid=896a0e4f-c6c8-46c7-aef2-c6f81fd8b613)

</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/87665329/210016847-f8b92c86-1599-4f29-ac9f-2bd32f532f9e.png)
[Lesson Preview](https://www.theodinproject.com/lessons/preview?uuid=c36d899d-322d-47c0-8f81-f0ff1306c47e)

</details>

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Indents the embedded Ruby code, as recommended in the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md#nest-codeblocks-within-lists).
- Removes the _span_ element that was interfering with the parsing of the first _li_ element.
- Adds the anchor tag using a block inline attribute list ([block IAL](https://kramdown.gettalong.org/syntax.html#block-ials)) supported by kramdown. This attaches the anchor tag directly to the _li_ element instead of to a _span_ element.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
This fix uses a block IAL from kramdown, which is not supported by GitHub's Markdown parsing engine. Thus, the _preview_ function on GitHub can't be relied on to see the final effect, and the Lesson Preview tool must be used instead. If this isn't a satisfactory compromise, the block IAL could be replaced by a _span_ element nested inside the list element (instead of outside it as was previously the case). Example: [Lesson Preview](https://www.theodinproject.com/lessons/preview?uuid=f5a00936-dcfb-4b7b-90c4-5434f132c552)

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
