### PR TITLE
Foundations: Added iframe sandbox options

### DIFF
--- a/foundations/html_css/flexbox/flexbox-alignment.md
+++ b/foundations/html_css/flexbox/flexbox-alignment.md
@@ -37,11 +37,11 @@ Because `justify-content` and `align-items` are based on the main and cross axis
 
 Check out this Scrim for an interactive demo of how `justify-content` and its different properties behave:
 
-<iframe src="https://scrimba.com/learn/flexbox/justify-content-flexbox-tutorial-cVWPacR?embed=odin,mini-header,no-big-play,no-next-up" width="100%" height="400"></iframe>
+<iframe src="https://scrimba.com/learn/flexbox/justify-content-flexbox-tutorial-cVWPacR?embed=odin,mini-header,no-big-play,no-next-up" sandbox="allow-scripts allow-same-origin" width="100%" height="400"></iframe>
 
 This next Scrim covers the behavior of `align-items`, how to perfectly center an element on a page using flexbox and much more:
 
-<iframe src="https://scrimba.com/learn/flexbox/align-items-flexbox-tutorial-cJqymH9?embed=odin,mini-header,no-big-play,no-next-up" width="100%" height="400"></iframe>
+<iframe src="https://scrimba.com/learn/flexbox/align-items-flexbox-tutorial-cJqymH9?embed=odin,mini-header,no-big-play,no-next-up" sandbox="allow-scripts allow-same-origin" width="100%" height="400"></iframe>
 
 
 #### Gap

--- a/foundations/html_css/flexbox/flexbox-axes.md
+++ b/foundations/html_css/flexbox/flexbox-axes.md
@@ -47,7 +47,7 @@ We've strayed from the point slightly... We were talking about flex-direction an
 
 For an interactive demo of how axes work with flexbox, check out this Scrim:
 
-<iframe src="https://scrimba.com/learn/flexbox/main-axis-and-cross-axis-flexbox-tutorial-cz94MT8?embed=odin,mini-header,no-big-play,no-next-up" width="100%" height="400"></iframe>
+<iframe src="https://scrimba.com/learn/flexbox/main-axis-and-cross-axis-flexbox-tutorial-cz94MT8?embed=odin,mini-header,no-big-play,no-next-up" sandbox="allow-scripts allow-same-origin" width="100%" height="400"></iframe>
 
 ### Knowledge Check
 

--- a/foundations/html_css/flexbox/flexbox-growing-and-shrinking.md
+++ b/foundations/html_css/flexbox/flexbox-growing-and-shrinking.md
@@ -26,7 +26,7 @@ Very often you see the flex shorthand defined with only _one_ value. In that cas
 
 For an interactive explanation and demo of the flex shorthand, check out this Scrim:
 
-<iframe src="https://scrimba.com/learn/flexbox/the-flex-property-flexbox-tutorial-cGNKJTv?embed=odin,mini-header,no-big-play,no-next-up" width="100%" height="400"></iframe>
+<iframe src="https://scrimba.com/learn/flexbox/the-flex-property-flexbox-tutorial-cGNKJTv?embed=odin,mini-header,no-big-play,no-next-up" sandbox="allow-scripts allow-same-origin" width="100%" height="400"></iframe>
 
 
 #### Flex-Grow
@@ -89,7 +89,7 @@ It _is_ possible to get fancy, and set up layouts where some columns relate to e
 
 4. Watch this interactive Scrim for an alternative explanation and demo of using flex-grow, flex-shrink and flex-basis in a real world scenario:
 
-<iframe src="https://scrimba.com/learn/flexbox/flex-grow-shrink-basis-flexbox-tutorial-ck6L7fv?embed=odin,mini-header,no-big-play,no-next-up" width="100%" height="400"></iframe>
+<iframe src="https://scrimba.com/learn/flexbox/flex-grow-shrink-basis-flexbox-tutorial-ck6L7fv?embed=odin,mini-header,no-big-play,no-next-up" sandbox="allow-scripts allow-same-origin" width="100%" height="400"></iframe>
 
 </div>
 

--- a/foundations/html_css/flexbox/flexbox-intro.md
+++ b/foundations/html_css/flexbox/flexbox-intro.md
@@ -48,7 +48,7 @@ If it's hard to see what's going on in the small embedded CodePen, feel free to 
 
 For a more interactive explanation and example, try the following Scrim (let us know what you think of these):
 
-<iframe src="https://scrimba.com/learn/flexbox/your-first-flexbox-layout-flexbox-tutorial-canLGCw?embed=odin,mini-header,no-big-play,no-next-up" width="100%" height="400"></iframe>
+<iframe src="https://scrimba.com/learn/flexbox/your-first-flexbox-layout-flexbox-tutorial-canLGCw?embed=odin,mini-header,no-big-play,no-next-up" sandbox="allow-scripts allow-same-origin" width="100%" height="400"></iframe>
 
 #### Flex Containers and Flex Items
 

--- a/foundations/tying_it_all_together/conclusion.md
+++ b/foundations/tying_it_all_together/conclusion.md
@@ -44,7 +44,7 @@ In the end, it doesn't matter which path you take. It's only important that you 
 
 ### Still Can’t Decide, Let the Spinner Settle Your Fate
 
-<iframe src="https://wheeldecide.com/e.php?c1=Ruby+on+Rails&c2=Node&col=rgy&t=The+Odin+Project+Path+Wheel&time=7" width="250" height="250" scrolling="no" frameborder="0"></iframe>
+<iframe src="https://wheeldecide.com/e.php?c1=Ruby+on+Rails&c2=Node&col=rgy&t=The+Odin+Project+Path+Wheel&time=7" sandbox="allow-scripts allow-same-origin" width="250" height="250" scrolling="no" frameborder="0"></iframe>
 
 Feel free to share the results in chat!
 


### PR DESCRIPTION
## Because
The Chromium console (assuming also all other browsers that have introduced iframe sandboxes) is full of error messages on all pages that contain iframes. 

## This PR
This whitelists the [iframe sandbox options](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox):
- allow-scripts
Lets the resource run scripts (but not create popup windows).

- allow-same-origin
If this token is not used, the resource is treated as being from a special origin that always fails the [same-origin policy](https://developer.mozilla.org/en-US/docs/Glossary/Same-origin_policy) (potentially preventing access to [data storage/cookies](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#cross-origin_data_storage_access) and some JavaScript APIs).

These options remove the error messages and allow the iframes to continue working as expected. 

Unfortunately there are still some error messages generated by Scrimba's use of iframes within their embed URL (nested iframes for TOP's purpose) without adding code to handle the new sandbox rules. But the console is a lot cleaner from this change regardless. 

## Issue
As this is a small change I haven't created an issue for this. I came across the problem while trying to troubleshoot an unrelated problem with a cookie setting on my browser. I found it hard to troubleshoot as the console was flooded with irrelevant errors. 

## Additional Information
I understand the potential security implications of doing this, for example if [Scrimba](https://scrimba.com/) or [wheeldecide.com](https://wheeldecide.com) are compromised, but as this course needs to use external resources regardless I believe it's a risk worth taking. 

In support of this perspective, there's an iframe in `/react/class_based_components.md` where iframe sandboxing is disabled completely for [codesandbox.io](https://codesandbox.io).

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
