### PR TITLE
Foundations: Installations: Clarify wording in VM instructions so users don't enable EFI

### DIFF
--- a/foundations/installations/installations.md
+++ b/foundations/installations/installations.md
@@ -86,7 +86,7 @@ For example, if you have 8 GB (8192 MB respectively) of RAM, you could allocate 
 
 _(__note:__ Difficulty converting your **G**iga**B**ytes into **M**ega**B**ytes? 1 GB of RAM is equal to 1024 MB. Therefore, you can say that **8 GB = 8 x 1024 = 8192 MB.**)_
 
-As for **Processors** you want this to be at 2 and no more. Leave **Enable EFI (special OSes only)** as it is and click **Next** to continue.
+As for **Processors** you want this to be at 2 and no more. Leave **Enable EFI (special OSes only)** as it is - that is **unchecked** - and click **Next** to continue.
 
 #### Step 2.2.3: Virtual Hard Disk
 


### PR DESCRIPTION
## Because
Somewhat often users misconfigure their VMs and can't proceed with the instructions due to enabling EFI.


## This PR
Attempts to clarify the wording so this does not happen.


## Issue

nil

## Additional Information
[Example outcome of having it enabled on Discord](https://discord.com/channels/505093832157691914/690588860085960734/1078717694649585714)
![image attached to the Discord message mentioned](https://user-images.githubusercontent.com/95084627/221243534-a1b55e1d-5b23-4c9d-a0ab-0d5982e80327.png)

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
