### PR TITLE
Rails: Members Only: Update information regarding Devise/Turbo compatibility

### DIFF
--- a/ruby_on_rails/forms_and_authentication/project_members_only.md
+++ b/ruby_on_rails/forms_and_authentication/project_members_only.md
@@ -21,7 +21,7 @@ If you'd like to challenge yourself, don't even follow the steps below, just go 
 2. Create your new `members-only` Rails app and GitHub repo.  Update your README.
 3. Add devise to your Gemfile and install it in your app using set up instructions on the devise [README](https://github.com/heartcombo/devise)
 
-*note: At the time of writing, Devise and Turbo Drive don't play nicely together. When using devise with Turbo Drive you have two options. Either you can generate the devise views to your local app (covered in the devise README) and then for each view with a form disable turbo drive by adding the data attribute. This is time consuming but simple to follow. The other way is to create a custom controller to handle this and then use devise for that. [This GoRails episode](https://gorails.com/episodes/devise-hotwire-turbo) covers how you'd do that. You might not understand everything being done but it's a quicker solution. Hopefully Devise will be Rails 7 Turbo compatible by the time you read this*
+*note: For getting Devise to play nicely with Turbo Drive, be sure you read [this section](https://github.com/heartcombo/devise#hotwireturbo) of the Devise README. You’ll need to install the [Responders gem](https://github.com/heartcombo/responders). Make sure that in addition to adding the gem to your Gemfile that you also run the install generator. You’ll also need to specify delete requests on your links/buttons for signing the user out. More detailed information can be found in [Devise’s Guide for Hotwire Turbo Integration](https://github.com/heartcombo/devise/wiki/How-To:-Upgrade-to-Devise-4.9.0-%5BHotwire-Turbo-integration%5D).*
 
 #### Authentication and Posts
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
The process for getting Devise to cooperate with Turbo is much simpler now with the release of Devise 4.9


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Removes the old instructions for getting Devise to work with Hotwire Turbo
- Links learners to the relevant documentation for getting Devise to work with Turbo
- Tells learners that they'll need to install the Responders gem and specify `delete` requests for their logout buttons/links


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #25112 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
Definitely let me know if anything should be removed or added here. I know that learners often find this section pretty difficult to get through.


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
