### PR TITLE
Project micro Reddit: remove stray asterisk

### DIFF
--- a/ruby_on_rails/active_record_basics/project_micro_reddit.md
+++ b/ruby_on_rails/active_record_basics/project_micro_reddit.md
@@ -14,7 +14,7 @@ Example: You are building a blog for your startup which will have multiple autho
 
 This might look like:
 
-Note: We'll include the `:id`, `:created_at` and `:updated_at` columns but you can safely assume they're always there since Rails or the database gives them to you automatically*
+Note: We'll include the `:id`, `:created_at` and `:updated_at` columns but you can safely assume they're always there since Rails or the database gives them to you automatically
 
 * Authors
 


### PR DESCRIPTION
Remove stray asterisk that doesn't point to anything

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
- In  Project: Micro-Reddit there is a asterisk that points to nothing. After tracking it back this appears to have been caused back https://github.com/TheOdinProject/curriculum/commit/8931e443c97711da5e9311e2648d06466a1cb13d. Before that point there was an italicized note there, from which only the first asterisk got removed


## This PR
- Removes said asterisk

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
