### PR TITLE
Etch-a-Sketch in Javascript Basics: remove mention of grid from instructions

### DIFF
--- a/foundations/javascript_basics/project_etch_a_sketch.md
+++ b/foundations/javascript_basics/project_etch_a_sketch.md
@@ -16,7 +16,7 @@ Don't forget to commit early & often! You can [reference the Commit Message less
 2.  Create a webpage with a 16x16 grid of square divs.
     *   Create the divs using JavaScript. Don't try making them by hand with copy and pasting in your HTML file!
     *   It's best to put your grid squares inside another "container" div \(which can go directly in your HTML\).
-    *   You need make the divs appear as a grid \(versus just one on each line\). This is a perfect opportunity to apply what you have earlier learned about flexbox.
+    *   You need make the divs appear as a grid \(versus just one on each line\). This is a perfect opportunity to apply what you have learned about flexbox.
     *   Be careful with borders and margins, as they can adjust the size of the squares!
     *   "OMG, why isn't my grid being created???"
         *   Did you link your CSS stylesheet?

--- a/foundations/javascript_basics/project_etch_a_sketch.md
+++ b/foundations/javascript_basics/project_etch_a_sketch.md
@@ -16,11 +16,7 @@ Don't forget to commit early & often! You can [reference the Commit Message less
 2.  Create a webpage with a 16x16 grid of square divs.
     *   Create the divs using JavaScript. Don't try making them by hand with copy and pasting in your HTML file!
     *   It's best to put your grid squares inside another "container" div \(which can go directly in your HTML\).
-    *   There are several different ways to make the divs appear as a grid \(versus just one on each line\). Feel free to use any or play with each of them:
-        *   float/clear
-        *   inline-block
-        *   flexbox
-        *   CSS Grid
+    *   You need make the divs appear as a grid \(versus just one on each line\). This is a perfect opportunity to apply what you have earlier learned about flexbox.
     *   Be careful with borders and margins, as they can adjust the size of the squares!
     *   "OMG, why isn't my grid being created???"
         *   Did you link your CSS stylesheet?


### PR DESCRIPTION
Remove mention of CSS grid, float/clear & inline-block. Encourage use of flexbox instead.


## Because
Many learners have been confused and lead to rabbit holes by the mention of these options that have not yet been taught at this point. This removal allows the learner to focus on the basic functionality of Etch-a-Sketch, instead of trying to learn a whole new concept out of sync, while possibly struggling with the JS side of things.  CSS Grid is covered in full later. Float/clear and inline-block are sub-optimal  approaches to the problem the learner is facing.

Removing these extra suggestions should lead to a more streamlined learning process and less confusion. 


## This PR

- removes bullet points mentioning CSS grid, float/clear & inline-block as possible ways to create a grid for Etch-a-Sketch. 
- adds a mention that applying previously learned flexbox skills is ideal for the task


## Issue

Closes [#24609](https://github.com/TheOdinProject/curriculum/issues/24609)

## Additional Information



## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [ x ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [ x ] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [ x ] The `Because` section summarizes the reason for this PR
-   [ x ] The `This PR` section has a bullet point list describing the changes in this PR
-   [ x ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ x ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ x ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
