### PR TITLE
Actioncable lesson: Update HTML for Rails 7

### DIFF
--- a/ruby_on_rails/mailers_advanced_topics/actioncable_lesson.md
+++ b/ruby_on_rails/mailers_advanced_topics/actioncable_lesson.md
@@ -91,7 +91,7 @@ Lastly, to add the navbar functionality we can just add it straight into the mai
     <div class="navbar-item">
       <div class="buttons">
         <% if current_user %>
-          <%= link_to "Logout", destroy_user_session_path, method: :delete, class: 'button is-link' %>
+          <%= link_to "Logout", destroy_user_session_path, data: { "turbo-method": :delete }, class: 'button is-link' %>
         <% else %>
           <%= link_to "Login", new_user_session_path, class: 'button is-link' %>
         <% end %>

--- a/ruby_on_rails/mailers_advanced_topics/actioncable_lesson.md
+++ b/ruby_on_rails/mailers_advanced_topics/actioncable_lesson.md
@@ -91,7 +91,7 @@ Lastly, to add the navbar functionality we can just add it straight into the mai
     <div class="navbar-item">
       <div class="buttons">
         <% if current_user %>
-          <%= link_to "Logout", destroy_user_session_path, data: { turbo-method: :delete }, class: 'button is-link' %>
+          <%= link_to "Logout", destroy_user_session_path, data: { turbo_method: :delete }, class: 'button is-link' %>
         <% else %>
           <%= link_to "Login", new_user_session_path, class: 'button is-link' %>
         <% end %>

--- a/ruby_on_rails/mailers_advanced_topics/actioncable_lesson.md
+++ b/ruby_on_rails/mailers_advanced_topics/actioncable_lesson.md
@@ -91,7 +91,7 @@ Lastly, to add the navbar functionality we can just add it straight into the mai
     <div class="navbar-item">
       <div class="buttons">
         <% if current_user %>
-          <%= link_to "Logout", destroy_user_session_path, data: { "turbo-method": :delete }, class: 'button is-link' %>
+          <%= link_to "Logout", destroy_user_session_path, data: { turbo-method: :delete }, class: 'button is-link' %>
         <% else %>
           <%= link_to "Login", new_user_session_path, class: 'button is-link' %>
         <% end %>


### PR DESCRIPTION
## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Using `method: :delete` on a `link_to` helper in Rails 7 with Turbo enabled sends a GET request instead of a DELETE request. This would cause a routing error when trying to log out by clicking the navbar link. This PR fixes that by sending a real DELETE request using the `data-turbo-method` attribute.


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Removes `turbo: :delete` as that sends a GET request on Rails 7 with Turbo enabled
- Replaces with `data: { turbo-method: :delete }`


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
No specific issue

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
Additional links to Stack Overflow posts describing similar issues:
https://stackoverflow.com/questions/25659488/using-link-to-with-delete-action-in-rails
https://stackoverflow.com/questions/70474422/rails-7-link-to-with-method-delete-still-performs-get-request

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
