### PR TITLE
Forms and Authentication lesson: fix typos

### DIFF
--- a/ruby_on_rails/forms_and_authentication/sessions_cookies_authentication.md
+++ b/ruby_on_rails/forms_and_authentication/sessions_cookies_authentication.md
@@ -2,7 +2,7 @@
 
 "Sessions" are the idea that your user's state is somehow preserved when they click from one page to the next. Remember, HTTP is stateless, so it's up to either the browser or your application to "remember" what needs to be remembered.
 
-In this lesson you'll learn about sessions, browser cookies,and how authentication is built in Rails.  We'll cover both home-grown authentication and the most commonly used authentication gem, Devise.
+In this lesson you'll learn about sessions, browser cookies, and how authentication is built in Rails.  We'll cover both home-grown authentication and the most commonly used authentication gem, Devise.
 
 ### Lesson Overview
 


### PR DESCRIPTION
## Because
This PR corrects a simple typo in the lesson text for the ruby on rails forms and authentication lesson.

## This PR
* Adding a missing space in the 'Introduction'.

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
