### PR TITLE
Document existence of note boxes

### DIFF
--- a/LAYOUT_STYLE_GUIDE.md
+++ b/LAYOUT_STYLE_GUIDE.md
@@ -18,7 +18,7 @@ TOP uses Markdown for the layout and formatting of lesson and project files to g
 1. [Newlines](#newlines)
 1. [Lists](#lists)
 1. [Code](#code)
-1. [Note boxes](#notes)
+1. [Note boxes](#note-boxes)
 1. [Links](#links)
 1. [Images](#images)
 1. [Keyboard shortcuts](#keyboard-shortcuts)
@@ -379,16 +379,31 @@ Will result in the following output:
 
 - Next bullet.
 
-## Notes
+## Note boxes
 
-Notes can be added by wrapping the note in a `div` with class `lesson-note`. This will render the note into a box. Optionally you can add a header to the note; please wrap the header in a `h4`.
+Note boxes can be added by wrapping the content in a `div` with the class `lesson-note`. This will add styling to make the note stand out visually to users.
+
+A heading can be added to a note by using an `h4` element. When adding a heading, be sure to provide text that helps describe the note rather than "A note" or "Warning".
 
 ### Variations
 
-Notes come in several variation, which can be set by adding an extra class together with `lesson-note`. Options are:
-- `lesson-note--tip` for tips
-- `lesson-note--warning` for warnings about potential issues/pitfalls.
+Note boxes come in two variations, which can be set by adding an extra class together with `lesson-note`:
+- `lesson-note--tip` for tips or general information
+- `lesson-note--warning` for warnings about potential issues/pitfalls, and are more severe than a tip
 
+### Example
+~~~markdown
+<div class="lesson-note">
+<h4>An optional title</h4>
+A sample note box.
+</div>
+~~~
+~~~markdown
+<div class="lesson-note lesson-note--tip">
+<h4>An optional title</h4>
+A sample note box, variation: tip.
+</div>
+~~~
 ## Links
 
 Long links make source Markdown difficult to read and break the 80 character wrapping. **Wherever possible, shorten your links**.

--- a/LAYOUT_STYLE_GUIDE.md
+++ b/LAYOUT_STYLE_GUIDE.md
@@ -404,6 +404,7 @@ A sample note box.
 A sample note box, variation: tip.
 </div>
 ~~~
+
 ## Links
 
 Long links make source Markdown difficult to read and break the 80 character wrapping. **Wherever possible, shorten your links**.

--- a/LAYOUT_STYLE_GUIDE.md
+++ b/LAYOUT_STYLE_GUIDE.md
@@ -18,6 +18,7 @@ TOP uses Markdown for the layout and formatting of lesson and project files to g
 1. [Newlines](#newlines)
 1. [Lists](#lists)
 1. [Code](#code)
+1. [Note boxes](#notes)
 1. [Links](#links)
 1. [Images](#images)
 1. [Keyboard shortcuts](#keyboard-shortcuts)
@@ -378,6 +379,16 @@ Will result in the following output:
 
 - Next bullet.
 
+## Notes
+
+Notes can be added by wrapping the note in a `div` with class `lesson-note`. This will render the note into a box. Optionally you can add a header to the note; please wrap the header in a `h4`.
+
+### Variations
+
+Notes come in several variation, which can be set by adding an extra class together with `lesson-note`. Options are:
+- `lesson-note--tip` for tips
+- `lesson-note--warning` for warnings about potential issues/pitfalls.
+
 ## Links
 
 Long links make source Markdown difficult to read and break the 80 character wrapping. **Wherever possible, shorten your links**.
@@ -417,19 +428,19 @@ Example code which will be rendered as: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kb
 
 ```html
 <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>?</kbd>
-``` 
+```
 
 ### Style standardization
 
 - Use separate `<kbd>` elements for individual keys:
 
-  ~~~markdown 
+  ~~~markdown
   <kbd>Ctrl</kbd> + <kbd>Shift</kbd>
   ~~~
 
 - Use capitalized common abbreviations for the keys and avoid using symbols like `⌘`:
 
-  ~~~markdown 
+  ~~~markdown
   <kbd>Cmd</kbd>
   <kbd>Alt</kbd>
   <kbd>B</kbd>
@@ -438,7 +449,7 @@ Example code which will be rendered as: <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kb
 
 - Use symbols for character keys instead of spelling out the symbol like `period`:
 
-  ~~~markdown 
+  ~~~markdown
   <kbd>.</kbd>
   <kbd>,</kbd>
   <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>?</kbd>


### PR DESCRIPTION
## Because
- Currently the note boxes are only documented in the templates


## This PR
- Also adds them to the Layout Style Guide


## Issue
Closes #25744 

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
