### PR TITLE
JavaScript / React Testing Part 2 lesson: Note that data-testid is the default spelling

### DIFF
--- a/javascript/react_js/react_testing_part_two.md
+++ b/javascript/react_js/react_testing_part_two.md
@@ -123,7 +123,7 @@ Go through its test file, [submissions-list.test.jsx](https://github.com/TheOdin
 
 #### Note
 
-While the test suite above uses `data-test-id` to identify mocked child components, it must be remembered that the React Testing Library instead uses `data-testid` by default. This spelling was overridden for development convenience in a configuration file used to set up the test environment but this is not necessary.
+While the test suite above uses `data-test-id` to identify mocked child components, it must be remembered that the React Testing Library instead uses `data-testid` by default.
 
 </div>
 

--- a/javascript/react_js/react_testing_part_two.md
+++ b/javascript/react_js/react_testing_part_two.md
@@ -119,6 +119,14 @@ By just going through the code, it should give us some idea of what to test. It 
 
 Go through its test file, [submissions-list.test.jsx](https://github.com/TheOdinProject/theodinproject/blob/main/app/javascript/components/project-submissions/components/__tests__/submissions-list.test.jsx). Again, don't worry if all of it doesn't make sense, we'll chew over it shortly.
 
+<div class="lesson-note" markdown="1">
+
+#### Note
+
+While the test suite above uses `data-test-id` to identify mocked child components, it must be remembered that the React Testing Library instead uses `data-testid` by default. This spelling was overridden for development convenience in a configuration file used to set up the test environment but this is not necessary.
+
+</div>
+
 #### submissions-list.test.jsx
 
 We notice there are two child components of `SubmissionsList`. One of them is from a package called `react-flip-move`. External Code. We'll mock it.


### PR DESCRIPTION
## Because

In making the test suite linked above the new note (see github.com/TheOdinProject/theodinproject/blob/main/app/javascript/components/project-submissions/components/tests/submissions-list.test.jsx), TOP developers included a configuration file (see github.com/TheOdinProject/theodinproject/blob/main/setupTests.js) that overrides the React Testing Library's default spelling of this attribute, which is instead data-testid (see testing-library.com/docs/queries/bytestid/)

Students might be convinced to use data-test-id without realising there needs to be a config file (especially since this config file isn't mentioned in the lesson or the test suite linked), thus leading to errors during testing. So, this note aims to mitigate that.


## This PR

- Add a new note from Line 124 to Line 128 to clarify that data-testid is the default spelling of this attribute.


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
