### PR TITLE
Installations: ensure chrome output is hidden in the case where you run it in the background

### DIFF
--- a/foundations/installations/installations.md
+++ b/foundations/installations/installations.md
@@ -319,7 +319,7 @@ You can start chrome in two ways,
 google-chrome
 ~~~
 
-_(__note__: Chrome is going to use this terminal to output various messages and won't let you run other commands. Don't worry about those messages. If you want to use the same terminal that you run Chrome in for other commands, use `google-chrome &` instead.)_
+_(__note__: Chrome is going to use this terminal to output various messages and won't let you run other commands. Don't worry about those messages. If you want to use the same terminal that you run Chrome in for other commands, use `google-chrome &> /dev/null` instead, which will run the command in the background and hide any messages it may output.)_
 
 </details>
 


### PR DESCRIPTION
## Because
Not sure if this is too complex to introduce, but it is probably preferable over simply running the browser in the background.
If you ran chrome, or any other browser in the background, you will still see confusing logging/terminal output

## This PR
* Updates the command to run google chrome from the terminal to also hide its output, when run in the background
* Added some text explaining what the command does without explaining shell features or the meaning of `/dev/null`.

## Issue
n/a

## Additional Information
n/a

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
