### PR TITLE
Fix missing {} around animal

### DIFF
--- a/react/getting_started_with_react/rendering_techniques.md
+++ b/react/getting_started_with_react/rendering_techniques.md
@@ -52,7 +52,7 @@ We define an array called `animals`. Now inside our JSX, we use `map` to return 
 ~~~javascript
 function App() {
   const animals = ["Lion", "Cow", "Snake", "Lizard"];
-  const animalsList = animals.map((animal) => <li key={animal}>animal</li>)
+  const animalsList = animals.map((animal) => <li key={animal}>{animal}</li>)
   
   return (
     <div>


### PR DESCRIPTION
## Issue:
Missing {} around the word _animal_ in the .map function.

This will cause it to return the string "animal" for each item in the array.

----

The existing code will produce this:

### Animals:
- animal
- animal
- animal
- animal