### PR TITLE
Project: Sign-up Form: Fixed grammatical mistakes

### DIFF
--- a/intermediate_html_css/forms/project_sign_up_form.md
+++ b/intermediate_html_css/forms/project_sign_up_form.md
@@ -13,13 +13,13 @@ This project is intended to give you a chance to flex some of the new items you'
 
 #### Step 2: Gather Assets
 
-1. The design has a large background-image, so go find and download an image you want to use for that section. The one in the design can be found [on unsplash.com](https://unsplash.com/photos/25xggax4bSA), but feel free to select your own. Be sure to credit the creator of your image!
+1. The design has a large background-image, so go find and download an image you want to use for that section. The one in the design can be found on [unsplash.com](https://unsplash.com/photos/25xggax4bSA), but feel free to select your own. Be sure to credit the creator of your image!
 2. Pick an external font for the 'logo' section. We've used [Norse Bold](https://cdn.statically.io/gh/TheOdinProject/theodinproject/efdc2888072f409e687d31dc580595dbe4fe0ff4/app/assets/fonts/Norse-Bold.otf), but you can use any font you like.
 3. For the image-sidebar, we've used [this Odin logo](https://cdn.statically.io/gh/TheOdinProject/curriculum/5f37d43908ef92499e95a9b90fc3cc291a95014c/html_css/project-sign-up-form/odin-lined.png). Again, feel free to replace it.
 
 #### Step 3: Some Tips!
 
-1. How you attack this project is mostly up to you, but it is wise to begin by scaffolding out the structure of the page, and then take the various sections one by one.
+1. How you attack this project is mostly up to you, but it is wise to begin by scaffolding out the structure of the page, and then tackle the various sections one by one.
 2. The area behind the "ODIN" logo is a div that has a dark, but semi-transparent background color. This enhances the readability of the text against the busy background image.
 3. The color we've chosen for the 'Create Account' button is similar to tones found in the background image. Specifically, it is `#596D48`.
 4. The inputs, by default have a very light border (`#E5E7EB`), but we've included 2 variations. For starters, the password inputs should be given an `error` class.


### PR DESCRIPTION
## Because
Line 16: Link text should be 'unsplash.com' instead of 'on unsplash.com' since unsplash.com is the website
Line 22: Either 'and then take on' or 'and then tackle' would sound better than 'and then take'

## This PR
* Edited line 16: Changed link text from 'on unsplash.com' to 'unsplash.com'.
* Edited line 22: Changed 'and then take' to 'and then tackle'.


## Issue
NIL

## Additional Information
NIL


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
