### PR TITLE
Problem Solving: Addition of Fizzbuzz Leetcode page in the optional content section

### DIFF
--- a/foundations/javascript_basics/problem_solving.md
+++ b/foundations/javascript_basics/problem_solving.md
@@ -245,6 +245,7 @@ This section contains helpful links to other content. It isn't required, so cons
 
 *   Read the first chapter in [Think Like a Programmer: An Introduction to Creative Problem Solving](https://nostarch.com/thinklikeaprogrammer) (*not free*). This book's examples are in C++, but you will understand everything since the main idea of the book is to teach programmers to better solve problems. It's an amazing book and worth every penny. It will make you a better programmer.
 *   Watch this [video on repetitive programming techniques](https://ocw.mit.edu/courses/res-tll-004-stem-concept-videos-fall-2013/resources/basic-programming-techniques/).
+*   Solve the FizzBuzz problem on [Leetcode](https://leetcode.com/problems/fizz-buzz/).
 
 ### Knowledge Check
 


### PR DESCRIPTION
## Because
I had seen this problem on Leetcode a few days before going through this lesson myself. Although Leetcode as a tool might be too advanced for learners at this stage of their journey (it is for me), I did get a sense of accomplishment completing the problem.


## This PR

- Added additional content (Leetcode link to the Fizzbuzz problem).


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX
N/A

## Additional Information
N/A

## Pull Request Requirements
-   [X] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [X] The `Because` section summarizes the reason for this PR
-   [X] The `This PR` section has a bullet point list describing the changes in this PR
-   [N/A] If this PR addresses an open issue, it is linked in the `Issue` section
-   [N/A] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [N/A] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
