### PR TITLE
Foundations/Installations lesson: fix typo

### DIFF
--- a/foundations/installations/installations.md
+++ b/foundations/installations/installations.md
@@ -130,7 +130,7 @@ In the window that just came up you want to click on **Manage Groups**, click so
 
 #### Step 3.2: Add Yourself to sudo
 
-With `sudo` selected, click **Preferences** and in the window that shows up tick your user's name like this:
+With `sudo` selected, click **Properties** and in the window that shows up tick your user's name like this:
 
    ![No need to touch anything else.](https://cdn.statically.io/gh/TheOdinProject/curriculum/96d534641514fe4d62aabe2919fac3c52cb286e7/foundations/installations/installations/imgs/13_sudo_properties.png)
 


### PR DESCRIPTION
## Because
Typo in VM OS installation instructions - says to click a button with the wrong name

## This PR
- changed "Preferences" to "Properties"

## Issue
Closes #XXXXX

## Additional Information

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
