### PR TITLE
curriculum/.github/ISSUE_TEMPLATE/suggestion.yaml: Update Discord name field placeholder

### DIFF
--- a/.github/ISSUE_TEMPLATE/suggestion.yaml
+++ b/.github/ISSUE_TEMPLATE/suggestion.yaml
@@ -55,7 +55,7 @@ body:
     attributes:
       label: (Optional) Discord Name
       description: Optionally provide your discord name to help coordinate changes there if necessary
-      placeholder: ex. odinite#1234
+      placeholder: ex. odinite
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
## Because

The placeholder for the optional Discord name field in the suggestion.yaml template should be updated to reflect Discord's pomelo naming scheme.

## This PR

- Update the placeholder for the Discord name field in suggestion.yaml to reflect Discord's pomelo naming scheme.

## Issue
Closes #25732

## Additional Information
N/A



## Pull Request Requirements
- [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format, e.g., `Intro to HTML and CSS lesson: Fix link text`
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
- [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)