### PR TITLE
JavaScript: Added iframe sandbox options 

### DIFF
--- a/javascript/asynchronous_javascript_and_apis/async_and_await.md
+++ b/javascript/asynchronous_javascript_and_apis/async_and_await.md
@@ -65,7 +65,7 @@ This section contains a general overview of topics that you will learn in this l
 
 For a more interactive explanation and example, try the following Scrim (let us know what you think of these):
 
-<iframe src="https://scrimba.com/scrim/crd4eMc6?embed=odin,mini-header,no-next-up" width="100%" height="400"></iframe>
+<iframe src="https://scrimba.com/scrim/crd4eMc6?embed=odin,mini-header,no-next-up" sandbox="allow-scripts allow-same-origin allow-popups" width="100%" height="400"></iframe>
 
 ### The async keyword
 

--- a/javascript/asynchronous_javascript_and_apis/asynchronous_code.md
+++ b/javascript/asynchronous_javascript_and_apis/asynchronous_code.md
@@ -13,7 +13,7 @@ This section contains a general overview of topics that you will learn in this l
 
 For a more interactive explanation and example, try the following Scrim (let us know what you think of these):
 
-<iframe src="https://scrimba.com/scrim/cof4e4fb797a2d0a236ea38ce?embed=odin,mini-header,no-next-up" width="100%" height="400"></iframe>
+<iframe src="https://scrimba.com/scrim/cof4e4fb797a2d0a236ea38ce?embed=odin,mini-header,no-next-up" sandbox="allow-scripts allow-same-origin allow-popups" width="100%" height="400"></iframe>
 
 ### Callbacks
 

--- a/javascript/organizing_your_javascript_code/factory_functions_and_module_pattern.md
+++ b/javascript/organizing_your_javascript_code/factory_functions_and_module_pattern.md
@@ -26,7 +26,7 @@ This section contains a general overview of topics that you will learn in this l
 
 For a more interactive explanation and example, try the following Scrim (let us know what you think of these):
 
-<iframe src="https://scrimba.com/scrim/c2aaKzcV?embed=odin,mini-header,no-sidebar,no-next-up" width="100%" height="400"></iframe>
+<iframe src="https://scrimba.com/scrim/c2aaKzcV?embed=odin,mini-header,no-sidebar,no-next-up" sandbox="allow-scripts allow-same-origin allow-popups" width="100%" height="400"></iframe>
 
 ### Factory Function Introduction
 

--- a/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
+++ b/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
@@ -49,7 +49,7 @@ This section contains a general overview of topics that you will learn in this l
 
 For a more interactive explanation and example, try the following Scrim (let us know what you think of these):
 
-<iframe src="https://scrimba.com/scrim/co2624f87981575448091d5a2?embed=odin,mini-header,no-sidebar,no-next-up" width="100%" height="400"></iframe>
+<iframe src="https://scrimba.com/scrim/co2624f87981575448091d5a2?embed=odin,mini-header,no-sidebar,no-next-up" sandbox="allow-scripts allow-same-origin allow-popups" width="100%" height="400"></iframe>
 
 ### Objects as a Design Pattern
 
@@ -185,14 +185,14 @@ Now, to understand this code, let's use the three points from earlier:
 1. **All objects in JavaScript have a `prototype`**:
    - You can check the object's `prototype` by using the [`Object.getPrototypeOf()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf) function on the object, like `Object.getPrototypeOf(player1)`.
    - The return value (result) of this function refers to the `.prototype` property of the Object Constructor (i.e., `Player(name, marker)`) - `Object.getPrototypeOf(player1) === Player.prototype`.
-1. **The prototype is another object**: 
-   - The _value_ of the Object Constructor's `.prototype` property (i.e., `Player.prototype`) contains the `prototype` object. 
+1. **The prototype is another object**:
+   - The _value_ of the Object Constructor's `.prototype` property (i.e., `Player.prototype`) contains the `prototype` object.
    - The _reference_ to this value of `Player.prototype` is stored in every `Player` object, every time a `Player` object is created.
    - Hence, you get a `true` value returned when you check the Objects prototype - `Object.getPrototypeOf(player1) === Player.prototype`.
-1. **...that the original object _inherits_ from, and has access to all of its prototype's methods and properties**: 
+1. **...that the original object _inherits_ from, and has access to all of its prototype's methods and properties**:
    - As said in the earlier point, every `Player` object has a value which refers to `Player.prototype`. So: `Object.getPrototypeOf(player1) === Object.getPrototypeOf(player2)` (returns `true`).
    - So, any properties or methods defined on `Player.prototype` will be available to the created `Player` objects!
-   
+
 The last sub-item needs a little more explanation. What does defining 'on the `prototype`' mean? Consider the following code:
 
 ~~~javascript
@@ -232,11 +232,11 @@ We can narrow it down to two reasons:
 Let's now try to do the following:
 
 ~~~javascript
-// Player.prototype.__proto__ 
+// Player.prototype.__proto__
 Object.getPrototypeOf(Player.prototype) === Object.prototype // true
 
 // Output may slightly differ based on the browser
-player1.valueOf() // Output: Object { name: "steve", marker: "X", sayName: sayName() } 
+player1.valueOf() // Output: Object { name: "steve", marker: "X", sayName: sayName() }
 ~~~
 
 What's this `.valueOf` function, and where did it come from if we did not define it? It comes as a result of `Object.getPrototypeOf(Player.prototype)` having the value of `Object.prototype`! This means that `Player.prototype` is inheriting from `Object.prototype`. This `.valueOf` function is defined on `Object.prototype` just like `.sayHello` is defined on `Player.prototype`.
@@ -289,8 +289,8 @@ Player.prototype.getMarker = function() {
   console.log(`My marker is '${this.marker}'`)
 }
 
-// Object.getPrototypeOf(Player.prototype) should 
-// return the value of "Person.prototype" instead 
+// Object.getPrototypeOf(Player.prototype) should
+// return the value of "Person.prototype" instead
 // of "Object.prototype"
 Object.getPrototypeOf(Player.prototype) // returns Object.prototype
 
@@ -349,7 +349,7 @@ function Enemy(name) {
 // Use Object.setPrototypeOf(Enemy.prototype, Person.prototype)
 Enemy.prototype = Person.prototype
 
-Enemy.prototype.sayName = function() { 
+Enemy.prototype.sayName = function() {
   console.log('HAHAHAHAHAHA')
 }
 


### PR DESCRIPTION
## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->

The Chromium console (assuming also all other browsers that have introduced iframe sandboxes) is full of error messages on all pages that contain iframes. This problem got [fixed](https://github.com/TheOdinProject/curriculum/pull/25041) in Foundations course, but some iframes were left in JavaScript course.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
This whitelists the [iframe sandbox options](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox):
-  allow-scripts
    Lets the resource run scripts (but not create popup windows).

 -  allow-same-origin
    If this token is not used, the resource is treated as being from a special origin that always fails the [same-origin policy](https://developer.mozilla.org/en-US/docs/Glossary/Same-origin_policy) (potentially preventing access to [data storage/cookies](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#cross-origin_data_storage_access) and some JavaScript APIs).

These options remove the error messages and allow the iframes to continue working as expected.

Unfortunately there are still some error messages generated by Scrimba's use of iframes within their embed URL (nested iframes for TOP's purpose) without adding code to handle the new sandbox rules. But the console is a lot cleaner from this change regardless.

## Issue

Closes #25678

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
[Link](https://github.com/TheOdinProject/curriculum/pull/25041) to the pull request of the same issue in Foundations course.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
