### PR TITLE
Express and mongoose: correct headers to sentence case

### DIFF
--- a/nodeJS/express_and_mongoose/deployment.md
+++ b/nodeJS/express_and_mongoose/deployment.md
@@ -6,7 +6,7 @@ Whether it's to share our creations with friends, create a portfolio for future 
 
 In this lesson, we will learn how to deploy our apps to a hosting provider, allowing us to run, build, and operate our web applications in the cloud.
 
-### Lesson Overview
+### Lesson overview
 
 This section contains a general overview of topics that you will learn in this lesson.
 
@@ -16,13 +16,13 @@ This section contains a general overview of topics that you will learn in this l
 - Know how to deploy to a PaaS provider
 - Know how to troubleshoot common deployment issues
 
-### What are Hosting Providers?
+### What are hosting providers?
 
 Hosting providers are like server landlords. They own servers and rent space on them to customers, who can then use the space to store their websites and make them accessible to anyone on the web.
 
 You've already had some experience using a hosting provider when you deployed projects to Github pages earlier in the curriculum. GitHub pages is great for hosting **static** web pages for free, but we won't be able to use it for hosting our **dynamic** NodeJS apps. We're going to need something more powerful.
 
-### Static vs Dynamic Sites
+### Static vs dynamic sites
 
 Static websites consist of pre-written HTML pages. They are "static" because everyone who visits them will see the same content. To build static sites, you only need HTML, CSS and Javascript.
 
@@ -67,7 +67,7 @@ With NodeJS, we will be using MongoDB, a popular open-source database. Many PaaS
 
 Either choice isn't too difficult to setup, but it's always nice to have a fallback option! Later in this course, we will be following the MDN tutorial's instructions on deploying both our app and database connection to Railway. For now, we encourage you to try and figure out how to deploy your mini-message board project with just what you learn in this lesson. However, If you're having too much trouble, don't fret. Just come back to it later once you've finished the MDN tutorial and have that bit of deployment experience under your belt.
 
-#### Domain Names
+#### Domain names
 
 PaaS providers will give you a random domain name when you first deploy. In Heroku's case, it's usually something zen-like "afternoon-falls-4209". If you want to visit the app, you can go directly to `http://afternoon-falls-4209.herokuapp.com` to see your app live on the web in all its glory.
 
@@ -79,7 +79,7 @@ To find a new domain, try using [Domainr](https://domainr.com/).
 
 Once you have your domain, you need to point it to your project. The provider you are using will have exhaustive documentation on using custom domain names on their platform.
 
-### Our Recommended PaaS Services
+### Our recommended PaaS services
 
 Choosing a PaaS provider was once a simple decision. Heroku had a free tier that gave you everything needed to host as many small app's as you wanted, but they unfortunately discontinued it in 2022.
 
@@ -170,7 +170,7 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 
 ---
 
-### Debugging and Troubleshooting Deployments
+### Debugging and troubleshooting deployments
 
 Errors are an inevitable part of the software development process. They especially have a habit of popping up when deploying to a new environment like a hosting provider. When this happens, the key is not to panic and to follow a calm, step-by-step debugging process.
 
@@ -178,7 +178,7 @@ In most cases, you'll be running into errors that thousands of developers have e
 
 There are two stages of the deployment process where you are most likely to encounter problems. These are during deployment and right after.
 
-#### On Deployment
+#### On deployment
 
 If you run into an error while deploying, the first thing to do is to check the build logs. Finding the build logs should be easy; it's the stream of output you'll see after kicking off a new deployment.
 
@@ -188,7 +188,7 @@ If you don't recognize the error or what might cause it, your next step will be 
 
 Most of the errors you'll face during this stage will be related to properly setting up your app with what your hosting provider needs. Double-checking the deployment guide for your hosting provider is always a good place to start. It's very easy to miss a step or mistype something.
 
-#### After Deployment
+#### After deployment
 
 You've just deployed your app successfully; everything is going your way, and this will be a great day! However, when you visit your app... you are greeted with the dreaded 500 page.
 
@@ -206,7 +206,7 @@ As your application grows, you'll want to get more sophisticated with your error
 
 These services will give you more information about the error and the request that caused it, saving you a ton of time. However, setting up and using these services are out of the scope of this lesson. You can get by just fine with the logs for your first few apps.
 
-#### One Final Tip
+#### One final tip
 
 If something has broken in your latest deployment after successful deployments in the past, backtrack to the last working version to determine what changes you made and slowly reintroduce those changes again if you need to.
 
@@ -225,7 +225,7 @@ This will be where the Git skills you've been learning will start to really pay 
 
 </div>
 
-### Knowledge Check
+### Knowledge check
 
 This section contains questions for you to check your understanding of this lesson on your own. If you're having trouble answering a question, click it and review the material it links to.
 
@@ -236,7 +236,7 @@ This section contains questions for you to check your understanding of this less
 - [What steps can you take to diagnose an issue that arises during deployment?](#on-deployment)
 - [What steps can you take to diagnose an issue that only appears after deployment?](#after-deployment)
 
-### Additional Resources
+### Additional resources
 
 This section contains helpful links to related content. It isn't required, so consider it supplemental.
 

--- a/nodeJS/express_and_mongoose/express_101.md
+++ b/nodeJS/express_and_mongoose/express_101.md
@@ -1,7 +1,7 @@
 ### Introduction
 In the last lesson, we set the stage by explaining quite a bit of the background information you'll need to really understand what's going on as we start to dive into Express. This lesson will actually start you on the project that you'll be completing as you follow the tutorial.
 
-### Learning Outcomes
+### Learning outcomes
 By the end of this lesson, you should be able to do the following:
 
  - Use `express-generator` to generate a basic express site.
@@ -10,7 +10,7 @@ By the end of this lesson, you should be able to do the following:
  - Understand what Middleware is.
  - Understand `req`, `res` and `next` in the context of middleware.
 
-### Templating Engines
+### Templating engines
 
 A templating engine is a tool that allows you to insert variables and simple logic into your views. For instance, you could have a header that updates with the actual user's name once they've logged in, something that is not possible with plain HTML. As the lesson mentions, there are several templating languages available for JavaScript.  The tutorial uses [Pug (formerly known as Jade)](https://pugjs.org) which has a bit of a learning curve because it looks and feels dramatically different from regular HTML. If you've ever worked with Ruby on Rails you might be more comfortable with [ejs](https://ejs.co), which is _very_ similar to `erb`.
 
@@ -18,11 +18,11 @@ It's up to you which you choose! If you choose not to use Pug you will still be 
 
 ### Middleware
 
-This step of the MDN tutorial mentions middleware, but does not clearly define it. Middleware is a complicated word for a simple concept. <span id='middleware'>A middleware is just a plain JavaScript function that Express will call for you between the time it receives a network request and the time it fires off a response (i.e. it's a function that sits in the _middle_)</span>. You will eventually be using several of these functions that will run in a specific sequence for every request. 
+This step of the MDN tutorial mentions middleware, but does not clearly define it. Middleware is a complicated word for a simple concept. <span id='middleware'>A middleware is just a plain JavaScript function that Express will call for you between the time it receives a network request and the time it fires off a response (i.e. it's a function that sits in the _middle_)</span>. You will eventually be using several of these functions that will run in a specific sequence for every request.
 
 For example, you might have a logger (that prints details of the request to the console), an authenticator (that checks to see if the user is logged in, or otherwise has permission to access whatever they're requesting) and a static-file server (if the user is requesting a static file then it will send it to them). All of these functions will be called in the order you specify every time there's a request on the way to your `app.get("/")` function.
 
-It is possible and common to write your own middleware functions (you'll be doing that later) so let's take a minute to demystify what they're actually doing. Middleware functions are just plain JavaScript functions with a specific function signature (that is, it takes a specific set of arguments in a specific order). You've actually already seen it! 
+It is possible and common to write your own middleware functions (you'll be doing that later) so let's take a minute to demystify what they're actually doing. Middleware functions are just plain JavaScript functions with a specific function signature (that is, it takes a specific set of arguments in a specific order). You've actually already seen it!
 
 The three middleware function arguments are: `req`, `res`, and `next`. Technically, these are just variables, so you could call them anything, but convention (and the express documentation) almost always give them these names.
 
@@ -35,7 +35,7 @@ function(req, res, next) {
 ~~~
 
 When someone visits your site, their web-browser sends a request to your server. Express takes that request and passes it through all of the middleware functions that you have defined and used in your project.  Each function is defined with these parameters which might seem familiar to you from the plain Node tutorial that you went through in the 'Getting Started' lesson.  Technically, `req` and `res` are _almost_ the same here as they are in vanilla Node, but Express enhances them by adding a few useful properties and methods to them.
- 
+
  <span id='req'>`req`</span> or `request` is an object that has data about the incoming request such as the exact URL that was visited, any parameters in the URL, the `body` of the request (useful if the user is submitting a form with some data in it) and many other things.
 
  - You can see everything it includes in the [express docs](https://expressjs.com/en/4x/api.html#req).
@@ -55,7 +55,7 @@ const myLogger = function(req, res, next) {
   console.log("Request IP: " + req.ip);
   console.log("Request Method: " + req.method);
   console.log("Request date: " + new Date());
-  
+
   next(); // THIS IS IMPORTANT!
 }
 
@@ -79,7 +79,7 @@ As you work through this tutorial, make sure to put the `node_modules` folder in
 3. For a little more detail on the nature of middleware read the official documentation [here](http://expressjs.com/en/guide/using-middleware.html).
 </div>
 
-### Knowledge Check 
+### Knowledge check
 This section contains questions for you to check your understanding of this lesson. If you're having trouble answering the questions below on your own, review the material above to find the answer.
 
 - <a class='knowledge-check-link' href='#middleware'>What is middleware?</a>
@@ -88,7 +88,7 @@ This section contains questions for you to check your understanding of this less
 - <a class='knowledge-check-link' href='#next'>Why is `next` important?</a>
 - <a class='knowledge-check-link' href='#app-use'>What does `app.use` do?</a>
 
-### Additional Resources
+### Additional resources
 
 This section contains helpful links to related content. It isn't required, so consider it supplemental.
 

--- a/nodeJS/express_and_mongoose/express_103_routes_and_controllers.md
+++ b/nodeJS/express_and_mongoose/express_103_routes_and_controllers.md
@@ -3,7 +3,7 @@ The next step in the MDN express tutorial sets up all the routes and controllers
 
 If you remember from our earlier lessons, the controller is the code that sits between the models and the views. It determines which view is going to be shown, as well as which information is going to populate that view. In this lesson, you will copy and paste quite a bit of repetitive code to get the controllers and routes set up, but be sure to read everything in between them! There is a _lot_ of useful information therein.
 
-### Learning Outcomes
+### Learning outcomes
 
 By the end of this lesson, you should be able to do the following:
 
@@ -20,7 +20,7 @@ By the end of this lesson, you should be able to do the following:
 1. Continue where we left off with part 4 of the [Express tutorial](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/routes)
 </div>
 
-### Knowledge Check
+### Knowledge check
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
 - <a class='knowledge-check-link' href='https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/routes#defining_and_using_separate_route_modules'>How do you define a route function in Express?</a>
@@ -29,7 +29,7 @@ This section contains questions for you to check your understanding of this less
 - <a class='knowledge-check-link' href='https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/routes#create_the_route-handler_callback_functions'>What is a route-handler callback function commonly called?</a>
 
 
-### Additional Resources
+### Additional resources
 
 This section contains helpful links to related content. It isn't required, so consider it supplemental.
 

--- a/nodeJS/express_and_mongoose/express_104_view_templates.md
+++ b/nodeJS/express_and_mongoose/express_104_view_templates.md
@@ -2,7 +2,7 @@
 
 This lesson is fun! You'll be setting up several views, and you'll start to see your Application come together. We'll finally get to see our data showing up in the browser!  This is a long lesson that is broken up into several sub-lessons, so make sure you click through to see them all.
 
-### Learning Outcomes
+### Learning outcomes
 
 By the end of this lesson, you should be able to do the following:
 
@@ -26,7 +26,7 @@ By the end of this lesson, you should be able to do the following:
 
 </div>
 
-### Additional Resources
+### Additional resources
 
 This section contains helpful links to related content. It isn't required, so consider it supplemental.
 

--- a/nodeJS/express_and_mongoose/introduction_to_express.md
+++ b/nodeJS/express_and_mongoose/introduction_to_express.md
@@ -3,7 +3,7 @@ In the previous lessons, you got up and running with Node. You learned how to se
 
 In this section, we are going to be following the [express tutorial](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs) on MDN.  We'll go one lesson at a time, occasionally supplementing with a little deeper explanation or side projects to help you deepen your understanding of the material. There is a *ton* of information there, so be sure to take your time and READ EVERYTHING. The blue "notes" that are scattered throughout the tutorial often link to articles or other tutorials that will definitely improve your understanding of the content. Don't be lazy!
 
-### Learning Outcomes
+### Learning outcomes
 By the end of this lesson, you should be able to do the following:
 
 #### Express web framework
@@ -31,18 +31,18 @@ By the end of this lesson, you should be able to do the following:
 1. Read the [introductory lesson](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/Introduction) on the MDN website.  It is long but its main purpose is to show you the various bits and pieces that you'll be learning in the rest of the tutorial.  If you want you can code along a bit, but most of the examples aren't really intended for you to follow 100%.
 *DO* read the entire thing!  Some of it will be a review, but that's OK! Follow the links that they give and at least look at them.  They are a vital part of this lesson and will often direct you to the relevant portion of the official express docs (which are quite good)! You'll want to be somewhat familiar with them when it comes time to do your own projects.
 2. The [second lesson in MDN's Express tutorial](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/development_environment#using_npm)  walks you through setting up Node and NPM. If you've come this far, you should already have both set up. Still go through the Using NPM and Installing the Express Application Generator sections of this lesson as you'll learn more about installing and getting started with Express.
-3. Once you're all set up, take a look at the simple Node site you created in our first project. Rewrite it using express! You should be able to do this with just one app.js file and a few `app.get()`s. 
+3. Once you're all set up, take a look at the simple Node site you created in our first project. Rewrite it using express! You should be able to do this with just one app.js file and a few `app.get()`s.
 </div>
 
 
-### Additional Resources
+### Additional resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
 - The book [Express in Action](https://www.manning.com/books/express-in-action?a_bid=fe3fcff7&a_aid=express-in-action) by Evan M. Hahn is an incredible resource for Express beginners.
 - [This](https://www.youtube.com/watch?v=L72fhGm1tfE) video crash course provides you with all the basic concepts.
 - Web Dev Simplified's [Express JS crash course](https://www.youtube.com/watch?v=SccSCuHhOw0&ab_channel=WebDevSimplified) also packs a ton of great information into a 35 minute video.
 
-### Knowledge Check
+### Knowledge check
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
 - <a class='knowledge-check-link' href="https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/Introduction#introducing_express" title="Permalink to Introducing Node"> What is Express?</a>

--- a/nodeJS/express_and_mongoose/project_express_105_forms_and_deployment.md
+++ b/nodeJS/express_and_mongoose/project_express_105_forms_and_deployment.md
@@ -6,7 +6,7 @@ It's another long multi-part tutorial, with plenty of useful information scatter
 
 This is the last lesson on the MDN tutorial. The last step, listed below takes you through what you need to do to actually deploy your project so you can share it and show it off, so be sure to link it up in the student solutions below!
 
-### Learning Outcomes
+### Learning outcomes
 
 By the end of this lesson, you should be able to do the following:
 


### PR DESCRIPTION

## Because
- the style guide mandates sentence case for headings


## This PR
- corrects the headings in the Express and Mongoose course to sentence case.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
