### PR TITLE
React Testing Part 1: Add recommended use of userEvent

### DIFF
--- a/javascript/react_js/react_testing_part_one.md
+++ b/javascript/react_js/react_testing_part_one.md
@@ -129,6 +129,20 @@ The tests speak for themselves. In the first test, we utilize snapshots to check
 
 It's also important to note that after every test, React Testing Library unmounts the rendered components. That's why we render for each test. For a lot of tests for a component, the `beforeEach` jest function could prove handy.
 
+On the second test, we see that `userEvent.click()` is directly invoked from the `userEvent` import. The [recommended approach](https://testing-library.com/docs/user-event/intro/#writing-tests-with-userevent) for newer versions of the `userEvent` library is to use `userEvent.setup()`. We could rewrite the test as follows:
+  
+  
+  ~~~javascript
+  it("renders radical rhinos after button click", () => {
+    render(<App />);
+    const button = screen.getByRole("button", { name: "Click Me" });
+    const user = userEvent.setup();
+    user.click(button);
+
+    expect(screen.getByRole("heading").textContent).toMatch(/radical rhinos/i);
+  });
+  ~~~
+
 ### What are Snapshots?
 
 Snapshot testing is just comparing our rendered component with an associated snapshot file. For example, the snapshot file which was automatically generated after we ran the _"magnificent monkeys renders"_ test was:


### PR DESCRIPTION
Insert the recommended approach to use user events in testing.

I would have formatted it similar to a git diff and inside a lesson note div. I'd like to learn more how to effectively contribute

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Improve code quality by adhering to recommended practice by the library authors

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Add a rewrite of a test that involves the use of the `userEvent` library

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
None

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
None

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
