### PR TITLE
Flexbox Alignment: Update resources

### DIFF
--- a/foundations/html_css/flexbox/flexbox-alignment.md
+++ b/foundations/html_css/flexbox/flexbox-alignment.md
@@ -89,7 +89,7 @@ This section contains helpful links to related content. It isn’t required, so 
 
 * [Flexbox Froggy](https://flexboxfroggy.com/) is a funny little game for practicing moving things around with flexbox.
 * [Flexbox Zombies](https://mastery.games/flexboxzombies/) is another gamified take on flexbox. Free, but requires an account.
+* The [Basic Concepts of Flexbox](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox) article on MDN is another good starting point. There are helpful examples and interactive sections.
 * [Aligning Items in a Flex Container](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container) goes into more depth on the topic of axes and `align-items` vs `justify-content`.
 * This [Flexbox Tutorial](https://www.freecodecamp.org/news/css-flexbox-tutorial-with-cheatsheet/) from freecodecamp is another decent resource.
 * [Flexbox Crash Course](https://www.youtube.com/watch?v=3YW65K6LcIA) is a nice resource by Traversy Media.
-* [This flexbox visual cheatsheet](https://flexbox.malven.co/) has some useful references to flex and its properties.

--- a/foundations/html_css/flexbox/flexbox-alignment.md
+++ b/foundations/html_css/flexbox/flexbox-alignment.md
@@ -89,8 +89,7 @@ This section contains helpful links to related content. It isn’t required, so 
 
 * [Flexbox Froggy](https://flexboxfroggy.com/) is a funny little game for practicing moving things around with flexbox.
 * [Flexbox Zombies](https://mastery.games/flexboxzombies/) is another gamified take on flexbox. Free, but requires an account.
-* The [Basic Concepts of Flexbox](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox) article on MDN is another good starting point. There are helpful examples and interactive sections.
 * [Aligning Items in a Flex Container](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container) goes into more depth on the topic of axes and `align-items` vs `justify-content`.
 * This [Flexbox Tutorial](https://www.freecodecamp.org/news/css-flexbox-tutorial-with-cheatsheet/) from freecodecamp is another decent resource.
 * [Flexbox Crash Course](https://www.youtube.com/watch?v=3YW65K6LcIA) is a nice resource by Traversy Media.
-* [Learn flexbox the easy way](https://www.youtube.com/watch?v=u044iM9xsWU) by Kevin Powell explains flexbox very well in this video.
+* [This flexbox visual cheatsheet](https://flexbox.malven.co/) has some useful references to flex and its properties.


### PR DESCRIPTION
## Because

This comprehensive MDN article provides a solid foundation for understanding the basics of CSS Flex-box. It extensively covers the concept of axes while also briefly introducing alignment. To optimize the learning flow, I have moved this section to the previous lesson on flex-box axes, where students will receive a brief introduction to alignment. Additionally, in order to avoid duplication, I have removed the Kevin Powell video from this lesson since it is already mentioned in the Growing and Shrinking lesson. Instead, I have included the cheat sheet from the previous lesson in this current lesson.


## This PR

- Move MDN resource to the previous lesson.
- Remove one duplicate resource
- Move Flex-box cheat sheet from the previous lesson to this lesson


## Issue
Related to #25495

## Additional Information


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
