### PR TITLE
React Introduction: fix small factual error

### DIFF
--- a/javascript/react_js/react_introduction.md
+++ b/javascript/react_js/react_introduction.md
@@ -89,7 +89,7 @@ class App extends Component {
 }
 ~~~
 
-Secondly, we are declaring the class component, `App`. We do this by extending the React class Component, which we imported at the top of the file. In doing this, we are essentially "Reactifying" our App component by giving it all of the fun methods and properties every React component should have. One thing to notice is that React components, like all classes and factory functions, should always be declared with a capital letter at the beginning ([PascalCase](https://techterms.com/definition/pascalcase)). This is a naming convention used by most developers and recommended by the React core team at Facebook.
+Secondly, we are declaring the class component, `App`. We do this by extending the React class Component, which we imported at the top of the file. In doing this, we are essentially "Reactifying" our App component by giving it all of the fun methods and properties every React component should have. One thing to notice is that React components, like all classes and object constructors, should always be declared with a capital letter at the beginning ([PascalCase](https://techterms.com/definition/pascalcase)). This is a naming convention used by most developers and recommended by the React core team at Facebook.
 
 ~~~javascript
 constructor() {


### PR DESCRIPTION
Change line that says factory functions are declared in Pascal case to say constructors instead.

When I read that all factory functions are declared in PascalCase, I had a moment of panic thinking I'd been naming my factory functions wrong this whole time, but I confirmed by going back to an earlier Odin Project course, which did say constructors are declared in PascalCase and showed factory functions are declared in camelCase, and I read the same thing on numerous other websites.

Because:
Correcting this error would make sure others are not confused, will stick with consistent and widely used naming conventions, and will focus on the React lesson rather than wrongly worrying they've been doing something wrong. 

This PR:
- changes the line that erroneously says factory functions are all declared in PascalCase to say that all object constructors are declared in PascalCase.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
