### PR TITLE
CONTRIBUTING.md: repoint contributing links to .github/CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/archive/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/archive/bug_report.md
@@ -9,7 +9,7 @@ assignees: ""
 <!-- Thank you for taking the time to submit a bug report to The Odin Project. In order to get issues closed in a reasonable amount of time, you must include a baseline of information about the bug in question. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->
 
 Complete the following REQUIRED checkboxes:
--   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
+-   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
 -   [ ] The title of this issue follows the `Bug - location of bug: brief description of bug` format, e.g. `Bug - React section: Knowledge Checks don't link to resource`
 
 The following checkbox is OPTIONAL:

--- a/.github/ISSUE_TEMPLATE/archive/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/archive/feature_request.md
@@ -9,7 +9,7 @@ assignees: ""
 <!-- Thank you for taking the time to submit a new feature request to The Odin Project. In order to get issues closed in a reasonable amount of time, you must include a baseline of information about the feature/enhancement you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->
 
 Complete the following REQUIRED checkboxes:
--   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
+-   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
 -   [ ] The title of this issue follows the `location for request: brief description of request` format, e.g. `NodeJS course: Add lessons on XYZ`
 
 The following checkbox is OPTIONAL:
@@ -19,8 +19,8 @@ The following checkbox is OPTIONAL:
 <hr>
 
 **1. Description of the Feature Request:**
-<!-- 
-A clear and concise description of what the feature or enhancement is, including how it would be useful/beneficial or what problem(s) it would solve. 
+<!--
+A clear and concise description of what the feature or enhancement is, including how it would be useful/beneficial or what problem(s) it would solve.
 -->
 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,7 @@ Closes #XXXXX
 
 ## Pull Request Requirements
 <!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
--   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
+-   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
 -   [ ] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
 -   [ ] The `Because` section summarizes the reason for this PR
 -   [ ] The `This PR` section has a bullet point list describing the changes in this PR

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Our community can be found on the [TOP Discord server](https://discord.gg/fbFCkY
 
 ## Contributing
 
-The Odin Project depends on open-source contributions to improve, grow, and thrive. We welcome contributors of all experience levels and backgrounds to help maintain this awesome curriculum and community. If you would like to contribute to our curriculum, be sure to thoroughly read our [contributing guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md) in our main TOP repo.
+The Odin Project depends on open-source contributions to improve, grow, and thrive. We welcome contributors of all experience levels and backgrounds to help maintain this awesome curriculum and community. If you would like to contribute to our curriculum, be sure to thoroughly read our [contributing guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md) in our .github repo.
 
 Some of the things you can do to contribute to our curriculum include:
 * Correct typos and other grammar errors.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Our community can be found on the [TOP Discord server](https://discord.gg/fbFCkY
 
 ## Contributing
 
-The Odin Project depends on open-source contributions to improve, grow, and thrive. We welcome contributors of all experience levels and backgrounds to help maintain this awesome curriculum and community. If you would like to contribute to our curriculum, be sure to thoroughly read our [contributing guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md) in our .github repo.
+The Odin Project depends on open-source contributions to improve, grow, and thrive. We welcome contributors of all experience levels and backgrounds to help maintain this awesome curriculum and community. If you would like to contribute to our curriculum, be sure to thoroughly read our [contributing guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md).
 
 Some of the things you can do to contribute to our curriculum include:
 * Correct typos and other grammar errors.

--- a/git/intermediate_git/using_git_in_the_real_world.md
+++ b/git/intermediate_git/using_git_in_the_real_world.md
@@ -22,7 +22,7 @@ The key players in this story will be the `upstream` (the original GitHub reposi
 
 #### Initial Setup
 
-1. Read [the contributing guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md) for the project.
+1. Read [the contributing guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md) for the project.
 2. Fork the original ("upstream") repository into your own GitHub account by using the "fork" button at the top of that repo's page on GitHub.
 3. Clone your forked repository onto your local machine using something like `git clone git@github.com:your_user_name_here/curriculum.git` (you can get the url from the little widget on the sidebar on the right of that repo's page on GitHub).
 4. Because you cloned the repository, you've already got a remote that points to `origin`, which is your fork on GitHub.  You will use this to push changes back up to GitHub.  You'll also want to be able to pull directly from the original repository on GitHub, which we'll call `upstream`, by setting it up as another remote.  Do this by using `git remote add upstream git@github.com:TheOdinProject/curriculum.git` inside the project folder `curriculum`.


### PR DESCRIPTION
## Because
- We are centralizing to https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md as the single source of truth for CONTRIBUTING.md


## This PR
- Changes all https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md links to https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md


## Issue

Part of TheOdinProject/theodinproject#3901

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section