### PR TITLE
Intermediate HTML & CSS - Forms: Fixed broken link to internetingishard

### DIFF
--- a/intermediate_html_css/forms/form_basics.md
+++ b/intermediate_html_css/forms/form_basics.md
@@ -497,7 +497,7 @@ Certain aspects of other elements are downright impossible to style, for example
 ####Styling Forms
 
 1. Read and follow along to [MDN's Form Styling Guides](https://developer.mozilla.org/en-US/docs/Learn/Forms#form_styling_guides)
-2. Read and follow along to [the internetingishard guide to forms](https://www.internetingishard.com/html-and-css/forms/)
+2. Read and follow along to [the internetingishard guide to forms](https://internetingishard.netlify.app/html-and-css/forms/index.html)
 
 </div>
 


### PR DESCRIPTION
Fixed a broken link in the intermediate html&css - forms assignment

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
The link to the fourth assignment was broken - I believe it should route to: https://internetingishard.netlify.app/html-and-css/forms/index.html

## This PR

- On line 500, I updated the link to the assignment to read an _internetingishard_ site on forms.

## Issue
N/A

Closes N/A

## Additional Information
N/A

## Pull Request Requirements
-   [X] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [X] The `Because` section summarizes the reason for this PR
-   [X] The `This PR` section has a bullet point list describing the changes in this PR
-   [N/A] If this PR addresses an open issue, it is linked in the `Issue` section
-   [N/A] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [N/A] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
