### PR TITLE
Issue #25146 : replaced methods with names of methods

### DIFF
--- a/ruby/advanced_ruby/blocks.md
+++ b/ruby/advanced_ruby/blocks.md
@@ -453,7 +453,7 @@ arr.map(&:to_i)
 
 What happens under the hood is that `#to_proc` is called on the symbol `:to_i`. You can see what it does in the [ruby docs](https://ruby-doc.org/core-3.1.2/Symbol.html#method-i-to_proc). It returns a proc object which responds to the given method indicated by the symbol. So here, `#map` yields each value in the array to the proc object, which calls `#to_i` on it.
 
-(Yes, methods like `#to_i` can be passed around using symbols. It's outside the scope of this lesson, but check out the [documentation](https://ruby-doc.org/core-3.1.2/Object.html#method-i-send) for `#send` if you're interested. And this Stack Overflow [article](https://stackoverflow.com/questions/14881125/what-does-to-proc-method-mean) on how `#send` and `#to_i` are used together for `arr.map(&:to_i)` to work.)
+(Yes, names of methods like `#to_i` can be passed around using symbols. It's outside the scope of this lesson, but check out the [documentation](https://ruby-doc.org/core-3.1.2/Object.html#method-i-send) for `#send` if you're interested. And this Stack Overflow [article](https://stackoverflow.com/questions/14881125/what-does-to-proc-method-mean) on how `#send` and `#to_i` are used together for `arr.map(&:to_i)` to work.)
 
 <span id="proc-to-block">The `&` also works the other way. You can prepend it to a proc object and it converts it to a block, and passes the block to the method being called.</span>
 


### PR DESCRIPTION
## Because
Passing around a method, brings to mind something like a Proc object (or reference to a Proc object) somewhere that we pass around.

## This PR
* Rephrases "methods" to "names of methods" for this specific paragraph.

## Issue
Closes #25146

## Additional Information

## Pull Request Requirements

