### PR TITLE
JavaScript / "Project: Binary Search Trees": Ensure nodes in Step 1 are smaller than 100

### DIFF
--- a/javascript/computer_science/project_binary_search_trees.md
+++ b/javascript/computer_science/project_binary_search_trees.md
@@ -57,7 +57,7 @@ You'll build a balanced BST in this assignment. Do not use duplicate values beca
 
 Write a simple driver script that does the following:
 
-1. Create a binary search tree from an array of random numbers. You can create a function that returns an array of random numbers every time you call it, if you wish.
+1. Create a binary search tree from an array of random numbers < 100. You can create a function that returns an array of random numbers every time you call it, if you wish.
 1. Confirm that the tree is balanced by calling `isBalanced`
 1. Print out all elements in level, pre, post, and in order
 1. Unbalance the tree by adding several numbers > 100


### PR DESCRIPTION
## Because

In Step 1 of the "Tie it all together" section of the assignment at theodinproject.com/lessons/javascript-binary-search-trees#assignment, tell the student to ensure the nodes created have values smaller than 100.

Do this so that Step 4 will definitely unbalance the binary tree as intended, Step 4 reading:

"Unbalance the tree by adding several numbers > 100"


## This PR

- Change Line 60 from "1. Create a binary search tree from an array of random numbers. You can create a function that returns an array of random numbers every time you call it, if you wish." to "1. Create a binary search tree from an array of random numbers < 100. You can create a function that returns an array of random numbers every time you call it, if you wish."


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
