### PR TITLE
Feature: Move Backend Lessons From Foundations to Rails and Node Courses

### DIFF
--- a/shared/README.md
+++ b/shared/README.md
@@ -1,0 +1,1 @@
+Lessons shared between our paths.

--- a/shared/the_back_end/introduction_to_frameworks.md
+++ b/shared/the_back_end/introduction_to_frameworks.md
@@ -6,15 +6,12 @@ In addition to preventing repetition, frameworks provide great organization.  Th
 
 There are often several different popular frameworks for a given language.  They can have exciting names like [Ember](http://emberjs.com/), [Meteor](http://www.meteor.com/), [Django](https://www.djangoproject.com/), [Rails](http://rubyonrails.org/), [Grok](http://grok.zope.org/), etc.  Wikipedia has a [comprehensive comparison of frameworks](http://en.wikipedia.org/wiki/Comparison_of_web_application_frameworks) that should give you an appreciation of the number of them.  For Ruby alone, though Rails is the most popular, there are also [Sinatra](http://www.sinatrarb.com/) and [Padrino](http://www.padrinorb.com/) and more.
 
-A final thing to note is about licensing -- frameworks are typically (though not always) open-source and their license allows you to use them, modify them, make money off them, sell products with them, etc., all without owing any fees to their original creators.  You may not think too much about that as you blithely code away using other people's frameworks, but it's a very important distinction between open-source frameworks and commercially produced/sold software.  We'll get more into [Open Source Software (OSS)](https://en.wikipedia.org/wiki/Open-source_software) in later units.
-
 ### Lesson Overview
 
 This section contains a general overview of topics that you will learn in this lesson.
 
 *   What is a framework?
 *   What's the difference between a programming language and a framework?
-*   What languages have frameworks?
 
 ### Assignment
 
@@ -37,4 +34,4 @@ This section contains questions for you to check your understanding of this less
 
 This section contains helpful links to related content. It isn’t required, so consider it supplemental.
 
-*   [StackOverflow: What is a Web Framework? How does it compare with LAMP?](http://stackoverflow.com/questions/4507506/what-is-a-web-framework-how-does-it-compare-with-lamp)
+*   It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.

--- a/shared/the_back_end/introduction_to_the_backend_lesson.md
+++ b/shared/the_back_end/introduction_to_the_backend_lesson.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-The "frontend" denotes the interface that a web user interacts with - what they see (and hear) when using the web. The three languages of the frontend are fairly standardized: HTML for markup, CSS for presentation, and JavaScript for scripting. 
+The "frontend" denotes the interface that a web user interacts with - what they see (and hear) when using the web. The three languages of the frontend are fairly standardized: HTML for markup, CSS for presentation, and JavaScript for scripting.
 
 The "backend", meanwhile, denotes all that goes on "behind the scenes" on web servers to make the user experience possible. In contrast to front-end development, you can run pretty much any language you want to on your server since it doesn't rely on your user's browser understanding what's going on.  All the browser cares about is whether you've sent it properly formatted HTML, CSS and JavaScript files (and other assets like images).  That's led to a whole lot of different choices for back-end languages.  As long as it can take in an HTTP request and spit out some HTML, you can probably put it on a server somehow.
 
@@ -8,14 +8,11 @@ That said, some languages are more popular and practical than others.  If you're
 
 Some of the most popular server-side languages are PHP, C#, Ruby, Python and Java (not to be confused with JavaScript). Just as we can say "Which way to the nearest pub?" in Swedish, French, Italian, English, and Bad English, so too can all of those languages perform almost exactly the same functions, just using different syntax.
 
-As we covered back in the [Installations section](https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/installation-overview), the front-end languages live in the browser so there are no extra installations required.  For the reasons listed above, the back-end languages do require you to install them on your computer in order to get them running. NodeJS has already been installed as it is required in the JavaScript section of Foundations. Ruby and Rails are installed in their own respective sections as they aren't required until then.
-
 ### Lesson Overview
 
 This section contains a general overview of topics that you will learn in this lesson.
 
 *   What is the difference between front-end and back-end development?
-*   Why are we required to install back-end languages on our computer (besides to run them)?
 
 ### Assignment
 
@@ -23,7 +20,7 @@ This section contains a general overview of topics that you will learn in this l
 
   1.  Check out [this blog post on backend vs frontend programming](http://blog.teamtreehouse.com/i-dont-speak-your-language-frontend-vs-backend) for a quick refresher on the difference between the two.
   2.  [A good and short overview of the backend](https://techterms.com/definition/backend).
-  3.  [A much more detailed and thorough explanation](https://www.codecademy.com/articles/back-end-architecture) of the various aspects of the backend is provided by Codecademy, including a step-by-step breakdown of what happens in the backend when a browser makes a request to a server.  
+  3.  [A much more detailed and thorough explanation](https://www.codecademy.com/articles/back-end-architecture) of the various aspects of the backend is provided by Codecademy, including a step-by-step breakdown of what happens in the backend when a browser makes a request to a server.
 
 </div>
 
@@ -39,5 +36,5 @@ This section contains questions for you to check your understanding of this less
 ### Additional Resources
 
 This section contains helpful links to related content. It isn’t required, so consider it supplemental.
- 
+
 *   It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.


### PR DESCRIPTION
Because:
* We introduce the backend at the end of foundations, well before that information is relevant. By the time learners get to the backend courses in each path, this information will no longer be fresh in their heads.

This commit:
* Create a new shared directory for lessons that have the same content but are in different courses in each path.
* Move the backend section from foundations to the shared directory.
* Remove paragraph about licenses from the frameworks lesson - we don't recommend any frameworks that aren't open source.
* Remove paragraph about needing to install backend languages - by this point learners will have installed Ruby or Node.js depending on their path.
