### PR TITLE
Fundamentals Part 2 lesson: Update linked article for Switch statements

### DIFF
--- a/foundations/javascript_basics/fundamentals-2.md
+++ b/foundations/javascript_basics/fundamentals-2.md
@@ -33,7 +33,7 @@ Now it's time for the fun stuff...  So far we haven't done much with our program
 3. [This tutorial](http://javascript.info/logical-operators) will teach you about logical operators. A little heads up regarding this reading's tasks; there will be questions where you see `alert()` (with a number or string inside of the parenthesis), what's happening here will be discussed later in the curriculum. Some of the answers may not make sense now but they are accurate and will come to be understood as you progress in the curriculum. Don't worry too much about it now!
 4. [This article](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/conditionals) reinforces the concept and provides several interesting examples of how you could use it building websites.
 5. [This article](http://javascript.info/ifelse) covers the same basic concept \(read through it as a review!\) and - more importantly - offers the usual 'tasks' at the bottom of the page!
-6. [This tutorial](https://www.digitalocean.com/community/tutorials/how-to-use-the-switch-statement-in-javascript) teaches you about the `switch` statement, which comes in handy when you have multiple conditions.
+6. [This article](https://javascript.info/switch) teaches you about the `switch` statement, which comes in handy when you have multiple conditions.
 
 ### Assignment
 


### PR DESCRIPTION
## Because
The linked article from DigitalOcean contains incorrect information about switch statements, and needs to be replaced with a better, more accurate tutorial.


## This PR
- Replaces the article from DigitalOcean with this great article from [javascript.info](https://javascript.info/switch).


## Issue
Closes #24723


## Additional Information
Confirmed to be an issue by @CouchofTomato 


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
