### PR TITLE
Ruby OOP: Remove codecademy resource

### DIFF
--- a/ruby/object_oriented_programming_basics/object_oriented_programming.md
+++ b/ruby/object_oriented_programming_basics/object_oriented_programming.md
@@ -2,42 +2,34 @@
 
 You've got the building blocks of Ruby out of the way, great! Now it's time to get into the fun stuff... how do we combine those building blocks in the most efficient and elegant ways to produce the programs we'd like to write?
 
-The concepts you'll learn here are often less specific to Ruby itself and more widely applicable to any object-oriented language.  That's because the fundamental concepts are just that... fundamental.  Don't repeat yourself.  Modularize your code.  Have your classes and methods only do one thing.  Show as little of your interfaces to the world as you can.  Don't make methods or classes heavily dependent on each other.  Be lazy.  These will take some time and practice to implement effectively, but you'll already be taking a big step towards creating high quality code just by finishing up this section.
+The concepts you'll learn here are often less specific to Ruby itself and more widely applicable to any object-oriented language. That's because the fundamental concepts are just that... fundamental. Don't repeat yourself. Modularize your code. Have your classes and methods only do one thing. Show as little of your interfaces to the world as you can. Don't make methods or classes heavily dependent on each other. These will take some time and practice to implement effectively, but you'll already be taking a big step towards creating high quality code just by finishing up this section.
 
-There's a lot to do here but stick with it!  We'll start with the Codecademy lessons, which are interspersed with their projects so you'll get a chance to apply what you're learning.  The Launch School's OOP book will help you understand the material a bit deeper, which will be important when you start creating your own projects.
+There are two projects in this Object Oriented Programming Basics section, but this does not mean that you will only use OOP for these two projects. Ruby is a object-oriented language, so it is important to use OOP for all of the remaining projects.
 
+There is a lot of reading in this lesson, so you are encouraged to code along with each example. If you find an example that does not make sense, ask for help in the `#ruby-help` channel in our [Discord](https://discord.gg/fbFCkYabZB) server. To get the most out of each example, try to apply what you learned by adding similar functionality on your own.
 
 ### Learning Outcomes
 
 - You will learn about classes.
-- You will learn about Methods.
+- You will learn about methods.
 - You will learn about scope.
 
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">
 
-  1. Do [Codecademy Ruby sections 9 and 10](https://www.codecademy.com/learn/learn-ruby):
-      1. Object-Oriented Programming, Part I
-      2. Project: Virtual Computer
-      3. Object-Oriented Programming, Part II
-      4. Project: Banking on Ruby
-  2. Take a brief break from code and learn more about the world of Ruby:
-      1. Read about the [History of Ruby](https://www.sitepoint.com/history-ruby/)
-      2. Read about [Open Source Culture](https://opensource.guide/how-to-contribute/#why-contribute-to-open-source) in Section 1
-      3. Read about where you can find [Ruby's Community](https://www.ruby-lang.org/en/community/)
-  3. Read through [Launch School's OOP book](https://launchschool.com/books/oo_ruby/read/introduction) for a more thorough understanding.
-  4. Read through these reinforcing posts by Erik Trautman to help you answer the questions in the "Learning Outcomes" section:
-      1. [Ruby Explained: Classes](http://www.eriktrautman.com/posts/ruby-explained-classes)
-      2. [Ruby Explained: Inheritance and Scope](http://www.eriktrautman.com/posts/ruby-explained-inheritance-and-scope)
-  5. Read the article [Object Relationships in Basic Ruby](https://medium.com/@marcellamaki/object-relationships-in-basic-ruby-1af5773fff48) to see an example of how two classes can interact.
-  6. Read the [Bastard's Chapter on Error Handling](http://ruby.bastardsbook.com/chapters/exception-handling/) to reinforce your understanding of dealing with errors.
-  7. Do [Quiz #5](http://www.codequizzes.com/ruby/beginner/intro-object-oriented-programming) from [Code Quizzes](http://www.codequizzes.com).
-  8. Do [Quiz #7](http://www.codequizzes.com/ruby/beginner/modules-classes-inheritance) as well.
-  9. Glance over the [Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide) so you have an idea of how to make your code look more professional. It is recommended to install [rubocop](https://docs.rubocop.org/rubocop/installation.html), a static code analyzer (linter) and formatter, which is based on this style guide. 
-      1. Read the [basic usage](https://docs.rubocop.org/rubocop/usage/basic_usage.html) of rubocop in the terminal. 
-      2. To highlight the rubocop offenses in VSCode, you will need to have the 'Ruby' extension installed. In addition, you will need to update your settings.json file with the following lines:
-
+1. Read the [Object Oriented Programming with Ruby](https://launchschool.com/books/oo_ruby) online book, by Launch School.
+1. Read through these reinforcing posts by Erik Trautman to help you answer the questions in the "Learning Outcomes" section:
+    * [Ruby Explained: Classes](http://www.eriktrautman.com/posts/ruby-explained-classes)
+    * [Ruby Explained: Inheritance and Scope](http://www.eriktrautman.com/posts/ruby-explained-inheritance-and-scope)
+1. Read the article [Object Relationships in Basic Ruby](https://medium.com/@marcellamaki/object-relationships-in-basic-ruby-1af5773fff48) to see an example of how two classes can interact.
+1. Read the [Bastard's Chapter on Error Handling](http://ruby.bastardsbook.com/chapters/exception-handling/) to reinforce your understanding of dealing with errors.
+1. Do [Quiz #5](http://www.codequizzes.com/ruby/beginner/intro-object-oriented-programming) and [Quiz #7](http://www.codequizzes.com/ruby/beginner/modules-classes-inheritance) from Code Quizzes
+1. Every programming language community develops a style guide to help make code more maintainable and easier to read, therefore it is important to familiarize yourself with the [Ruby Style Guide](https://rubystyle.guide/).
+    * As you can see, there are a lot of guidelines. Instead of trying to remember everything, install [rubocop](https://docs.rubocop.org/rubocop/installation.html), a static code analyzer (linter) and formatter, which is based on this style guide.
+    * When it suggests a change that you don't understand, you can refer to this style guide to understand the reasons behind the rule. You will be inundated with offenses that seem minor, but we encourage you to make the recommended adjustments and trust the wisdom of the Ruby community that developed this style guide. If you feel strongly that you should ignore a particular rule, you can research ways to disable a particular rule or even ignore an entire file.
+    * Read the [basic usage](https://docs.rubocop.org/rubocop/usage/basic_usage.html) of rubocop in the terminal.
+    * To highlight the rubocop offenses in VSCode, you will need to have the 'Ruby' extension installed. In addition, you will need to update your settings.json file with the following lines:
 
 ~~~bash
 "ruby.lint": {
@@ -47,20 +39,17 @@ There's a lot to do here but stick with it!  We'll start with the Codecademy les
 
 **If the above instructions do not work**, explore the initial configuration options in the extension's [documentation](https://marketplace.visualstudio.com/items?itemName=rebornix.Ruby). Another alternative is to try the [ruby-rubocop](https://marketplace.visualstudio.com/items?itemName=misogi.ruby-rubocop) extension, but be aware of the potential problems listed in their documentation.
 
-As you begin to use rubocop, you will be inundated with multiple offenses that seem minor. At this point in your Ruby knowledge, make the recommended adjustments and trust the wisdom of the Ruby community that developed this style guide. Research the offenses that you do not understand. If you feel strongly that you should ignore a particular rule, you can research ways to disable a particular rule or even ignore an entire file.
-
 </div>
 
 ### Additional Resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
 * [This video presentation from Kevin Berridge](http://vimeo.com/91672848) covers major themes of practical object-oriented design, with many references to Sandi Metz's book, in about 40 minutes.
-* [Zetcode's Variables section](http://zetcode.com/lang/rubytutorial/variables/).
-* Now you're ready to read through [Zetcode's OOP section](http://zetcode.com/lang/rubytutorial/oop/).
-* Read through [Zetcode's second OOP section](http://zetcode.com/lang/rubytutorial/oop2/) until they start talking about exceptions (~80% of the way down).
-* Both of the below books are paid and optional, and not everyone agrees on exactly when you should read them. However, it **is** agreed that the resources are extremely valuable, therefore some guidelines have been set as to when you should attempt to (optionally) read them:
-  * Once you have gotten a few OOP projects completed (Tic-Tac-Toe, Mastermind, Hangman, and Custom Enumerables at minimum) you should be ready to read [99 Bottles of OOP](https://sandimetz.com/99bottles), by Sandi Metz, to start learning how to refactor your code in a more OOP way.
-  * Once you feel comfortable after learning to refactor existing code with 99 Bottles, the next logical step would be learning [Practical Object-Oriented Design in Ruby](https://www.poodr.com/), also by Sandi Metz.
+* If you need a variable refresher, check out [Zetcode's Variables section](https://zetcode.com/lang/rubytutorial/variables/).
+* If you want more examples to code along with, check out [Zetcode's OOP section](http://zetcode.com/lang/rubytutorial/oop/) and [Zetcode's second OOP section](https://zetcode.com/lang/rubytutorial/oop/) until they start talking about exceptions (~80% of the way down).
+* After you have completed several OOP projects, the following books by Sandi Metz are essential to build on the foundational concepts in this lesson.
+    * [99 Bottles of OOP](https://sandimetz.com/99bottles) is a hands-on workbook that you should code along with to get the most out of it. This is a great resource if you feel uncertain about OOP concepts and would like to guided through refactoring examples and explanations.
+    * [Practical Object-Oriented Design in Ruby](https://www.poodr.com/) is a traditional technical book with practical examples. This is a great resource after 99 Bottles or if you already feel like you fully understand OOP concepts.
 
 ### Knowledge Check
 


### PR DESCRIPTION
## Because
The exercises in the lesson were recently moved behind the paywall, so learners have to sign up for a free trial to be able to complete


## This PR
* Removes codecademy resource
* Removes links to learn about history, open source contributions and the ruby community.
* Updates lesson intro to include coding along with examples, since they got that experience at codecademy
* Clarifies that all projects should be done in OOP
* Combines some bullets points into one
* Rewords recommendation for Sandi Metz books


## Issue


## Additional Information
The only topic that the codecademy covers that I do not believe is covered in the rest of the material in this lesson is the use of `require`. However, I believe this learners pick this up outside of this lesson too.


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [ x The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
