### PR TITLE
Update Material Design link in project_admin_dashboard.md

### DIFF
--- a/intermediate_html_css/grid/project_admin_dashboard.md
+++ b/intermediate_html_css/grid/project_admin_dashboard.md
@@ -31,7 +31,7 @@ Now that you've had plenty of practice using Grid, we are going to build a full 
 
 1. Once you have your grid layout complete you can either recreate the dashboard example above or style your own design.
 2. Check out some color palettes from [Tailwind.](https://tailwindcss.com/docs/customizing-colors)
-3. All of the icons and more can be downloaded as SVGs from [Material Design Icons.](https://materialdesignicons.com/)
+3. All of the icons and more can be downloaded as SVGs from [Material Design Icons.](https://pictogrammers.com/library/mdi/)
 4. Choose your own fonts! The design example uses `Roboto`, which is available with Google fonts.
 
 #### Step 5: Some Tips!


### PR DESCRIPTION
## Because

The Meterial Design link towards the bottom of the page redirects to:

https://pictogrammers.com/library/mdi/

## This PR

Changes the link from:

https://materialdesignicons.com/

to:

https://pictogrammers.com/library/mdi/
