### PR TITLE
Foundations / Intro to CSS lesson: Use different <p> for each color type example

### DIFF
--- a/foundations/html_css/css-foundations/intro-to-css.md
+++ b/foundations/html_css/css-foundations/intro-to-css.md
@@ -236,8 +236,14 @@ Almost. Both of these properties can accept one of several kinds of values. A co
 p {
   /* hex example: */
   color: #1100ff;
+}
+
+p {
   /* rgb example: */
   color: rgb(100, 0, 127);
+}
+
+p {
   /* hsl example: */
   color: hsl(15, 82%, 56%);
 }


### PR DESCRIPTION
## Because

So that the student isn't confused into thinking that all three color examples would be worth declaring in the same <p> element (as only one would take effect).


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->

- Split the <p> element beginning on Line 236 into 3 <p> elements, each containing a different one of the color declarations in the original <p> element.


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
