### PR TITLE
Git Basics: Fix a typo

### DIFF
--- a/git/foundations_git/git_basics.md
+++ b/git/foundations_git/git_basics.md
@@ -212,4 +212,4 @@ This section contains questions for you to check your understanding of this less
 This section contains helpful links to related content. It isn’t required, so consider it supplemental.
 
 -   [Complete Git and GitHub Tutorial from Basics to Advance](https://www.youtube.com/watch?v=apGV9Kg7ics) -  by Kunal Kushwaha
--   [Git-Referance](https://git-scm.com/docs)
+-   [Git - Reference](https://git-scm.com/docs)


### PR DESCRIPTION
## Because
There is a typo in the "Additional Resources" section of `git_basics.md`, where "Git-Referance" should be corrected to "Git - Reference".


## This PR

- Fixed the typo in git_basics.md by changing "Git-Referance" to "Git - Reference".


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
