### PR TITLE
Advanced Ruby: Pattern Matching: Correct pattern matching statement return values

### DIFF
--- a/ruby/advanced_ruby/pattern_matching.md
+++ b/ruby/advanced_ruby/pattern_matching.md
@@ -95,7 +95,28 @@ When we say "pattern", we aren't talking about design patterns which you may hav
 
 ### Return Values
 
-There are two possible return values from a pattern match statement. The first is `true`, which is returned whenever there is a match, even when the match is the else clause in a statement. The second possible return value is a `NoMatchingPatternError` whenever no match can be found. In our examples below, when we `puts` something inside a case statement, we'll use `# =>` to show the value that will be printed by this. In your terminal, though, you'll see the value printed followed by `=> true` below. We'll omit that because it's not relevant to what we're trying to show you. Just be aware that the `true` you see is just the return value of the last thing evaluated. Standard Ruby behaviour.
+There are two possible outcomes for a pattern match statement - either there is a match or there is no match. If there is a match, it will return the last evaluated value in the body of the matching branch. 
+If there are no matches, the pattern matching statement will return `NoMatchingPatternError`.
+Consider the following example, where the variable `result` is assigned the value 3.
+
+~~~ruby
+grade = 'C'
+
+result = case grade
+  in 'A' then 1
+  in 'B' then 2
+  in 'C' then 3
+  else 0
+end
+
+puts result
+#=> 3
+~~~
+
+When we `puts` something inside a case statement, we'll use `#=>` to show what `puts` will print. 
+In your terminal, however, you'll see the value printed followed by `=> nil`, since `puts` returns `nil`. 
+We'll omit that because it's not relevant to what we're trying to show you. 
+Just be aware that the `nil` you see is just the return value of `puts`. Standard Ruby behaviour.
 
 As you'll see, though, the point of a pattern match usually is to not only match against a pattern, but also bind all or part of the match to one or more variables that you can then use outside of the pattern match expression.
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
The original paragraph, as described in the issue, has outdated information about pattern matching statements only returning true or `NoMatchingPatternError`. I corrected the description about there being only two possible return values. Instead, I state there's two possible outcomes, with the first outcome returning the last evaluated value in the matched branch and the second being the NoMatchingPatternError. 
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
Revises the **Return Values** section to reflect new (albeit not _that_ new) information.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #24586 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
I'm not sure if "outcome" is the best possible way to distinguish the two cases, but I think it gets the point across.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
