### PR TITLE
GitHub workflows: bump actions/checkout to v3

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,7 +8,7 @@ jobs:
         name: Check for spelling errors
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - uses: codespell-project/actions-codespell@master
           with:
             check_filenames: true


### PR DESCRIPTION
## Because
We are still using the old (v2) version of https://github.com/actions/checkout, which runs on Node12. Due to Node12 having become EOL GitHub is planning to move all actions to Node16 by summer 2023 (see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/), and is already annotating every action which runs on Node12 with a warning.


## This PR
- Bumps actions/checkout to the next major version, v3, which runs on Node16 by default


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR