### PR TITLE
Fix: allow scrimba iframes to open new tabs

### DIFF
--- a/foundations/html_css/flexbox/flexbox-alignment.md
+++ b/foundations/html_css/flexbox/flexbox-alignment.md
@@ -37,11 +37,11 @@ Because `justify-content` and `align-items` are based on the main and cross axis
 
 Check out this Scrim for an interactive demo of how `justify-content` and its different properties behave:
 
-<iframe src="https://scrimba.com/learn/flexbox/justify-content-flexbox-tutorial-cVWPacR?embed=odin,mini-header,no-big-play,no-next-up" sandbox="allow-scripts allow-same-origin" width="100%" height="400"></iframe>
+<iframe src="https://scrimba.com/learn/flexbox/justify-content-flexbox-tutorial-cVWPacR?embed=odin,mini-header,no-big-play,no-next-up" sandbox="allow-scripts allow-same-origin allow-popups" width="100%" height="400"></iframe>
 
 This next Scrim covers the behavior of `align-items`, how to perfectly center an element on a page using flexbox and much more:
 
-<iframe src="https://scrimba.com/learn/flexbox/align-items-flexbox-tutorial-cJqymH9?embed=odin,mini-header,no-big-play,no-next-up" sandbox="allow-scripts allow-same-origin" width="100%" height="400"></iframe>
+<iframe src="https://scrimba.com/learn/flexbox/align-items-flexbox-tutorial-cJqymH9?embed=odin,mini-header,no-big-play,no-next-up" sandbox="allow-scripts allow-same-origin allow-popups" width="100%" height="400"></iframe>
 
 
 #### Gap

--- a/foundations/html_css/flexbox/flexbox-axes.md
+++ b/foundations/html_css/flexbox/flexbox-axes.md
@@ -46,7 +46,7 @@ We've strayed from the point slightly... We were talking about flex-direction an
 
 For an interactive demo of how axes work with flexbox, check out this Scrim:
 
-<iframe src="https://scrimba.com/learn/flexbox/main-axis-and-cross-axis-flexbox-tutorial-cz94MT8?embed=odin,mini-header,no-big-play,no-next-up" sandbox="allow-scripts allow-same-origin" width="100%" height="400"></iframe>
+<iframe src="https://scrimba.com/learn/flexbox/main-axis-and-cross-axis-flexbox-tutorial-cz94MT8?embed=odin,mini-header,no-big-play,no-next-up" sandbox="allow-scripts allow-same-origin allow-popups" width="100%" height="400"></iframe>
 
 ### Knowledge Check
 

--- a/foundations/html_css/flexbox/flexbox-growing-and-shrinking.md
+++ b/foundations/html_css/flexbox/flexbox-growing-and-shrinking.md
@@ -26,7 +26,7 @@ Very often you see the flex shorthand defined with only _one_ value. In that cas
 
 For an interactive explanation and demo of the flex shorthand, check out this Scrim:
 
-<iframe src="https://scrimba.com/learn/flexbox/the-flex-property-flexbox-tutorial-cGNKJTv?embed=odin,mini-header,no-big-play,no-next-up" sandbox="allow-scripts allow-same-origin" width="100%" height="400"></iframe>
+<iframe src="https://scrimba.com/learn/flexbox/the-flex-property-flexbox-tutorial-cGNKJTv?embed=odin,mini-header,no-big-play,no-next-up" sandbox="allow-scripts allow-same-origin allow-popups" width="100%" height="400"></iframe>
 
 
 #### Flex-Grow
@@ -87,7 +87,7 @@ It _is_ possible to get fancy, and set up layouts where some columns relate to e
 
 3. Watch this interactive Scrim for an alternative explanation and demo of using flex-grow, flex-shrink and flex-basis in a real world scenario:
 
-<iframe src="https://scrimba.com/learn/flexbox/flex-grow-shrink-basis-flexbox-tutorial-ck6L7fv?embed=odin,mini-header,no-big-play,no-next-up" sandbox="allow-scripts allow-same-origin" width="100%" height="400"></iframe>
+<iframe src="https://scrimba.com/learn/flexbox/flex-grow-shrink-basis-flexbox-tutorial-ck6L7fv?embed=odin,mini-header,no-big-play,no-next-up" sandbox="allow-scripts allow-same-origin allow-popups" width="100%" height="400"></iframe>
 
 </div>
 

--- a/foundations/html_css/flexbox/flexbox-intro.md
+++ b/foundations/html_css/flexbox/flexbox-intro.md
@@ -22,7 +22,7 @@ You will almost definitely need to come back and reference these lessons (or a c
 
 ### Let's Flex!
 
-Flexbox is a way to arrange items into rows or columns. These items will flex (i.e. grow or shrink) based on some simple rules that you can define. To get started, let's look at a simple demonstration. 
+Flexbox is a way to arrange items into rows or columns. These items will flex (i.e. grow or shrink) based on some simple rules that you can define. To get started, let's look at a simple demonstration.
 
 <div class="lesson-note" markdown="1">
 
@@ -58,7 +58,7 @@ If it's hard to see what's going on in the small embedded CodePen, feel free to 
 
 For a more interactive explanation and example, try the following Scrim (let us know what you think of these):
 
-<iframe src="https://scrimba.com/learn/flexbox/your-first-flexbox-layout-flexbox-tutorial-canLGCw?embed=odin,mini-header,no-big-play,no-next-up" sandbox="allow-scripts allow-same-origin" width="100%" height="400"></iframe>
+<iframe src="https://scrimba.com/learn/flexbox/your-first-flexbox-layout-flexbox-tutorial-canLGCw?embed=odin,mini-header,no-big-play,no-next-up" sandbox="allow-scripts allow-same-origin allow-popups" width="100%" height="400"></iframe>
 
 #### Flex Containers and Flex Items
 


### PR DESCRIPTION
## Because
- #25041 added sandbox options to some of the scrimba iframes, but this disallows scrimba to open new tabs/windows, which breaks the open in fullscreen functionality


## This PR
- Adds `allow-popups` to the sandbox options, which allows scrimba to open new windows, although still subjected to the other sandbox flags
- Note that there are also some scrimba iframes that are not sandboxed at all; I've left those alone for now, but thats something to consider in a future issue

Closes TheOdinProject/theodinproject#3882
Closes #25676
## Additional Information

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
