### PR TITLE
Installing Ruby: Update installing_ruby.md to change ruby version to 3.2.2

### DIFF
--- a/ruby/introduction/installing_ruby.md
+++ b/ruby/introduction/installing_ruby.md
@@ -101,7 +101,7 @@ It's finally time to install Ruby using `rbenv`!
 Inside the terminal, run this command:
 
 ~~~bash
-rbenv install 3.1.2 --verbose
+rbenv install 3.2.2 --verbose
 ~~~
 
 This command will take 10-15 minutes to complete. The `--verbose` flag will show you what's going on so you can be sure it hasn't gotten stuck. While it installs, take this time to watch [this video](https://youtu.be/X2CYWg9-2N0) or to get a glass of water.
@@ -127,7 +127,7 @@ git -C "$(rbenv root)"/plugins/ruby-build pull
 Once Ruby is installed, you need to tell rbenv which version to use by default. Inside the terminal, type:
 
 ~~~bash
-rbenv global 3.1.2
+rbenv global 3.2.2
 ~~~
 
 Then,
@@ -139,7 +139,7 @@ ruby -v
 The above command should return something similar to this:
 
 ~~~bash
-ruby 3.1.2pxx (20xx-xx-xx revision xxxxx) [x86_64-linux]
+ruby 3.2.2pxx (20xx-xx-xx revision xxxxx) [x86_64-linux]
 ~~~
 where x represents the version available at the time you installed Ruby.
 
@@ -248,7 +248,7 @@ You'll notice nothing happened in the terminal. That's okay and is typical respo
 
 #### Step 2.3: Install Ruby
 
-We can now (finally) install Ruby! Our curriculum currently uses version 3.1.2, which will allow you to complete this path's materials and content without error. We upgrade the material to accommodate newer versions as necessary. Without further ado, let's get going!
+We can now (finally) install Ruby! Our curriculum currently uses version 3.2.2, which will allow you to complete this path's materials and content without error. We upgrade the material to accommodate newer versions as necessary. Without further ado, let's get going!
 
 First, let's upgrade `ruby-build`:
 
@@ -259,7 +259,7 @@ brew upgrade ruby-build
 Now we're ready to install our desired version of Ruby:
 
 ~~~bash
-rbenv install 3.1.2 --verbose
+rbenv install 3.2.2 --verbose
 ~~~
 
 This command will take 10-15 minutes to complete. The `--verbose` flag will show you what's going on so you can be sure it hasn't gotten stuck. While it installs, take this time to watch [this video](https://www.youtube.com/watch?v=X2CYWg9-2N0) or to get a glass of water.
@@ -267,14 +267,14 @@ This command will take 10-15 minutes to complete. The `--verbose` flag will show
 Once Ruby is installed, you need to tell rbenv which version to use by default. Inside the terminal, type:
 
 ~~~bash
-rbenv global 3.1.2
+rbenv global 3.2.2
 ~~~
 
-You can double check that this worked by typing `ruby -v` and checking that the output says version 3.1.2:
+You can double check that this worked by typing `ruby -v` and checking that the output says version 3.2.2:
 
 ~~~bash
 ruby -v
-ruby 3.1.2pxx (20xx-xx-xx revision xxxxx) [x86_64-darwin18]
+ruby 3.2.2pxx (20xx-xx-xx revision xxxxx) [x86_64-darwin18]
 ~~~
 
 If you don't see the output above, close and reopen the terminal window and then run the command again.


### PR DESCRIPTION
## Because
The installation guide instructs users to install Ruby version 3.1.2, while the main site itself is already using version 3.2.2 which may cause confusion for learners who installed version 3.1.2 who want to contribute to the site.


## This PR
Revised the installation guide of ruby to use version 3.2.2 to avoid compatibility issues, and create a more accessible environment for new contributors.


## Issue
Closes #25695 

## Additional Information


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
