### PR TITLE
Fix syntax error in passport.use

### DIFF
--- a/nodeJS/authentication/authentication_basics.md
+++ b/nodeJS/authentication/authentication_basics.md
@@ -169,7 +169,7 @@ passport.use(
     } catch(err) {
       return done(err);
     };
-  });
+  })
 );
 ~~~
 


### PR DESCRIPTION
The original code contained an extra semicolon at the end of the authentication callback function passed to passport.use(). This resulted in a syntax error that prevented the code from executing properly. This commit removes the unnecessary semicolon.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
Passport.use function has syntax error. 


## This PR
This PR removes the unnecessary semicolon, allowing the code to run without error and ensuring that the authentication logic works correctly.


## Issue
<!--
-->
There are no related issues or pull requests for this commit.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
