### PR TITLE
Intro to CSS lesson: Fix syntax error in "Order Matters!" section

### DIFF
--- a/foundations/html_css/css-foundations/intro-to-css.md
+++ b/foundations/html_css/css-foundations/intro-to-css.md
@@ -234,7 +234,7 @@ When two selectors have the same level of specificity, the rule that is defined 
 ~~~css
 /* styles.css */
 .first_declared, .last_declared {
-  background_color: rgb(200, 50, 150);
+  background-color: rgb(200, 50, 150);
   font-weight: 800;
 }
 .first_declared {


### PR DESCRIPTION
Changed background_color to background-color in styles.css

## Because
Syntax was incorrect in a lesson.


## This PR
Fixes one spelling error.

## Issue
There is no outgoing issue for this change.

## Additional Information
N/A


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
