### PR TITLE
Ruby on Rails: Action Cable lesson: Fix typo in code example

### DIFF
--- a/ruby_on_rails/mailers_advanced_topics/actioncable_lesson.md
+++ b/ruby_on_rails/mailers_advanced_topics/actioncable_lesson.md
@@ -123,7 +123,7 @@ module ApplicationCable
     private
 
     def find_verified_user
-      if verified_user = env['warden'].user
+      if verified_user == env['warden'].user
         verified_user
       else
         reject_unauthorized_connection


### PR DESCRIPTION
## Because

We want a comparison, not assignment here.

## This PR

- Fixes the typo.

## Issue

nil

## Additional Information

nil

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
