### PR TITLE
Rails: Advanced Topics lesson: update routes command

### DIFF
--- a/ruby_on_rails/mailers_advanced_topics/advanced_topics.md
+++ b/ruby_on_rails/mailers_advanced_topics/advanced_topics.md
@@ -33,7 +33,7 @@ The routes file line for a singular resource would look like:
 
 Just note that the word "resource" is singular and so is `dashboard`.  That trips up a lot of people who make the typo of writing "resource" instead of "resources" when they really want plural resources (which are more common).
 
-The `$ rake routes` for a singular resource would only contain 6 routes (since we don't use `#index` anymore), and you would no longer see any of the `:id` portions of the routes, e.g.
+The `$ rails routes` for a singular resource would only contain 6 routes (since we don't use `#index` anymore), and you would no longer see any of the `:id` portions of the routes, e.g.
 
 ~~~bash
   edit_dashboard  GET /dashboard/edit(.:format)  dashboards#edit
@@ -60,7 +60,7 @@ Sometimes it just makes sense for one resource to be nested inside of another.  
 
 Note that the `#resources` method now takes a block which will consist of a set of routes.
 
-When you visit the URL, you'll have to specify the `:id` parameter for BOTH objects.  The `$ rake routes` for the above would include something like:
+When you visit the URL, you'll have to specify the `:id` parameter for BOTH objects.  The `$ rails routes` for the above would include something like:
 
 ~~~ruby
   course_lesson  GET  /courses/:course_id/lessons/:id(.:format)  lessons#show
@@ -68,7 +68,7 @@ When you visit the URL, you'll have to specify the `:id` parameter for BOTH obje
 
 It should also be noted that you're being taken to the controller of the deepest nested resource, and that's also the `:id` parameter which will be called simply `:id` (any parent resource parameters, as in the above, will be specifically called something like `:course_id`).
 
-View helpers are also automatically generated in a logical way (as you can see in your `$ rake routes` output).  When you use view helpers like `#course_lesson_path` you will need to specify both parameters in order, e.g. `course_lesson_path(1,3)`.
+View helpers are also automatically generated in a logical way (as you can see in your `$ rails routes` output).  When you use view helpers like `#course_lesson_path` you will need to specify both parameters in order, e.g. `course_lesson_path(1,3)`.
 
 Don't nest routes too deeply! If you're more than a layer or two deep, something should be different.  In fact, oftentimes you'll see only some of the controller actions nested -- only the ones that actually *need* the parent's ID to uniquely specify it.  For instance, you can grab a specific Lesson by knowing only its ID.  But to get all the lessons that are listed beneath a specific Course, you need the Course ID so it will have to be nested.  Same is true for creating lessons, since they will need a parent specified:
 
@@ -118,7 +118,7 @@ If you'd like to add a non-RESTful route to the whole collection of your resourc
 
 The `upcoming` route will map to the `courses#upcoming` action but will not take an `:id` parameter.
 
-If any of this seems confusing, just play around with them and run `$ rake routes` to see what is happening behind the scenes.
+If any of this seems confusing, just play around with them and run `$ rails routes` to see what is happening behind the scenes.
 
 #### Redirects and Wildcard Routes
 
@@ -133,7 +133,7 @@ You might want to provide a URL out of convenience for your user but map it dire
 
 Well, that got interesting fast.  The basic principle here is to just use the `#redirect` method to send one route to another route.  If your route is quite simple, it's a really straightforward method.  But if you want to also send the original parameters, you need to do a bit of gymnastics by capturing the parameter inside `%{here}`.  Note the single quotes around everything.
 
-In the example above, we've also renamed the route for convenience by using an alias with the `:as` parameter.  This lets us use that name in methods like the `#_path` helpers.  Again, test out your `$ rake routes` with questions.
+In the example above, we've also renamed the route for convenience by using an alias with the `:as` parameter.  This lets us use that name in methods like the `#_path` helpers.  Again, test out your `$ rails routes` with questions.
 
 ### Advanced Layouts: Nesting Layouts and Passing Information
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
The Advanced Topics lesson in the Rails course ([here's a link to the lesson](https://www.theodinproject.com/lessons/ruby-on-rails-advanced-topics)) has users run `rake routes` to view their routes. This doesn't work in Rails 7. It isn't like other rake tasks that have been aliased for `rails` to work as well (ie. `db:migrate`). This isn't handled at all through rake anymore, and users will get an error running `rake routes` in a Rails 7 project.


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Replaces all instances of `rake routes` with `rails routes`

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
