### PR TITLE
"Organizing Your Javascript Code Introduction" lesson (additional resources): Link to book "YDKJS" refers to 1st (archived) edition of the book

### DIFF
--- a/javascript/organizing_your_javascript_code/organizing_your_javascript_code_introduction.md
+++ b/javascript/organizing_your_javascript_code/organizing_your_javascript_code_introduction.md
@@ -19,5 +19,5 @@ Going through these will give us a chance to learn about a few other important c
 
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
-- The book [You Don't Know JS (YDKJS)](https://github.com/getify/You-Dont-Know-JS/tree/1st-ed#titles) is free on GitHub, and explains how Javascript works "under the hood". If you ever wondered why JavaScript works the way it does, this book is for you!
+- The book [You Don't Know JS (YDKJS)](https://github.com/getify/You-Dont-Know-JS/tree/2nd-ed) is free on GitHub, and explains how Javascript works "under the hood". If you ever wondered why JavaScript works the way it does, this book is for you!
 - [Namaste JavaScript](https://youtube.com/playlist?list=PLlasXeu85E9cQ32gLCvAvr9vNaUccPVNP) is a free JavaScript playlist which will definitely make you fall in love with the beauty of JavaScript. The concepts are very well explained and you get to know how things work behind the scenes.


### PR DESCRIPTION
## Because
The link to the "You Don't Know JS" book (lesson: "Organizing Your Javascript Code Íntroduction") is refering to the 1st and now archived version of the book.

## This PR
Switches the link so it refers directly to the 2nd and newest edition of the book

## Issue
I couldn't find an open issue to this PR.

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR