### PR TITLE
Html-foundations/Working with text lesson: Add missing inline code styling for em tags

### DIFF
--- a/foundations/html_css/html-foundations/working-with-text.md
+++ b/foundations/html_css/html-foundations/working-with-text.md
@@ -95,9 +95,9 @@ Sometimes you will want to make text bold without giving it an important meaning
 
 ### Em Element
 
-The em element makes text italic. It also semantically places emphasis on the text, which again may affect things like screen readers. To define an emphasised element we wrap text content in a `<em>` tag.
+The `<em>` element makes text italic. It also semantically places emphasis on the text, which again may affect things like screen readers. To define an emphasised element we wrap text content in a `<em>` tag.
 
-To use em on its own:
+To use `<em>` on its own:
 
 <p class="codepen" data-height="300" data-theme-id="dark" data-default-tab="html,result" data-slug-hash="wvewqpp" data-user="TheOdinProjectExamples" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;">
   <span>See the Pen <a href="https://codepen.io/TheOdinProjectExamples/pen/wvewqpp">
@@ -106,7 +106,7 @@ To use em on its own:
 </p>
 <script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
 
-Again, like the strong element, you will find yourself mostly using the em element with other text elements:
+Again, like the strong element, you will find yourself mostly using the `<em>` element with other text elements:
 
 <p class="codepen" data-height="300" data-theme-id="dark" data-default-tab="html,result" data-slug-hash="VwWZzyj" data-user="TheOdinProjectExamples" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;">
   <span>See the Pen <a href="https://codepen.io/TheOdinProjectExamples/pen/VwWZzyj">


### PR DESCRIPTION
## Because
Lesson on working with text did not use inline code styling when referencing em tags. PR adds correct styling for reference to em tag.

## This PR
- Replaces em with `<em>` when referencing the Em element

## Issue
N/A

## Additional Information
N/A

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
