### PR TITLE
Fix: Scrimba Iframes

### DIFF
--- a/foundations/html_css/css-foundations/block-and-inline.md
+++ b/foundations/html_css/css-foundations/block-and-inline.md
@@ -13,7 +13,7 @@ This section contains a general overview of topics that you will learn in this l
 
 For a more interactive explanation and example, try the following Scrim (let us know what you think of these):
 
-<iframe src="https://scrimba.com/scrim/co5024997a7e46c232d9abe55?embed=odin,mini-header,no-next-up" width="100%" height="400"></iframe>
+<iframe src="https://scrimba.com/scrim/co5024997a7e46c232d9abe55?embed=odin,mini-header,no-next-up" sandbox="allow-scripts allow-same-origin allow-popups" width="100%" height="400"></iframe>
 
 ### Block vs Inline
 

--- a/foundations/html_css/css-foundations/intro-to-css.md
+++ b/foundations/html_css/css-foundations/intro-to-css.md
@@ -12,7 +12,7 @@ This section contains a general overview of topics that you will learn in this l
 
 For a more interactive explanation and example, try the following Scrim (let us know what you think of these):
 
-<iframe src="https://scrimba.com/scrim/co12d4cf99cf2776f19e84a9d?embed=odin,mini-header,no-sidebar,no-next-up" width="100%" height="400"></iframe>
+<iframe src="https://scrimba.com/scrim/co12d4cf99cf2776f19e84a9d?embed=odin,mini-header,no-sidebar,no-next-up" sandbox="allow-scripts allow-same-origin allow-popups" width="100%" height="400"></iframe>
 
 
 ### Basic Syntax

--- a/foundations/html_css/css-foundations/the-box-model.md
+++ b/foundations/html_css/css-foundations/the-box-model.md
@@ -14,7 +14,7 @@ This section contains a general overview of topics that you will learn in this l
 
 For a more interactive explanation and example, try the following Scrim (let us know what you think of these):
 
-<iframe src="https://scrimba.com/scrim/cof3d488184abe24ec6258ab4?embed=odin,mini-header,no-next-up" width="100%" height="400"></iframe>
+<iframe src="https://scrimba.com/scrim/cof3d488184abe24ec6258ab4?embed=odin,mini-header,no-next-up" sandbox="allow-scripts allow-same-origin allow-popups" width="100%" height="400"></iframe>
 
 ### The Box Model
 

--- a/foundations/html_css/css-foundations/the-cascade.md
+++ b/foundations/html_css/css-foundations/the-cascade.md
@@ -12,7 +12,7 @@ This section contains a general overview of topics that you will learn in this l
 
 For a more interactive explanation and example, try the following Scrim (let us know what you think of these):
 
-<iframe src="https://scrimba.com/scrim/cof994391b86aefab81df8cba?embed=odin,mini-header,no-next-up" width="100%" height="400"></iframe>
+<iframe src="https://scrimba.com/scrim/cof994391b86aefab81df8cba?embed=odin,mini-header,no-next-up" sandbox="allow-scripts allow-same-origin allow-popups" width="100%" height="400"></iframe>
 
 ### The Cascade of CSS
 


### PR DESCRIPTION
Because:
* Some of them had missing sandbox attributes and were causing console errors.
* Resolves: https://github.com/TheOdinProject/curriculum/issues/25720

This commit:
* Adds missing sandbox attributes to Scrimba iframes in block and inline lesson.
* Adds missing sandbox attributes to Scrimba iframes in intro to css lesson.
* Adds missing sandbox attributes to Scrimba iframes in the box model lesson.
* Adds missing sandbox attributes to Scrimba iframes in the cascade lesson.

