### PR TITLE
Foundations Introduction: Format headings with sentence case

### DIFF
--- a/foundations/README.md
+++ b/foundations/README.md
@@ -3,11 +3,11 @@ This is where it all begins! A hands-on introduction to all of the essential too
 ## The Outline
 
 - Introduction
-  - How this Course Will Work - [lesson](introduction/how_this_course_will_work.md)
-  - Introduction to Web Development - [lesson](introduction/introduction_to_web_development.md)
-  - Motivation and Mindset - [lesson](introduction/motivation_and_mindset.md)
-  - Asking For Help - [lesson](introduction/asking_for_help.md)
-  - Join the Odin Community - [lesson](introduction/join_the_odin_community.md)
+  - How this course will work - [lesson](introduction/how_this_course_will_work.md)
+  - Introduction to web development - [lesson](introduction/introduction_to_web_development.md)
+  - Motivation and mindset - [lesson](introduction/motivation_and_mindset.md)
+  - Asking for help - [lesson](introduction/asking_for_help.md)
+  - Join the Odin community - [lesson](introduction/join_the_odin_community.md)
 - Prerequisites
   - Computer Basics - [lesson](installations/computer_basics.md)
   - How Does the Web Work? - [lesson](installations/how_does_the_web_work.md)

--- a/foundations/introduction/how_this_course_will_work.md
+++ b/foundations/introduction/how_this_course_will_work.md
@@ -12,7 +12,7 @@ By the end of this unit, you should not only understand how the web works but al
 
 This section intentionally covers a very broad range of topics. It's silly to go diving straight into server-side programming without having a context for what it is and why it's useful (and why you should learn it!).
 
-### How It Works
+### How it works
 
 This curriculum works by pulling together the best content from across the internet for learning a particular topic.  In each lesson, we'll introduce the topic and try to provide some useful context before pointing you to external resources made by others.
 
@@ -20,7 +20,7 @@ Most lessons will contain questions that you should be able to answer before mov
 
 Try not to think of The Odin Project, or programming, as a class in school. It's not material you learn all at once to take a test, and then pass or fail. You can think of it as a snowball. You, yourself, are a snowball. You're rolling down a hill full of snow; the further you roll, the more snow will stick to you. Sure, snow will also fall off you, and you'll forget things often, but that's just part of the process. Don't be scared if you get to a project and you feel like you haven't retained or memorized anything. That's natural and happens to everyone. The information will come back to you as you start solving your problems one at a time, relying on Google and the Odin Community for help.
 
-### A Note About Language
+### A note about language
 
 The Odin Project attracts people from all over the world who aspire to learn how to become developers. Please be aware that this curriculum is written in English and maintained by English speakers who are not able or expected to translate it for you. As you develop into a programmer, you will find that the world you are entering into is firmly rooted in the English language. This means that the syntax of your programming language, the documentation that teaches you how to use it, and the majority of the people in the community are all expecting to communicate with you in English.
 
@@ -30,7 +30,7 @@ As another part of this preparation, we *highly* recommend spending extra time o
 
 In addition to this, you might also consider using a translation dictionary in your own language alongside our curriculum so you can readily reference it as you go. We do not have any recommendations on these since there are such a wide variety of languages spoken throughout the world, finding one may perhaps be a good first step in learning how to find useful tools online by searching. This is a skill you will utilize and improve as you progress in your learning to be a developer.
 
-### What Comes Next
+### What comes next
 
 Once you've completed this course, you should feel comfortable with the building blocks of web programming but itching to dig deeper.  Though we spend a fair bit of time digging into each of the major topics in this course, it's really just a taste of what comes next (and all the cool stuff you can do with it).
 
@@ -45,7 +45,7 @@ Additional resources are the only thing that is considered optional unless expli
 
 **DO NOT SKIP ANYTHING!** 
 
-### Additional Resources
+### Additional resources
 
 This section contains helpful links to related content. It isn’t required, so consider it supplemental.
  

--- a/foundations/introduction/introduction_to_web_development.md
+++ b/foundations/introduction/introduction_to_web_development.md
@@ -10,7 +10,7 @@ Web developers are in high demand, generally have a good work/life balance, and 
 
 For more details, Wikipedia describes the breadth of the web development profession in their [entry on web design](https://en.wikipedia.org/wiki/Web_design).
 
-### Types of Web Developers
+### Types of web developers
 
 Earlier, we mentioned that web development work could be in the front end, the back end, or the full stack. What exactly do these terms mean?
 
@@ -24,7 +24,7 @@ Back-end developers use programming languages like Java, Python, Ruby, and JavaS
 
 For more detail, Udacity has a great blog post on this topic: [3 Web Dev Careers Decoded: Front-End vs Back-End vs Full Stack](https://www.udacity.com/blog/2020/12/front-end-vs-back-end-vs-full-stack-web-developers.html)
 
-### Types of Careers
+### Types of careers
 
 Now that you know about the different types of web developers, let's cover what we mentioned earlier about the different types of clients and employers you may work with.
 
@@ -38,7 +38,7 @@ As a consultant for a web consultancy, you would give up some of your freelancin
 
 Finally, large, older companies still need web developers. These companies offer a good work/life balance, pay, and benefits but often move slower than a company that is highly focused on tech.
 
-### Tools of the Trade
+### Tools of the trade
 
 These are some of the basic tools you will use regularly. You may not know what they are now, but you most certainly will going forward.
 
@@ -89,7 +89,7 @@ And it might even be life changing, too.
 
 *What are you waiting for?*
 
-### Additional Resources
+### Additional resources
 
 This section contains helpful links to related content. It isn’t required, so consider it supplemental.
 

--- a/foundations/introduction/join_the_odin_community.md
+++ b/foundations/introduction/join_the_odin_community.md
@@ -2,7 +2,7 @@
 
 Working and collaborating with other people is an important part of working as a web developer. Therefore, we at The Odin Project encourage you to participate in our online chat community, which we'll talk more about below. By joining the community, you can grow alongside other Odinites and help each other learn web development. While you're at it, you can check out our [Facebook page](https://www.facebook.com/theodinproject/), [follow us on Twitter](https://twitter.com/TheOdinProject) and catch up on [Instagram](https://www.instagram.com/theodinproject/). Use #TheOdinProject to share your Odin Project progress, updates, thoughts and to see what other Odin students are up to!
 
-### Why a Community Is Awesome for You
+### Why a community is awesome for you
 
 Learning web development will be a long and arduous journey, but you can make the marathon a lot more fun by getting involved in our Discord community. No matter what pace you are doing our curriculum, there will always be people a few steps ahead of you that are willing to help. Furthermore, helping others that are a few steps behind you is a great way to deepen your own understanding and make your learning stick.
 
@@ -10,11 +10,11 @@ When you're slogging through the [desert of despair](https://www.thinkful.com/bl
 
 Remember that project you struggled so hard to figure out and that you're so proud of finishing? Through our community, you will get to share your work and progress with those who fully appreciate how much hard work went into it.
 
-### Why a Community Is Awesome for Odin
+### Why a community is awesome for Odin
 
 We are working hard to update existing lessons and produce new content, so we would love to hear your feedback on the lessons and projects. We hope you find the lessons fun, engaging, and informative and find the projects challenging but achievable. So please let us know your thoughts!
 
-### Before Asking for Help
+### Before asking for help
 
 As most of the projects are designed to push you to your limit, please remember that there is always a community to turn to! You don't need to know how to solve every problem straight away, BUT you do need to have a general idea of where you are going. This becomes really important when asking your questions because sometimes the problem is your **approach** and not your code.
 
@@ -24,7 +24,7 @@ You should also do a [Google search](https://www.google.com/) to find relevant i
 
 If these methods don't yield a solution for you, then it's time to reach out to the Odin community and ask for help.
 
-### Asking for Help
+### Asking for help
 
 So you've spent some time struggling to solve the problem on your own, and now it's time to fire up the Odin Discord and ask for help. The first thing to keep in mind is [don't ask to ask](https://dontasktoask.com/). While this is a simple idea (with a pretty catchy motto!), it can help you get answers to your questions much faster and will make it easier to others to feel comfortable offering you help.
 
@@ -44,7 +44,7 @@ Screenshots are great for showing the output of commands or error messages in th
 
 Sometimes there might be no one around to help you with your issue. That is the ideal time to get familiar with the [Discord search function](https://support.discordapp.com/hc/en-us/articles/115000468588-Using-Search). Search for specific keywords or error messages to see if anyone else had a similar issue before and how they solved it!
 
-### Formatting Your Questions
+### Formatting your questions
 
 Asking your questions in a readable format helps everyone debug them better. Here are some ways to go about that:
 
@@ -72,7 +72,7 @@ Your Multiple Lines of Colorful Code
 
 \`\`\`
 
-### Chat Features
+### Chat features
 
 *   Have fun with giphys: type `/giphy hi` to say hi to everyone.
 *   Type `!help` for more information on chat commands.
@@ -80,49 +80,49 @@ Your Multiple Lines of Colorful Code
 *   Don't forget to visit all the available rooms!
 
 
-### How to Help Others Solve Coding Problems
+### How to help others solve coding problems
 
 Not only is it important to know how to ask an effective question, it is also important to know how to help others effectively. Please take a moment to review these guidelines so that you will have proper expectations of the help you will receive in our Discord community. In addition, come back and review these guidelines when you are ready to start helping others.
 
-#### 1.  Instead of Answering the Question, Guide Them to the Answer
+#### 1.  Instead of answering the question, guide them to the answer
 
 Unless the problem is a simple typo or syntax error, it is more beneficial to guide them to find their own answer. This approach will teach good debugging skills and will increase their ability to solve future problems.
 
 Start by asking probing questions, such as "What have you already tried?", “What do you expect this function to do?”, or “What do you think that error means?”.
 
-#### 2.  Help Only When You Are Certain of the Answer
+#### 2.  Help only when you are certain of the answer
 
 If you are not 100% certain of the answer, you may end up doing more harm than good, so please let someone else answer it.
 
 Do not worry about how long someone has to wait for an answer. The right answer is worth the wait.
 
-#### 3.  Help Only When No One Else Is Currently Helping
+#### 3.  Help only when no one else is currently helping
 
 If somebody is already getting help, do not jump in the middle of the conversation. We know you mean well, but it is overwhelming for the person receiving help to follow multiple conversations. 
 
-#### 4.  Help Only When You Have Plenty of Time
+#### 4.  Help only when you have plenty of time
 
 If you do not have much time to help, please let someone else answer the question.
 
-#### 5.  Adjust Your Expectations to Their Level
+#### 5.  Adjust your expectations to their Level
 
 If the question does not reveal where they are in the curriculum, ask them so that you can adjust your expectations to their knowledge level.
 
-#### 6.  Ask for Clarifications
+#### 6.  Ask for clarifications
 
 If the question seems confusing or ambiguous, ask for more clarity, or politely link them to our bot command `!question`, which links to the [How to be great at asking coding questions](https://medium.com/@gordon_zhu/how-to-be-great-at-asking-questions-e37be04d0603) article.
 
-#### 7.  Ask for Live Code
+#### 7.  Ask for live code
 
 If the question needs to have live code to fully understand or debug, ask them to use [replit](https://replit.com) to provide it. If the problem is difficult to isolate, they should recreate the problem with isolated code.
 
-#### 8.  Do Not Answer Googleable Questions
+#### 8.  Do not answer googleable questions
 
 Learning how to research these questions is a very important skill for developers, so we need to empower them to find their own answer. When we answer these questions, it hinders their personal growth and makes them codependent on our community. 
 
 Instead of answering these questions, politely ask them to google their question or use our bot command `!google` with the search terms.
 
-#### 9.  Do Not Answer Questions Covered in Our Curriculum
+#### 9.  Do not answer questions covered in our curriculum
 
 If you know that the answer is provided in our curriculum, ask them where they are at in the curriculum.
 
@@ -130,33 +130,33 @@ If they have not reached that portion of the curriculum, let them know they will
 
 If they have already been through that portion of the curriculum, politely direct to review that lesson.
 
-#### 10.  Answer the Question Before Pointing Out Other Problems
+#### 10.  Answer the question before pointing out other problems
 
 When helping someone it can be easy to spot other problems in their code. Resolve the original question, before pointing out any other problems that need attention.
 
-#### 11.  Encourage Students to Use a Debugger
+#### 11.  Encourage students to use a debugger
 
 It is common for students to not understand the importance of using a debugger to look at the values of their variables at different points in their program. When students are getting unexpected values, politely encourage them to use a debugger with our bot command `!debug`.
 
-#### 12.  Watch for Students That Need to Take a Step Back
+#### 12.  Watch for students that need to take a step back
 
 It is common for students to focus too hard on a problem and not be able to clearly see everything. When this situation arises, politely encourage them to step back from the problem and take a break. Often times, stepping away from a problem will help them see the bigger picture and how to solve it.
 
-#### 13.  Watch for Students That Are in over Their Head
+#### 13.  Watch for students that are in over their head
 
 It is common for students to skip a lesson/project or think they know more than they actually do. When this situation arises, politely encourage them to go back and reread a section of the curriculum for more understanding.
   
-#### 14.  Admit When the Problem Goes Beyond Your Current Knowledge
+#### 14.  Admit when the problem goes beyond your current knowledge
 
 It is common for the actual issue to go beyond the initial question. If it goes beyond your current knowledge, it is important to admit that you are unsure of the correct answer and let someone else help. 
 
 After digging deeper into the problem, they might be able to continue troubleshooting on their own or they can wait for someone more experienced to help.
 
-#### 15.  Be Patient
+#### 15.  Be patient
 
 Helping others solve a problem is not always easy. Remember to be patient as they struggle through the problem.
 
-#### 16.  Duck Out of the Conversation If You Get Frustrated
+#### 16.  Duck out of the conversation if you get frustrated
 
 Sometimes there are misunderstandings and interactions go poorly. You are a volunteer and are not obligated to help when things get out of hand. Politely duck out of the conversation and let someone else step up.
 
@@ -183,7 +183,7 @@ Sometimes there are misunderstandings and interactions go poorly. You are a volu
 
 </div>
 
-### Additional Resources
+### Additional resources
 
 This section contains helpful links to related content. It isn’t required, so consider it supplemental.
  

--- a/foundations/introduction/motivation_and_mindset.md
+++ b/foundations/introduction/motivation_and_mindset.md
@@ -18,7 +18,7 @@ Your motivation could be a combination of these reasons or something else entire
 To give your motivation a bit of a boost, you can read about the success of others in our discord [odin-success-stories](https://discord.com/channels/505093832157691914/1089990025162260570) channel (You need to [join the Discord server](https://discord.gg/fbFCkYabZB) first in order to see the channel).
 
 
-### Growth Mindset
+### Growth mindset
 
 Your mindset is very important when teaching yourself *any* new skills, not just programming. Your mindset will have more of an impact on your chances of success than just about anything else.
 
@@ -41,7 +41,7 @@ To learn more about the growth mindset, check out these resources:
 *   [Grit](https://ted.com/talks/angela_lee_duckworth_grit_the_power_of_passion_and_perseverance)
 *   [You can learn anything](https://www.khanacademy.org/talks-and-interviews/conversations-with-sal/a/the-learning-myth-why-ill-never-tell-my-son-hes-smart)
 
-### The Learning Process
+### The learning process
 
 Learning concepts and then practicing them will help you to more fully understand how things work and fit together. Projects are the ultimate method for ensuring that your theoretical understanding aligns with how the programming concepts and techniques actually operate.
 
@@ -59,7 +59,7 @@ You can practice this method of learning by helping others in our community.
 
 *   The Ruby Rogues have a [podcast on How to Learn](https://topenddevs.com/podcasts/ruby-rogues/episodes/131-rr-how-to-learn), which should be motivational and useful to you, so check it out for some useful thoughts on learning.
 
-### What to Do When You're Stuck
+### What to do when you're stuck
 
 You will inevitably get stuck at some point in the curriculum, perhaps due to a concept that you are having difficulty understanding or perhaps due to something not working correctly in a project. Whatever it is, use the following tools to get unstuck:
 
@@ -67,7 +67,7 @@ You will inevitably get stuck at some point in the curriculum, perhaps due to a 
 *   Take a break: Allow your diffuse learning state to work on the problem.
 *   Ask for help in our [chat](https://discord.gg/fbFCkYabZB): Come prepared with your research. People will be more willing to help you when they can see you have already put effort into trying to figure out the solution on your own.
 
-### A Note on AI Code Generation
+### A note on AI code generation
 
 As technology advances, we have seen some incredible tools emerge that can help accelerate coding capacity. One particular area that has exploded in popularity lately is the usage of Large Language Models (LLMs) and generative AIs for code completion (like GitHub Copilot) and code generation (like ChatGPT).
 
@@ -85,7 +85,7 @@ For learners that are new to programming, tools like ChatGPT or Github Copilot c
 
 We do not recommend using AI tools for your learning.
 
-### Managing Your Study Time
+### Managing your study time
 
 You will have more success with Odin by putting **consistent** time into it rather than working on it once a week. Building a habit of studying every day at a specific time and with a specific goal will ensure that you make consistent progress.
 
@@ -97,7 +97,7 @@ Deadlines cause un-needed stress. Since The Odin Project is a free and open plat
 
 Long story short: Don't worry, just go learn!
 
-### Pitfalls to Avoid
+### Pitfalls to avoid
 
 The following are some of the pitfalls that beginners often encounter when learning how to program. Try your best to avoid these.
 
@@ -113,7 +113,7 @@ To learn more about the Pomodoro Technique, read this [great article](https://me
 
 If you want to try it out, [TomatoTimer](http://tomato-timer.com/#) is an easy-to-use Pomodoro timer.
 
-#### Not Taking Breaks
+#### Not taking breaks
 
 As you get into the material, you may feel compelled to continuously study for long periods of time. It might seem like you are getting more work done at first, but this often leads to burnout, which consequently results in lower productivity.
 
@@ -132,31 +132,31 @@ What to do during your break:
 
 Read [this article](https://simpleprogrammer.com/taking-breaks-will-boost-productivity/) for more information on breaks & productivity.
 
-#### Digital Distractions
+#### Digital distractions
 
 Digital distractions are email and Facebook notifications and time-wasting websites, such as social media. These distractions break your focus and make procrastination tempting. Therefore, they should be avoided during study time.
 
 **Solution:** Turn off notifications and add a blocker to your internet to limit your time on distracting sites.
 
-#### Physical Distractions
+#### Physical distractions
 
 Physical distractions are distractions from your environment, like a TV in the background or other people talking. These distractions can be just as damaging to your focus as digital distractions.
 
 **Solution:** Find a quiet place to study where you can go to focus in your home. If that's not an option, you can use noise cancelling headphones to block out noisy distractions in your environment.
 
-#### Rabbit Holes
+#### Rabbit holes
 
 Because we cover so much material on The Odin Project and link to so many high quality courses and tools, it is easy for students to get pulled into rabbit holes by spending time trying to learn all there is to know about a subject that they aren't ready for or won't benefit them much. **We have put a lot of effort into structuring the curriculum** so that all of the important things that you need to know about web development are covered exactly when you need to know them.
 
 **Solution:** Stick to the path laid out as much as possible. Try to limit time spent going down rabbit holes as these sidetracks can really ruin your momentum.
 
-#### Comparing Yourself to Others
+#### Comparing yourself to others
 
 Students often compare themselves to others who are farther along in their coding journey or have more experience. This is a recipe for depression and frustration. 
 
 **Solution:** Only compare yourself to your past self. Have your abilities and knowledge improved from where you were last week, last month, or last year? Be proud of the progress that you've made!
 
-#### Counter Productive Note-Taking
+#### Counter productive note-taking
 
 The Odin Project does not recommend taking a lot of notes throughout your web development educational journey because it can be time-consuming and often leads to wasted effort.
 
@@ -166,7 +166,7 @@ The Odin Project does not recommend taking a lot of notes throughout your web de
 
 Learning any new skill is a journey full of speed bumps and obstacles to be overcome. We hope that the principles laid out here will put you in a much better position to succeed and get the most out of The Odin Project.
 
-### Additional Resources
+### Additional resources
 
 This section contains helpful links to related content. It isn’t required, so consider it supplemental.
 


### PR DESCRIPTION
## Because
Previously, the headings of foundations/introduction did not follow sentence case formatting and were inconsistently formatted.


## This PR
Formats all headings in the foundations/introduction lessons with sentence case as per the style guide.


## Issue
Closes #25843 

## Additional Information
None


## Pull Request Requirements
-   [X ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [X ] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [ X] The `Because` section summarizes the reason for this PR
-   [X ] The `This PR` section has a bullet point list describing the changes in this PR
-   [ X] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ X] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ X] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
