### PR TITLE
Foundations course / Intro to CSS lesson: Clarify sub-heading isn't a typo

### DIFF
--- a/foundations/html_css/css-foundations/intro-to-css.md
+++ b/foundations/html_css/css-foundations/intro-to-css.md
@@ -105,7 +105,7 @@ Instead of a period, we use a hashtag immediately followed by the case-sensitive
 
 The major difference between classes and IDs is that an element can only have **one** ID. An ID cannot be repeated on a single page, and the ID attribute should not contain any whitespace at all.
 
-#### Grouping Selector
+#### The Grouping Selector
 
 What if we have two groups of elements that share some of their style declarations?
 


### PR DESCRIPTION
## Because
Clarifies that sub-heading isn't a typo while making sure the student learns a common CSS term.

"Grouping Selector" is indeed a common CSS term, however, to a student that might not be clear--it might be interpreted as a typo for the plural-containing "Grouping Selectors", since selectors are indeed being grouped in one of the following codeblocks and, also, on Line 146 there's a sub-heading called "Chaining Selectors".

See w3schools.com/css/css_selectors.asp for an example of the usage of the term "The grouping selector".

## This PR

- Change "Grouping Selector" on Line 108 to "The Grouping Selector".


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
