### PR TITLE
Skip extra section in form-validation article

### DIFF
--- a/intermediate_html_css/forms/form_validations.md
+++ b/intermediate_html_css/forms/form_validations.md
@@ -188,7 +188,7 @@ It's also worth noting client-side validations are not a silver bullet for ensur
 1. Read and follow along to [MDN's Client-Side Form Validation Guide](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation)
     * Skip the section on "Validating forms using JavaScript". This will be covered in a future lesson. 
 
-2. Go through SitePoint's [Complete Guide to HTML Forms and Constraint Validation Guide](https://www.sitepoint.com/html-forms-constraint-validation-complete-guide/). You can skip the section on "JavaScript and the Constraint Validation API".
+2. Go through SitePoint's [Complete Guide to HTML Forms and Constraint Validation Guide](https://www.sitepoint.com/html-forms-constraint-validation-complete-guide/). You can skip the section on "JavaScript and the Constraint Validation API" and "Creating a Custom Form Validator".
 
 3. Read Silo Creative's article [Improving UX in forms](https://www.silocreativo.com/en/css-rescue-improving-ux-forms/).
 


### PR DESCRIPTION
closes #25082

this section of that article is heavy on the JS and should be skipped for now.