### PR TITLE
Getting Hired / It Starts With You lesson: Fix grammar by adding missing verb

### DIFF
--- a/getting_hired/preparing_for_job_search/starts_with_you.md
+++ b/getting_hired/preparing_for_job_search/starts_with_you.md
@@ -55,6 +55,6 @@ Some questions to ask (which you'll probably hear again in your early interviews
 9. Do I lean in to challenges or avoid them?
 10. What are some really difficult problems I've solved before?
 
-Applying without much experience means you need to fill in your weak spots and emphasize your strengths.  For almost everyone, your biggest strength will be hunger and ability to learn.  But companies have heard that story before, so you'll have to tie in other strengths that you can to make your story compelling.
+Applying without much experience means you need to fill in your weak spots and emphasize your strengths.  For almost everyone, your biggest strength will be hunger and ability to learn.  But companies have heard that story before, so you'll have to tie in other strengths that you can use to make your story compelling.
 
 A quick note -- there is a difference between hunger for opportunity and desperation.  Hunger is about seeking reward (which you can do when you're in a comfortable situation and optimizing opportunities) and desperation is about avoiding failure (which occurs when you absolutely MUST have that job).  Do whatever it takes to not sound desperate, even if you are.


### PR DESCRIPTION
## Because

Add missing verb ("use") in order to fix grammar in theodinproject.com/lessons/node-path-getting-hired-it-starts-with-you#what-are-your-assets-and-liabilities.

Specifically, the part reading "companies have heard that story before, so you’ll have to tie in other strengths that you can to make your story compelling" needs a word like "use" between "can to" to make grammatical sense, I think. Also makes it read a bit better.


## This PR

- Put the word "use" between "can to" in Line 58.


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
