### PR TITLE
HTML Foundations Links and Images Lesson: clarify necessity of img alt attribute

### DIFF
--- a/foundations/html_css/html-foundations/links-and-images.md
+++ b/foundations/html_css/html-foundations/links-and-images.md
@@ -194,7 +194,7 @@ Using the metaphor we used earlier, using `../` in a filepath is kind of like st
 
 ### Alt attribute
 
-<span id="two-attributes"></span>Besides the src attribute, every image element should also have an alt (alternative text) attribute.
+<span id="two-attributes"></span>Besides the src attribute, every image element must also have an alt (alternative text) attribute.
 
 The alt attribute is used to describe an image. It will be used in place of the image if it cannot be loaded. It is also used with screen readers to describe what the image is to visually impaired users.
 


### PR DESCRIPTION
## Because
The lesson language regarding the alt attribute seems imprecise.
"should" implies preferred or best practice; "must" indicates a requirement.
Based on the following, it seems like an img tag **must** have an alt attribute:
1) Knowledge check on line 232
2) https://www.w3.org/WAI/tutorials/images/ (perhaps this can be part of Additional Resources?)
3) Attempting to validate an image without an alt on https://validator.w3.org/ gives an error rather than a warning


## This PR
- A one word tweak, per above


## Issue
None known

## Additional Information
None Known


## Pull Request Requirements
-   [X] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [X] The `Because` section summarizes the reason for this PR
-   [X] The `This PR` section has a bullet point list describing the changes in this PR
-   [X] If this PR addresses an open issue, it is linked in the `Issue` section
-   [X] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [X] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
