### PR TITLE
grammar fix : express 101

### DIFF
--- a/nodeJS/express_and_mongoose/express_101.md
+++ b/nodeJS/express_and_mongoose/express_101.md
@@ -14,7 +14,7 @@ By the end of this lesson, you should be able to do the following:
 
 A templating engine is a tool that allows you to insert variables and simple logic into your views. For instance, you could have a header that updates with the actual user's name once they've logged in, something that is not possible with plain HTML. As the lesson mentions, there are several templating languages available for JavaScript.  The tutorial uses [Pug (formerly known as Jade)](https://pugjs.org) which has a bit of a learning curve because it looks and feels dramatically different from regular HTML. If you've ever worked with Ruby on Rails you might be more comfortable with [ejs](https://ejs.co), which is _very_ similar to `erb`.
 
-It's up to you which you choose! If you choose not to use Pug you will still be able to follow the tutorial just fine. Most of the Odin staff prefer ejs to Pug simply because we like working with HTML, but in the end, there is nothing wrong with Pug if you like the look of it or want to learn something new.
+It's up to you which you choose! If you choose not to use Pug you will still be able to follow the tutorial just fine. Most of the Odin staff prefer ejs over Pug simply because we like working with HTML, but in the end, there is nothing wrong with Pug if you like the look of it or want to learn something new.
 
 ### Middleware
 


### PR DESCRIPTION
Grammar fixed in line number 17

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
The grammar was was wrong in line number 17 instead of  " Most of the Odin staff prefer ejs to Pug simply because we like working with HTML " it should be " Most of the Odin staff prefer ejs over Pug simply because we like working with HTML "

