### PR TITLE
 Etch-a-Sketch Project: Fix wording of Extra Credit

### DIFF
--- a/foundations/javascript_basics/project_etch_a_sketch.md
+++ b/foundations/javascript_basics/project_etch_a_sketch.md
@@ -36,5 +36,9 @@ Don't forget to commit early & often! You can [reference the Commit Message less
 5.  Push your project to GitHub!
 
 #### Extra Credit
-*   Instead of just changing the color of a square from black to white \(for example\), have each pass through with the mouse change it to a completely random RGB value.   Then try having each pass just add another 10% of black to it so that only after 10 passes is the square completely black.
-</div>
+Transform the behavior of a square when interacting with the mouse by introducing a series of modifications. 
+
+1. Rather than a simple color change from black to white, each interaction should randomize the square's RGB value entirely. 
+2. Additionally, implement a progressive darkening effect where each interaction adds 10% more black or color to the square. The objective is to achieve a completely black square only after ten interactions.
+
+You can choose to do either one or both of these challenges, it's up to you.


### PR DESCRIPTION
## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The wording of the Extra Credit section of the Etch-a-Sketch project wasn't clear.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Split the problem into 2 parts.
- Improve the wording of the challenges to make it more clear.

## Issue
Closes #24738

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [X] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [X] The `Because` section summarizes the reason for this PR
-   [X] The `This PR` section has a bullet point list describing the changes in this PR
-   [X] If this PR addresses an open issue, it is linked in the `Issue` section
-   [X] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [X] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
