### PR TITLE
Ruby: fix variable typo

### DIFF
--- a/ruby/computer_science/time_complexity.md
+++ b/ruby/computer_science/time_complexity.md
@@ -54,9 +54,9 @@ Let's go back to our `odd_numbers_less_than_ten method`. How many steps does our
     3. If it is then we output it to the terminal. That's 1 step every 2 iterations.
     4. We increase `current_number` by 1. That is 1 step.
 
-3. To exit the loop, we need to compare `currentNumber` one last time to see that it is not less than ten any more. That is one last step.
+3. To exit the loop, we need to compare `current_number` one last time to see that it is not less than ten any more. That is one last step.
 
-So there are 3 steps for every loop iteration and it iterates 9 times which is 27 steps. Then we have one step which iterates for only half the loop iteration which is 5 steps. Assigning an initial value to `currentNumber` and checking the exit condition of the loop is one step each. 27 + 5 + 1 + 1 = 34 steps.
+So there are 3 steps for every loop iteration and it iterates 9 times which is 27 steps. Then we have one step which iterates for only half the loop iteration which is 5 steps. Assigning an initial value to `current_number` and checking the exit condition of the loop is one step each. 27 + 5 + 1 + 1 = 34 steps.
 
 Therefore we can say our algorithm takes 34 steps to complete.
 


### PR DESCRIPTION
Typo, variable written as `currentNumber` instead of `current_number` in [Time Complexity Lesson](https://www.theodinproject.com/lessons/ruby-time-complexity)

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Typo in the lesson where one of the variables was written in `camelCase` and not `snake_case`.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- change from `currentNumber` to `current_number`

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
