### PR TITLE
Forms and Grid sections: Update headings to follow style guide

### DIFF
--- a/intermediate_html_css/forms/form_basics.md
+++ b/intermediate_html_css/forms/form_basics.md
@@ -6,14 +6,14 @@ You need to specify the proper types of inputs for each possible data item since
 
 In this lesson, we will explore the basics of HTML forms and some of the different types of inputs available to you.
 
-### Learning Outcomes
+### Learning outcomes
 
 By the end of this lesson, you should be able to:
 
 - Create forms with HTML
 - Have a basic idea of how to style forms
 
-### The Form Element
+### The form element
 
 The form element is a container element like the div element we learned earlier in the curriculum. The form element wraps all of the inputs a user will interact with on a form.
 
@@ -35,11 +35,11 @@ The markup for creating a form element looks like this:
 </form>
 ~~~
 
-### Form Controls
+### Form controls
 
 To start collecting user data, we need to use form control elements. These are all the elements users will interact with on the form, such as text boxes, dropdowns, checkboxes and buttons. In the following few sections, we will explore some of the form controls you will use most commonly.
 
-### The Input Element
+### The input element
 
 The input element is the most versatile of all the form control elements. It accepts a `type` attribute which tells the browser what *type* of data it should expect and how it should render the input element.
 
@@ -70,7 +70,7 @@ Labels accept a `for` attribute, which associates it with a particular input.  T
 
 When a label is associated with an input and is clicked, it will focus the cursor on that input, ready for the user to input some data. This helps make our forms more accessible to users who rely on assistive technologies.
 
-**Placeholder Attribute**
+**Placeholder attribute**
 
 To guide users on what to enter in form elements, we can include placeholder text in input fields.
 
@@ -81,10 +81,10 @@ This is done by adding a `placeholder` attribute to an input. The value will be 
 <input type="text" id="first_name" placeholder="Bob...">
 ~~~
 
-Use placeholder text to demonstrate how text should be entered and formatted. 
+Use placeholder text to demonstrate how text should be entered and formatted.
 
 
-<span id="the-name-attribute">**The Name Attribute**</span>
+<span id="the-name-attribute">**The name attribute**</span>
 
 We need to use labels so that users understand what the data entered into an input field will represent. Just like that, we also need to let the backend, where we send our data, know what each piece of data represents.
 
@@ -118,7 +118,7 @@ The output we care about from the response is the "form" object. It should look 
 
 Try changing the `name` attributes of some of the input fields in the form and removing the attribute entirely, then submit the form again to see how the form data in the response changes.
 
-**Using Form Controls Outside of Forms**
+**Using form controls outside of forms**
 
 It's worth mentioning that you can use any of the form controls HTML provides outside of the `<form>` element, even when you don't have a backend server where you can send data.
 
@@ -133,7 +133,7 @@ For example you might want to have an input that gets some data from a user and 
 
 We will need to manipulate data from form controls like this in projects later in the curriculum.
 
-**The Type Attribute**
+**The type attribute**
 
 `Email inputs` are specialized text inputs just for email addresses. They are different from text inputs in that they will display a different keyboard which will include the @ symbol on mobile devices to make entering email addresses easier.
 
@@ -173,7 +173,7 @@ To create a date input, we use the input element with a `type` attribute of "dat
 <input type="date" id="dob" name="dob">
 ~~~
 
-**Text Area**
+**Text area**
 
 While technically not an input element, the text area element provides an input box that can accept text that spans multiple lines like user comments and reviews. It can also be resized by clicking and dragging the bottom right corner to make it bigger or smaller.
 
@@ -195,11 +195,11 @@ Text area elements accept a couple of unique attributes that other form controls
 <textarea rows="20" cols="60"></textarea>
 ~~~
 
-### Selection Elements
+### Selection elements
 
 Sometimes you will want users to select a value from a predefined list. This is where select elements will be useful.
 
-**Select Dropdown**
+**Select dropdown**
 
 The select element renders a dropdown list where users can select an option. Syntactically, select elements have similar markup to unordered lists. The select element wraps option elements which are the options that can be selected.
 
@@ -249,7 +249,7 @@ We may also split the list of options into groups using the `<optgroup>` element
 </select>
 ~~~
 
-**Radio Buttons**
+**Radio buttons**
 
 Select dropdowns are great for saving space on the page when we have an extensive list of options we want users to choose from. However, when we have a smaller list of 5 or fewer options to choose from, it is often a better user experience to have them displayed on the page instead of hidden behind a dropdown.
 
@@ -355,7 +355,7 @@ To create a button, we use the `<button>`  element. The content or text we want 
 
 The button element also accepts a `type` attribute that tells the browser which kind of button it is dealing with. There are three types of buttons available to us.
 
-**Submit Buttons**
+**Submit buttons**
 
 Once a user is finished filling in a form, they will need a way to submit it.  There is a specialized button for this; the submit button. When a submit button is clicked, it will submit the form it is contained within. The `type` attribute has a value of submit by default, i.e. if the `type` is not specified or the value provided is invalid.
 
@@ -365,7 +365,7 @@ To create a submit button, we use the button element with a `type` attribute of 
 <button type="submit">Submit</button>
 ~~~
 
-**Reset Button**
+**Reset button**
 
 A reset button clears all the data the user has entered into the form and sets all the inputs in the form back to what they were initially.
 
@@ -375,7 +375,7 @@ To create a reset button, we use the button element with a `type` attribute of "
 <button type="reset">Reset</button>
 ~~~
 
-**Generic Button**
+**Generic button**
 
 The third and final button type is simply a generic button that can be used for anything. It's commonly used with JS for creating interactive UI's.
 
@@ -387,13 +387,13 @@ To create a generic button, we use the button element with a `type` attribute of
 
 **Note**: It is important to remember that a button within a form with the `type` value of submit (which happens to be the default value) will always try to make a new request and submit data back to the server. Hence, for buttons that are used within a form for different purposes other than submitting the data, the `type` attribute should always be specified to avoid unwanted effects of submitting a form.
 
-### Organizing Form Elements
+### Organizing form elements
 
 Using the correct inputs for the data we want users to enter goes a long way towards making our forms user friendly. However, in larger forms, users can easily get overwhelmed and discouraged if there are many inputs to fill in.
 
 Luckily, HTML provides a couple of elements that make it easy to organize forms into sections that are visually distinct and manageable to digest.
 
-**Fieldset Element**
+**Fieldset element**
 
 The fieldset element is a container element that allows us to group related form inputs into one logical unit.
 
@@ -467,11 +467,11 @@ A common use-case for these elements is using a fieldset to group radio buttons 
 </fieldset>
 ~~~
 
-### A Note on Styling Forms
+### A note on styling forms
 
 We will provide resources that go deep into styling forms in the assignment section that comes next. However, before we get to the assignment, we should talk about some of the challenges with styling HTML forms and how we can get around them:
 
-**Default Browser Styles**
+**Default browser styles**
 
 Each browser has its own default styles for form controls, making your forms visually different for users depending on what browser they are using.
 
@@ -489,28 +489,36 @@ Certain aspects of other elements are downright impossible to style, for example
 
 <div class="lesson-content__panel" markdown="1">
 
-#### Form Basics
+#### Form basics
 
 1. Read and follow along to [MDN's Introductory Guides to Forms](https://developer.mozilla.org/en-US/docs/Learn/Forms#introductory_guides)
 2. Read and follow along to [MDN's The Different Form Controls Guides](https://developer.mozilla.org/en-US/docs/Learn/Forms#the_different_form_controls)
 
-#### Styling Forms
+#### Styling forms
 
 1. Read and follow along to [MDN's Form Styling Guides](https://developer.mozilla.org/en-US/docs/Learn/Forms#form_styling_guides)
 2. Read and follow along to [the internetingishard guide to forms](https://internetingishard.netlify.app/html-and-css/forms/index.html)
 
 </div>
 
-### Knowledge Check
+### Knowledge check
 
-- [Explain what the form element is for and what two attributes it should always include.](#the-form-element)
-- [Explain what form controls are at a high level.](#form-controls)
-- [What is the `name` attribute for?](#the-name-attribute)
-- [What are the three most common form controls you can use for allowing users to select predefined options?](#selection-elements)
-- [What are the three types of buttons in HTML?](#buttons)
-- [What are the two most challenging aspects of styling forms?](#a-note-on-styling-forms)
+- [Introduction](#introduction)
+- [Learning outcomes](#learning-outcomes)
+- [The form element](#the-form-element)
+- [Form controls](#form-controls)
+- [The input element](#the-input-element)
+- [Selection elements](#selection-elements)
+- [Buttons](#buttons)
+- [Organizing form elements](#organizing-form-elements)
+- [A note on styling forms](#a-note-on-styling-forms)
+- [Assignment](#assignment)
+  - [Form basics](#form-basics)
+  - [Styling forms](#styling-forms)
+- [Knowledge check](#knowledge-check)
+- [Additional resources](#additional-resources)
 
-### Additional Resources
+### Additional resources
 
 This section contains helpful links to other content. It isn’t required, so consider it supplemental.
 

--- a/intermediate_html_css/forms/form_basics.md
+++ b/intermediate_html_css/forms/form_basics.md
@@ -23,17 +23,15 @@ Later in the curriculum, we will learn to hook backend systems up to frontend fo
 The second is the `method` attribute which tells the browser [which HTTP request method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) it should use to submit the form.
 The GET and POST request methods are the two you will find yourself using the most.
 
-We use GET when we want to retrieve something from a server. For example, Google uses a GET request when you search as it *gets* the search results.
+We use GET when we want to retrieve something from a server. For example, Google uses a GET request when you search as it _gets_ the search results.
 
 POST is used when we want to change something on the server, for example, when a user makes an account or makes a payment on a website.
 
 The markup for creating a form element looks like this:
 
-~~~html
-<form action="example.com/path" method="post">
-
-</form>
-~~~
+```html
+<form action="example.com/path" method="post"></form>
+```
 
 ### Form controls
 
@@ -41,15 +39,15 @@ To start collecting user data, we need to use form control elements. These are a
 
 ### The input element
 
-The input element is the most versatile of all the form control elements. It accepts a `type` attribute which tells the browser what *type* of data it should expect and how it should render the input element.
+The input element is the most versatile of all the form control elements. It accepts a `type` attribute which tells the browser what _type_ of data it should expect and how it should render the input element.
 
 A text input looks like this:
 
-~~~html
+```html
 <form action="example.com/path" method="post">
-  <input type="text">
+  <input type="text" />
 </form>
-~~~
+```
 
 Text inputs accept any text input. For example, you would use it to collect things like users' first and last names.
 
@@ -59,14 +57,14 @@ An input on its own isn't very useful since the user will not know what kind of 
 
 To create a label, we use the `<label>` element. The text we want displayed in the label will go between its opening and closing tags:
 
-~~~html
+```html
 <form action="example.com/path" method="post">
   <label for="first_name">First Name:</label>
-  <input type="text" id="first_name">
+  <input type="text" id="first_name" />
 </form>
-~~~
+```
 
-Labels accept a `for` attribute, which associates it with a particular input.  The input we want to associate with a label needs an `id` attribute with the same value as the label's `for` attribute.
+Labels accept a `for` attribute, which associates it with a particular input. The input we want to associate with a label needs an `id` attribute with the same value as the label's `for` attribute.
 
 When a label is associated with an input and is clicked, it will focus the cursor on that input, ready for the user to input some data. This helps make our forms more accessible to users who rely on assistive technologies.
 
@@ -74,15 +72,14 @@ When a label is associated with an input and is clicked, it will focus the curso
 
 To guide users on what to enter in form elements, we can include placeholder text in input fields.
 
-This is done by adding a `placeholder` attribute to an input. The value will be the *placeholder* text we want to display in the input:
+This is done by adding a `placeholder` attribute to an input. The value will be the _placeholder_ text we want to display in the input:
 
-~~~html
+```html
 <label for="first_name">First Name:</label>
-<input type="text" id="first_name" placeholder="Bob...">
-~~~
+<input type="text" id="first_name" placeholder="Bob..." />
+```
 
 Use placeholder text to demonstrate how text should be entered and formatted.
-
 
 <span id="the-name-attribute">**The name attribute**</span>
 
@@ -90,10 +87,10 @@ We need to use labels so that users understand what the data entered into an inp
 
 We do this by adding a `name` attribute to our inputs:
 
-~~~html
+```html
 <label for="first_name">First Name:</label>
-<input type="text" id="first_name" name="first_name">
-~~~
+<input type="text" id="first_name" name="first_name" />
+```
 
 The `name` attribute serves as a reference to the data inputted into a form control after submitting it. You can think of it as a variable name for the input. Form input should always have a `name` attribute; otherwise, it will be ignored when the form is submitted.
 
@@ -108,13 +105,13 @@ To get a better understanding of what this looks like we can submit a form to [h
 
 The output we care about from the response is the "form" object. It should look something like this:
 
-~~~json
+```json
 "form": {
     "age": "33",
     "first_name": "John",
     "last_name": "Doe"
   },
-~~~
+```
 
 Try changing the `name` attributes of some of the input fields in the form and removing the attribute entirely, then submit the form again to see how the form data in the response changes.
 
@@ -141,37 +138,42 @@ They also validate that the user has entered a correctly formatted email address
 
 To create an email input, we use an input element with `type` attribute of "email":
 
-~~~html
+```html
 <label for="user_email">Email Address:</label>
-<input type="email" id="user_email" name="email" placeholder="you@example.com">
-~~~
+<input
+  type="email"
+  id="user_email"
+  name="email"
+  placeholder="you@example.com"
+/>
+```
 
-`Password inputs` are another specialized text input. They differ from regular text inputs in that they mask the inputted data with another character – usually an asterisk (*) or bullet point (•) – to prevent anyone from seeing what has been entered.
+`Password inputs` are another specialized text input. They differ from regular text inputs in that they mask the inputted data with another character – usually an asterisk (\*) or bullet point (•) – to prevent anyone from seeing what has been entered.
 
 A password input can be created using an input element with a type of "password":
 
-~~~html
+```html
 <label for="user_password">Password:</label>
-<input type="password" id="user_password" name="password">
-~~~
+<input type="password" id="user_password" name="password" />
+```
 
 The `number input` only accepts number values and ignores any other characters the user tries to enter.
 
 We create a number input using the input element with a `type` attribute of "number":
 
-~~~html
+```html
 <label for="amount">Amount:</label>
-<input type="number" id="amount" name="amount">
-~~~
+<input type="number" id="amount" name="amount" />
+```
 
 To collect dates from a user, we can use a `date input`. This input is unique because it provides a better user experience for choosing dates by rendering a simple date picker calendar.
 
 To create a date input, we use the input element with a `type` attribute of "date":
 
-~~~html
+```html
 <label for="dob">Date of Birth:</label>
-<input type="date" id="dob" name="dob">
-~~~
+<input type="date" id="dob" name="dob" />
+```
 
 **Text area**
 
@@ -179,21 +181,21 @@ While technically not an input element, the text area element provides an input 
 
 To create a text area, we use the `<textarea>` element:
 
-~~~html
+```html
 <textarea></textarea>
-~~~
+```
 
 Unlike input elements, Textarea elements do have a closing tag. This allows you to wrap some initial content you want the text area to display:
 
-~~~html
+```html
 <textarea>Some initial content</textarea>
-~~~
+```
 
 Text area elements accept a couple of unique attributes that other form controls do not. These are the `rows` and `cols` attributes. They allow you to control the initial height (rows) and width (cols) of the text area:
 
-~~~html
+```html
 <textarea rows="20" cols="60"></textarea>
-~~~
+```
 
 ### Selection elements
 
@@ -205,7 +207,7 @@ The select element renders a dropdown list where users can select an option. Syn
 
 To create a select dropdown, we use the `<select>` element. Any options we want to display within the select element are defined using `<option>` elements:
 
-~~~html
+```html
 <select name="Car">
   <option value="mercedes">Mercedes</option>
   <option value="tesla">Tesla</option>
@@ -214,14 +216,13 @@ To create a select dropdown, we use the `<select>` element. Any options we want 
   <option value="mini">Mini</option>
   <option value="ford">Ford</option>
 </select>
-
-~~~
+```
 
 All the option elements should(otherwise the text content inside is used) have a `value` attribute. This value will be sent to the server when the form is submitted.
 
 We can set one of the options to be the default selected element when the browser first renders the form by giving one of the options the `selected` attribute:
 
-~~~html
+```html
 <select name="Car">
   <option value="mercedes">Mercedes</option>
   <option value="tesla">Tesla</option>
@@ -230,11 +231,11 @@ We can set one of the options to be the default selected element when the browse
   <option value="mini">Mini</option>
   <option value="ford">Ford</option>
 </select>
-~~~
+```
 
 We may also split the list of options into groups using the `<optgroup>` element. The optgroup element takes a `label` attribute which the browser uses as the label for each group:
 
-~~~html
+```html
 <select name="fashion">
   <optgroup label="Clothing">
     <option value="t_shirt">T-Shirts</option>
@@ -247,7 +248,7 @@ We may also split the list of options into groups using the `<optgroup>` element
     <option value="sandals">Sandals</option>
   </optgroup>
 </select>
-~~~
+```
 
 **Radio buttons**
 
@@ -255,45 +256,45 @@ Select dropdowns are great for saving space on the page when we have an extensiv
 
 In this case, we can use radio buttons. Radio buttons allow us to create multiple options that the user can choose one of. To create radio buttons, we use the ever adaptable input element again with a `type` attribute of "radio":
 
-~~~html
+```html
 <h1>Ticket Type</h1>
 <div>
-  <input type="radio" id="child" name="ticket_type" value="child">
+  <input type="radio" id="child" name="ticket_type" value="child" />
   <label for="child">Child</label>
 </div>
 
 <div>
-  <input type="radio" id="adult" name="ticket_type" value="adult">
+  <input type="radio" id="adult" name="ticket_type" value="adult" />
   <label for="adult">Adult</label>
 </div>
 
 <div>
-  <input type="radio" id="senior" name="ticket_type" value="senior">
+  <input type="radio" id="senior" name="ticket_type" value="senior" />
   <label for="senior">Senior</label>
 </div>
-~~~
+```
 
 When we select one of the radio buttons and then select another, it will deselect the first one. Radio buttons know to do this because they have the same `name` attribute. This is how the browser knows these elements are part of the same group of options.
 
 We can set the default selected radio button by adding the `checked` attribute to it:
 
-~~~html
+```html
 <h1>Ticket Type</h1>
 <div>
-  <input type="radio" id="child" name="ticket_type" value="child">
+  <input type="radio" id="child" name="ticket_type" value="child" />
   <label for="child">Child</label>
 </div>
 
 <div>
-  <input type="radio" id="adult" name="ticket_type" value="adult" checked>
+  <input type="radio" id="adult" name="ticket_type" value="adult" checked />
   <label for="adult">Adult</label>
 </div>
 
 <div>
-  <input type="radio" id="senior" name="ticket_type" value="senior">
+  <input type="radio" id="senior" name="ticket_type" value="senior" />
   <label for="senior">Senior</label>
 </div>
-~~~
+```
 
 **Checkboxes**
 
@@ -301,69 +302,69 @@ Checkboxes are similar to radio buttons in that they allow users to choose from 
 
 To create a checkbox, we use the input element with a `type` attribute of "checkbox":
 
-~~~html
+```html
 <h1>Pizza Toppings</h1>
 
 <div>
-  <input type="checkbox" id="sausage" name="topping" value="sausage">
+  <input type="checkbox" id="sausage" name="topping" value="sausage" />
   <label for="sausage">Sausage</label>
 </div>
 
 <div>
-  <input type="checkbox" id="onions" name="topping" value="onions">
+  <input type="checkbox" id="onions" name="topping" value="onions" />
   <label for="onions">Onions</label>
 </div>
 
 <div>
-  <input type="checkbox" id="pepperoni" name="topping" value="pepperoni">
+  <input type="checkbox" id="pepperoni" name="topping" value="pepperoni" />
   <label for="pepperoni">Pepperoni</label>
 </div>
 
 <div>
-  <input type="checkbox" id="mushrooms" name="topping" value="mushrooms">
+  <input type="checkbox" id="mushrooms" name="topping" value="mushrooms" />
   <label for="mushrooms">Mushrooms</label>
 </div>
-~~~
+```
 
 We can also have a single checkbox when we want users to toggle if they want something to be true or false. Like signing up to a newsletter when they create an account for example:
 
-~~~html
+```html
 <div>
-  <input type="checkbox" id="newsletter" name="news_letter">
+  <input type="checkbox" id="newsletter" name="news_letter" />
   <label for="newsletter">Send me the news letter</label>
 </div>
-~~~
+```
 
 We can set checkboxes to be checked by default on page load by giving them a `checked` attribute:
 
-~~~html
+```html
 <div>
-  <input type="checkbox" id="newsletter" name="news_letter" checked>
+  <input type="checkbox" id="newsletter" name="news_letter" checked />
   <label for="newsletter">Send me the news letter</label>
 </div>
-~~~
+```
 
 ### Buttons
 
 The button element creates clickable buttons that the user can interact with to submit forms and trigger other actions.
 
-To create a button, we use the `<button>`  element. The content or text we want to have displayed inside the button will go within the opening and closing tags:
+To create a button, we use the `<button>` element. The content or text we want to have displayed inside the button will go within the opening and closing tags:
 
-~~~html
+```html
 <button>Click Me</button>
-~~~
+```
 
 The button element also accepts a `type` attribute that tells the browser which kind of button it is dealing with. There are three types of buttons available to us.
 
 **Submit buttons**
 
-Once a user is finished filling in a form, they will need a way to submit it.  There is a specialized button for this; the submit button. When a submit button is clicked, it will submit the form it is contained within. The `type` attribute has a value of submit by default, i.e. if the `type` is not specified or the value provided is invalid.
+Once a user is finished filling in a form, they will need a way to submit it. There is a specialized button for this; the submit button. When a submit button is clicked, it will submit the form it is contained within. The `type` attribute has a value of submit by default, i.e. if the `type` is not specified or the value provided is invalid.
 
 To create a submit button, we use the button element with a `type` attribute of "submit":
 
-~~~html
+```html
 <button type="submit">Submit</button>
-~~~
+```
 
 **Reset button**
 
@@ -371,9 +372,9 @@ A reset button clears all the data the user has entered into the form and sets a
 
 To create a reset button, we use the button element with a `type` attribute of "reset":
 
-~~~html
+```html
 <button type="reset">Reset</button>
-~~~
+```
 
 **Generic button**
 
@@ -381,9 +382,9 @@ The third and final button type is simply a generic button that can be used for 
 
 To create a generic button, we use the button element with a `type` attribute of "button":
 
-~~~html
+```html
 <button type="button">Click to Toggle</button>
-~~~
+```
 
 **Note**: It is important to remember that a button within a form with the `type` value of submit (which happens to be the default value) will always try to make a new request and submit data back to the server. Hence, for buttons that are used within a form for different purposes other than submitting the data, the `type` attribute should always be specified to avoid unwanted effects of submitting a form.
 
@@ -399,15 +400,15 @@ The fieldset element is a container element that allows us to group related form
 
 To create a fieldset, we use the `<fieldset>` element. Whatever form inputs we want to group together go within the opening and closing fieldset tags:
 
-~~~html
+```html
 <fieldset>
   <label for="first_name">First Name</label>
-  <input type="text" id="first_name" name="first_name">
+  <input type="text" id="first_name" name="first_name" />
 
   <label for="last_name">Last Name</label>
-  <input type="text" id="last_name" name="last_name">
+  <input type="text" id="last_name" name="last_name" />
 </fieldset>
-~~~
+```
 
 **Legend**
 
@@ -415,57 +416,56 @@ The legend element is used to give field sets a heading or caption so the user c
 
 To create a legend, we use the `<legend>` element with the text we want to display within its opening and closing tags. A legend should always come right after an opening fieldset tag:
 
-~~~html
+```html
 <fieldset>
   <legend>Contact Details</legend>
 
   <label for="name">Name:</label>
-  <input type="text" id="name" name="name">
+  <input type="text" id="name" name="name" />
 
   <label for="phone_number">Phone Number:</label>
-  <input type="tel" id="phone_number" name="phone_number">
+  <input type="tel" id="phone_number" name="phone_number" />
 
   <label for="email">Email:</label>
-  <input type="email" id="email" name="email">
+  <input type="email" id="email" name="email" />
 </fieldset>
 
 <fieldset>
   <legend>Delivery Details</legend>
 
   <label for="street_address">Street Address:</label>
-  <input type="text" id="street_address" name="street_address">
+  <input type="text" id="street_address" name="street_address" />
 
   <label for="city">City:</label>
-  <input type="text" id="city" name="city">
+  <input type="text" id="city" name="city" />
 
   <label for="zip_code">Zip Code:</label>
-  <input type="text" id="zip_code" name="zip_code">
+  <input type="text" id="zip_code" name="zip_code" />
 </fieldset>
-~~~
+```
 
 A common use-case for these elements is using a fieldset to group radio buttons and using a legend to communicate to the user what each of the options is ultimately for:
 
-~~~html
+```html
 <fieldset>
   <legend>What would you like to drink?</legend>
 
   <div>
-    <input type="radio" name="drink" id="coffee" value="coffee">
+    <input type="radio" name="drink" id="coffee" value="coffee" />
     <label for="coffee">Coffee</label>
   </div>
 
   <div>
-    <input type="radio" name="drink" id="tea" value="tea">
+    <input type="radio" name="drink" id="tea" value="tea" />
     <label for="tea">Tea</label>
   </div>
 
   <div>
-    <input type="radio" name="drink" id="soda" value="soda">
+    <input type="radio" name="drink" id="soda" value="soda" />
     <label for="soda">Soda</label>
   </div>
-
 </fieldset>
-~~~
+```
 
 ### A note on styling forms
 
@@ -503,20 +503,12 @@ Certain aspects of other elements are downright impossible to style, for example
 
 ### Knowledge check
 
-- [Introduction](#introduction)
-- [Learning outcomes](#learning-outcomes)
-- [The form element](#the-form-element)
-- [Form controls](#form-controls)
-- [The input element](#the-input-element)
-- [Selection elements](#selection-elements)
-- [Buttons](#buttons)
-- [Organizing form elements](#organizing-form-elements)
-- [A note on styling forms](#a-note-on-styling-forms)
-- [Assignment](#assignment)
-  - [Form basics](#form-basics)
-  - [Styling forms](#styling-forms)
-- [Knowledge check](#knowledge-check)
-- [Additional resources](#additional-resources)
+- [Explain what the form element is for and what two attributes it should always include.](#the-form-element)
+- [Explain what form controls are at a high level.](#form-controls)
+- [What is the `name` attribute for?](#the-name-attribute)
+- [What are the three most common form controls you can use for allowing users to select predefined options?](#selection-elements)
+- [What are the three types of buttons in HTML?](#buttons)
+- [What are the two most challenging aspects of styling forms?](#a-note-on-styling-forms)
 
 ### Additional resources
 

--- a/intermediate_html_css/forms/form_basics.md
+++ b/intermediate_html_css/forms/form_basics.md
@@ -23,14 +23,16 @@ Later in the curriculum, we will learn to hook backend systems up to frontend fo
 The second is the `method` attribute which tells the browser [which HTTP request method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) it should use to submit the form.
 The GET and POST request methods are the two you will find yourself using the most.
 
-We use GET when we want to retrieve something from a server. For example, Google uses a GET request when you search as it _gets_ the search results.
+We use GET when we want to retrieve something from a server. For example, Google uses a GET request when you search as it *gets* the search results.
 
 POST is used when we want to change something on the server, for example, when a user makes an account or makes a payment on a website.
 
 The markup for creating a form element looks like this:
 
 ~~~html
-<form action="example.com/path" method="post"></form>
+<form action="example.com/path" method="post">
+
+</form>
 ~~~
 
 ### Form controls
@@ -39,13 +41,13 @@ To start collecting user data, we need to use form control elements. These are a
 
 ### The input element
 
-The input element is the most versatile of all the form control elements. It accepts a `type` attribute which tells the browser what _type_ of data it should expect and how it should render the input element.
+The input element is the most versatile of all the form control elements. It accepts a `type` attribute which tells the browser what *type* of data it should expect and how it should render the input element.
 
 A text input looks like this:
 
 ~~~html
 <form action="example.com/path" method="post">
-  <input type="text" />
+  <input type="text">
 </form>
 ~~~
 
@@ -60,7 +62,7 @@ To create a label, we use the `<label>` element. The text we want displayed in t
 ~~~html
 <form action="example.com/path" method="post">
   <label for="first_name">First Name:</label>
-  <input type="text" id="first_name" />
+  <input type="text" id="first_name">
 </form>
 ~~~
 
@@ -72,14 +74,15 @@ When a label is associated with an input and is clicked, it will focus the curso
 
 To guide users on what to enter in form elements, we can include placeholder text in input fields.
 
-This is done by adding a `placeholder` attribute to an input. The value will be the _placeholder_ text we want to display in the input:
+This is done by adding a `placeholder` attribute to an input. The value will be the *placeholder* text we want to display in the input:
 
 ~~~html
 <label for="first_name">First Name:</label>
-<input type="text" id="first_name" placeholder="Bob..." />
+<input type="text" id="first_name" placeholder="Bob...">
 ~~~
 
 Use placeholder text to demonstrate how text should be entered and formatted.
+
 
 <span id="the-name-attribute">**The name attribute**</span>
 
@@ -89,7 +92,7 @@ We do this by adding a `name` attribute to our inputs:
 
 ~~~html
 <label for="first_name">First Name:</label>
-<input type="text" id="first_name" name="first_name" />
+<input type="text" id="first_name" name="first_name">
 ~~~
 
 The `name` attribute serves as a reference to the data inputted into a form control after submitting it. You can think of it as a variable name for the input. Form input should always have a `name` attribute; otherwise, it will be ignored when the form is submitted.
@@ -140,21 +143,16 @@ To create an email input, we use an input element with `type` attribute of "emai
 
 ~~~html
 <label for="user_email">Email Address:</label>
-<input
-  type="email"
-  id="user_email"
-  name="email"
-  placeholder="you@example.com"
-/>
+<input type="email" id="user_email" name="email" placeholder="you@example.com">
 ~~~
 
-`Password inputs` are another specialized text input. They differ from regular text inputs in that they mask the inputted data with another character – usually an asterisk (\*) or bullet point (•) – to prevent anyone from seeing what has been entered.
+`Password inputs` are another specialized text input. They differ from regular text inputs in that they mask the inputted data with another character – usually an asterisk (*) or bullet point (•) – to prevent anyone from seeing what has been entered.
 
 A password input can be created using an input element with a type of "password":
 
 ~~~html
 <label for="user_password">Password:</label>
-<input type="password" id="user_password" name="password" />
+<input type="password" id="user_password" name="password">
 ~~~
 
 The `number input` only accepts number values and ignores any other characters the user tries to enter.
@@ -163,7 +161,7 @@ We create a number input using the input element with a `type` attribute of "num
 
 ~~~html
 <label for="amount">Amount:</label>
-<input type="number" id="amount" name="amount" />
+<input type="number" id="amount" name="amount">
 ~~~
 
 To collect dates from a user, we can use a `date input`. This input is unique because it provides a better user experience for choosing dates by rendering a simple date picker calendar.
@@ -172,7 +170,7 @@ To create a date input, we use the input element with a `type` attribute of "dat
 
 ~~~html
 <label for="dob">Date of Birth:</label>
-<input type="date" id="dob" name="dob" />
+<input type="date" id="dob" name="dob">
 ~~~
 
 **Text area**
@@ -259,17 +257,17 @@ In this case, we can use radio buttons. Radio buttons allow us to create multipl
 ~~~html
 <h1>Ticket Type</h1>
 <div>
-  <input type="radio" id="child" name="ticket_type" value="child" />
+  <input type="radio" id="child" name="ticket_type" value="child">
   <label for="child">Child</label>
 </div>
 
 <div>
-  <input type="radio" id="adult" name="ticket_type" value="adult" />
+  <input type="radio" id="adult" name="ticket_type" value="adult">
   <label for="adult">Adult</label>
 </div>
 
 <div>
-  <input type="radio" id="senior" name="ticket_type" value="senior" />
+  <input type="radio" id="senior" name="ticket_type" value="senior">
   <label for="senior">Senior</label>
 </div>
 ~~~
@@ -281,17 +279,17 @@ We can set the default selected radio button by adding the `checked` attribute t
 ~~~html
 <h1>Ticket Type</h1>
 <div>
-  <input type="radio" id="child" name="ticket_type" value="child" />
+  <input type="radio" id="child" name="ticket_type" value="child">
   <label for="child">Child</label>
 </div>
 
 <div>
-  <input type="radio" id="adult" name="ticket_type" value="adult" checked />
+  <input type="radio" id="adult" name="ticket_type" value="adult" checked>
   <label for="adult">Adult</label>
 </div>
 
 <div>
-  <input type="radio" id="senior" name="ticket_type" value="senior" />
+  <input type="radio" id="senior" name="ticket_type" value="senior">
   <label for="senior">Senior</label>
 </div>
 ~~~
@@ -306,22 +304,22 @@ To create a checkbox, we use the input element with a `type` attribute of "check
 <h1>Pizza Toppings</h1>
 
 <div>
-  <input type="checkbox" id="sausage" name="topping" value="sausage" />
+  <input type="checkbox" id="sausage" name="topping" value="sausage">
   <label for="sausage">Sausage</label>
 </div>
 
 <div>
-  <input type="checkbox" id="onions" name="topping" value="onions" />
+  <input type="checkbox" id="onions" name="topping" value="onions">
   <label for="onions">Onions</label>
 </div>
 
 <div>
-  <input type="checkbox" id="pepperoni" name="topping" value="pepperoni" />
+  <input type="checkbox" id="pepperoni" name="topping" value="pepperoni">
   <label for="pepperoni">Pepperoni</label>
 </div>
 
 <div>
-  <input type="checkbox" id="mushrooms" name="topping" value="mushrooms" />
+  <input type="checkbox" id="mushrooms" name="topping" value="mushrooms">
   <label for="mushrooms">Mushrooms</label>
 </div>
 ~~~
@@ -330,7 +328,7 @@ We can also have a single checkbox when we want users to toggle if they want som
 
 ~~~html
 <div>
-  <input type="checkbox" id="newsletter" name="news_letter" />
+  <input type="checkbox" id="newsletter" name="news_letter">
   <label for="newsletter">Send me the news letter</label>
 </div>
 ~~~
@@ -339,7 +337,7 @@ We can set checkboxes to be checked by default on page load by giving them a `ch
 
 ~~~html
 <div>
-  <input type="checkbox" id="newsletter" name="news_letter" checked />
+  <input type="checkbox" id="newsletter" name="news_letter" checked>
   <label for="newsletter">Send me the news letter</label>
 </div>
 ~~~
@@ -403,10 +401,10 @@ To create a fieldset, we use the `<fieldset>` element. Whatever form inputs we w
 ~~~html
 <fieldset>
   <label for="first_name">First Name</label>
-  <input type="text" id="first_name" name="first_name" />
+  <input type="text" id="first_name" name="first_name">
 
   <label for="last_name">Last Name</label>
-  <input type="text" id="last_name" name="last_name" />
+  <input type="text" id="last_name" name="last_name">
 </fieldset>
 ~~~
 
@@ -421,26 +419,26 @@ To create a legend, we use the `<legend>` element with the text we want to displ
   <legend>Contact Details</legend>
 
   <label for="name">Name:</label>
-  <input type="text" id="name" name="name" />
+  <input type="text" id="name" name="name">
 
   <label for="phone_number">Phone Number:</label>
-  <input type="tel" id="phone_number" name="phone_number" />
+  <input type="tel" id="phone_number" name="phone_number">
 
   <label for="email">Email:</label>
-  <input type="email" id="email" name="email" />
+  <input type="email" id="email" name="email">
 </fieldset>
 
 <fieldset>
   <legend>Delivery Details</legend>
 
   <label for="street_address">Street Address:</label>
-  <input type="text" id="street_address" name="street_address" />
+  <input type="text" id="street_address" name="street_address">
 
   <label for="city">City:</label>
-  <input type="text" id="city" name="city" />
+  <input type="text" id="city" name="city">
 
   <label for="zip_code">Zip Code:</label>
-  <input type="text" id="zip_code" name="zip_code" />
+  <input type="text" id="zip_code" name="zip_code">
 </fieldset>
 ~~~
 
@@ -451,17 +449,17 @@ A common use-case for these elements is using a fieldset to group radio buttons 
   <legend>What would you like to drink?</legend>
 
   <div>
-    <input type="radio" name="drink" id="coffee" value="coffee" />
+    <input type="radio" name="drink" id="coffee" value="coffee">
     <label for="coffee">Coffee</label>
   </div>
 
   <div>
-    <input type="radio" name="drink" id="tea" value="tea" />
+    <input type="radio" name="drink" id="tea" value="tea">
     <label for="tea">Tea</label>
   </div>
 
   <div>
-    <input type="radio" name="drink" id="soda" value="soda" />
+    <input type="radio" name="drink" id="soda" value="soda">
     <label for="soda">Soda</label>
   </div>
 </fieldset>

--- a/intermediate_html_css/forms/form_basics.md
+++ b/intermediate_html_css/forms/form_basics.md
@@ -29,9 +29,9 @@ POST is used when we want to change something on the server, for example, when a
 
 The markup for creating a form element looks like this:
 
-```html
+~~~html
 <form action="example.com/path" method="post"></form>
-```
+~~~
 
 ### Form controls
 
@@ -43,11 +43,11 @@ The input element is the most versatile of all the form control elements. It acc
 
 A text input looks like this:
 
-```html
+~~~html
 <form action="example.com/path" method="post">
   <input type="text" />
 </form>
-```
+~~~
 
 Text inputs accept any text input. For example, you would use it to collect things like users' first and last names.
 
@@ -57,12 +57,12 @@ An input on its own isn't very useful since the user will not know what kind of 
 
 To create a label, we use the `<label>` element. The text we want displayed in the label will go between its opening and closing tags:
 
-```html
+~~~html
 <form action="example.com/path" method="post">
   <label for="first_name">First Name:</label>
   <input type="text" id="first_name" />
 </form>
-```
+~~~
 
 Labels accept a `for` attribute, which associates it with a particular input. The input we want to associate with a label needs an `id` attribute with the same value as the label's `for` attribute.
 
@@ -74,10 +74,10 @@ To guide users on what to enter in form elements, we can include placeholder tex
 
 This is done by adding a `placeholder` attribute to an input. The value will be the _placeholder_ text we want to display in the input:
 
-```html
+~~~html
 <label for="first_name">First Name:</label>
 <input type="text" id="first_name" placeholder="Bob..." />
-```
+~~~
 
 Use placeholder text to demonstrate how text should be entered and formatted.
 
@@ -87,10 +87,10 @@ We need to use labels so that users understand what the data entered into an inp
 
 We do this by adding a `name` attribute to our inputs:
 
-```html
+~~~html
 <label for="first_name">First Name:</label>
 <input type="text" id="first_name" name="first_name" />
-```
+~~~
 
 The `name` attribute serves as a reference to the data inputted into a form control after submitting it. You can think of it as a variable name for the input. Form input should always have a `name` attribute; otherwise, it will be ignored when the form is submitted.
 
@@ -105,13 +105,13 @@ To get a better understanding of what this looks like we can submit a form to [h
 
 The output we care about from the response is the "form" object. It should look something like this:
 
-```json
+~~~json
 "form": {
     "age": "33",
     "first_name": "John",
     "last_name": "Doe"
   },
-```
+~~~
 
 Try changing the `name` attributes of some of the input fields in the form and removing the attribute entirely, then submit the form again to see how the form data in the response changes.
 
@@ -138,7 +138,7 @@ They also validate that the user has entered a correctly formatted email address
 
 To create an email input, we use an input element with `type` attribute of "email":
 
-```html
+~~~html
 <label for="user_email">Email Address:</label>
 <input
   type="email"
@@ -146,34 +146,34 @@ To create an email input, we use an input element with `type` attribute of "emai
   name="email"
   placeholder="you@example.com"
 />
-```
+~~~
 
 `Password inputs` are another specialized text input. They differ from regular text inputs in that they mask the inputted data with another character – usually an asterisk (\*) or bullet point (•) – to prevent anyone from seeing what has been entered.
 
 A password input can be created using an input element with a type of "password":
 
-```html
+~~~html
 <label for="user_password">Password:</label>
 <input type="password" id="user_password" name="password" />
-```
+~~~
 
 The `number input` only accepts number values and ignores any other characters the user tries to enter.
 
 We create a number input using the input element with a `type` attribute of "number":
 
-```html
+~~~html
 <label for="amount">Amount:</label>
 <input type="number" id="amount" name="amount" />
-```
+~~~
 
 To collect dates from a user, we can use a `date input`. This input is unique because it provides a better user experience for choosing dates by rendering a simple date picker calendar.
 
 To create a date input, we use the input element with a `type` attribute of "date":
 
-```html
+~~~html
 <label for="dob">Date of Birth:</label>
 <input type="date" id="dob" name="dob" />
-```
+~~~
 
 **Text area**
 
@@ -181,21 +181,21 @@ While technically not an input element, the text area element provides an input 
 
 To create a text area, we use the `<textarea>` element:
 
-```html
+~~~html
 <textarea></textarea>
-```
+~~~
 
 Unlike input elements, Textarea elements do have a closing tag. This allows you to wrap some initial content you want the text area to display:
 
-```html
+~~~html
 <textarea>Some initial content</textarea>
-```
+~~~
 
 Text area elements accept a couple of unique attributes that other form controls do not. These are the `rows` and `cols` attributes. They allow you to control the initial height (rows) and width (cols) of the text area:
 
-```html
+~~~html
 <textarea rows="20" cols="60"></textarea>
-```
+~~~
 
 ### Selection elements
 
@@ -207,7 +207,7 @@ The select element renders a dropdown list where users can select an option. Syn
 
 To create a select dropdown, we use the `<select>` element. Any options we want to display within the select element are defined using `<option>` elements:
 
-```html
+~~~html
 <select name="Car">
   <option value="mercedes">Mercedes</option>
   <option value="tesla">Tesla</option>
@@ -216,13 +216,13 @@ To create a select dropdown, we use the `<select>` element. Any options we want 
   <option value="mini">Mini</option>
   <option value="ford">Ford</option>
 </select>
-```
+~~~
 
 All the option elements should(otherwise the text content inside is used) have a `value` attribute. This value will be sent to the server when the form is submitted.
 
 We can set one of the options to be the default selected element when the browser first renders the form by giving one of the options the `selected` attribute:
 
-```html
+~~~html
 <select name="Car">
   <option value="mercedes">Mercedes</option>
   <option value="tesla">Tesla</option>
@@ -231,11 +231,11 @@ We can set one of the options to be the default selected element when the browse
   <option value="mini">Mini</option>
   <option value="ford">Ford</option>
 </select>
-```
+~~~
 
 We may also split the list of options into groups using the `<optgroup>` element. The optgroup element takes a `label` attribute which the browser uses as the label for each group:
 
-```html
+~~~html
 <select name="fashion">
   <optgroup label="Clothing">
     <option value="t_shirt">T-Shirts</option>
@@ -248,7 +248,7 @@ We may also split the list of options into groups using the `<optgroup>` element
     <option value="sandals">Sandals</option>
   </optgroup>
 </select>
-```
+~~~
 
 **Radio buttons**
 
@@ -256,7 +256,7 @@ Select dropdowns are great for saving space on the page when we have an extensiv
 
 In this case, we can use radio buttons. Radio buttons allow us to create multiple options that the user can choose one of. To create radio buttons, we use the ever adaptable input element again with a `type` attribute of "radio":
 
-```html
+~~~html
 <h1>Ticket Type</h1>
 <div>
   <input type="radio" id="child" name="ticket_type" value="child" />
@@ -272,13 +272,13 @@ In this case, we can use radio buttons. Radio buttons allow us to create multipl
   <input type="radio" id="senior" name="ticket_type" value="senior" />
   <label for="senior">Senior</label>
 </div>
-```
+~~~
 
 When we select one of the radio buttons and then select another, it will deselect the first one. Radio buttons know to do this because they have the same `name` attribute. This is how the browser knows these elements are part of the same group of options.
 
 We can set the default selected radio button by adding the `checked` attribute to it:
 
-```html
+~~~html
 <h1>Ticket Type</h1>
 <div>
   <input type="radio" id="child" name="ticket_type" value="child" />
@@ -294,7 +294,7 @@ We can set the default selected radio button by adding the `checked` attribute t
   <input type="radio" id="senior" name="ticket_type" value="senior" />
   <label for="senior">Senior</label>
 </div>
-```
+~~~
 
 **Checkboxes**
 
@@ -302,7 +302,7 @@ Checkboxes are similar to radio buttons in that they allow users to choose from 
 
 To create a checkbox, we use the input element with a `type` attribute of "checkbox":
 
-```html
+~~~html
 <h1>Pizza Toppings</h1>
 
 <div>
@@ -324,25 +324,25 @@ To create a checkbox, we use the input element with a `type` attribute of "check
   <input type="checkbox" id="mushrooms" name="topping" value="mushrooms" />
   <label for="mushrooms">Mushrooms</label>
 </div>
-```
+~~~
 
 We can also have a single checkbox when we want users to toggle if they want something to be true or false. Like signing up to a newsletter when they create an account for example:
 
-```html
+~~~html
 <div>
   <input type="checkbox" id="newsletter" name="news_letter" />
   <label for="newsletter">Send me the news letter</label>
 </div>
-```
+~~~
 
 We can set checkboxes to be checked by default on page load by giving them a `checked` attribute:
 
-```html
+~~~html
 <div>
   <input type="checkbox" id="newsletter" name="news_letter" checked />
   <label for="newsletter">Send me the news letter</label>
 </div>
-```
+~~~
 
 ### Buttons
 
@@ -350,9 +350,9 @@ The button element creates clickable buttons that the user can interact with to 
 
 To create a button, we use the `<button>` element. The content or text we want to have displayed inside the button will go within the opening and closing tags:
 
-```html
+~~~html
 <button>Click Me</button>
-```
+~~~
 
 The button element also accepts a `type` attribute that tells the browser which kind of button it is dealing with. There are three types of buttons available to us.
 
@@ -362,9 +362,9 @@ Once a user is finished filling in a form, they will need a way to submit it. Th
 
 To create a submit button, we use the button element with a `type` attribute of "submit":
 
-```html
+~~~html
 <button type="submit">Submit</button>
-```
+~~~
 
 **Reset button**
 
@@ -372,9 +372,9 @@ A reset button clears all the data the user has entered into the form and sets a
 
 To create a reset button, we use the button element with a `type` attribute of "reset":
 
-```html
+~~~html
 <button type="reset">Reset</button>
-```
+~~~
 
 **Generic button**
 
@@ -382,9 +382,9 @@ The third and final button type is simply a generic button that can be used for 
 
 To create a generic button, we use the button element with a `type` attribute of "button":
 
-```html
+~~~html
 <button type="button">Click to Toggle</button>
-```
+~~~
 
 **Note**: It is important to remember that a button within a form with the `type` value of submit (which happens to be the default value) will always try to make a new request and submit data back to the server. Hence, for buttons that are used within a form for different purposes other than submitting the data, the `type` attribute should always be specified to avoid unwanted effects of submitting a form.
 
@@ -400,7 +400,7 @@ The fieldset element is a container element that allows us to group related form
 
 To create a fieldset, we use the `<fieldset>` element. Whatever form inputs we want to group together go within the opening and closing fieldset tags:
 
-```html
+~~~html
 <fieldset>
   <label for="first_name">First Name</label>
   <input type="text" id="first_name" name="first_name" />
@@ -408,7 +408,7 @@ To create a fieldset, we use the `<fieldset>` element. Whatever form inputs we w
   <label for="last_name">Last Name</label>
   <input type="text" id="last_name" name="last_name" />
 </fieldset>
-```
+~~~
 
 **Legend**
 
@@ -416,7 +416,7 @@ The legend element is used to give field sets a heading or caption so the user c
 
 To create a legend, we use the `<legend>` element with the text we want to display within its opening and closing tags. A legend should always come right after an opening fieldset tag:
 
-```html
+~~~html
 <fieldset>
   <legend>Contact Details</legend>
 
@@ -442,11 +442,11 @@ To create a legend, we use the `<legend>` element with the text we want to displ
   <label for="zip_code">Zip Code:</label>
   <input type="text" id="zip_code" name="zip_code" />
 </fieldset>
-```
+~~~
 
 A common use-case for these elements is using a fieldset to group radio buttons and using a legend to communicate to the user what each of the options is ultimately for:
 
-```html
+~~~html
 <fieldset>
   <legend>What would you like to drink?</legend>
 
@@ -465,7 +465,7 @@ A common use-case for these elements is using a fieldset to group radio buttons 
     <label for="soda">Soda</label>
   </div>
 </fieldset>
-```
+~~~
 
 ### A note on styling forms
 

--- a/intermediate_html_css/forms/form_validations.md
+++ b/intermediate_html_css/forms/form_validations.md
@@ -6,7 +6,7 @@ Validations are a vital ingredient in well-designed forms. They help protect our
 
 This lesson will explore some of the built-in validations you can use with HTML forms. We will also dive into styling validations with CSS.
 
-### Learning Outcomes
+### Learning outcomes
 
 By the end of this lesson, you should be able to:
 
@@ -14,7 +14,7 @@ By the end of this lesson, you should be able to:
 - Know how to use a few of the basic built-in HTML validations
 - Know how to build custom validations
 
-### Required Validation
+### Required validation
 
 We will often want to ensure specific fields have been filled in before submitting the form, for example, the email and password in a login form.
 
@@ -29,11 +29,11 @@ on <a href="https://codepen.io">CodePen</a>.</span>
 
 To ensure a good user experience and to meet accessibility guidelines, we should always indicate which fields are required. This will often be done by adding an asterisk(\*) to the required field label like we have done in the example.
 
-### Text Length Validations
+### Text length validations
 
 Sometimes we will want users to enter a minimum or a maximum amount of text into a field. Real-world examples of using these validations would be the old 140 character limit that Twitter used to have in its status field or having minimum and maximum length constraints on a username field.
 
-#### Minimum Length Validation
+#### Minimum length validation
 
 To add the minimum length validation, we give the form control a `minlength` attribute with an integer value that represents the minimum amount of characters we want to allow in the form control:
 
@@ -46,7 +46,7 @@ To add the minimum length validation, we give the form control a `minlength` att
 
 Try entering less than three characters into the text area and clicking the tweet button to see the validation in action.
 
-#### Maximum Length Validation
+#### Maximum length validation
 
 To add a maximum length validation, we give the form control a `maxlength` attribute with an integer value which represents the maximum amount of characters we want to allow in the form control:
 
@@ -59,7 +59,7 @@ To add a maximum length validation, we give the form control a `maxlength` attri
 
 With the maximum length validation, the browser will prevent users from entering more characters than the max length attribute value. Try this for yourself in the example above.
 
-#### Combining Validations
+#### Combining validations
 
 HTML allows us to apply as many validations as we wish to a form control. For example, we can give our tweet textarea both `minlength` and `maxlength` validations:
 
@@ -72,7 +72,7 @@ HTML allows us to apply as many validations as we wish to a form control. For ex
 
 This gives us much more scope to control what users input.
 
-### Number Range Validations
+### Number range validations
 
 Just like we often need to control the length of text-based form controls, there will be many situations where we will want to control the range of values users can enter into number based form controls.
 
@@ -82,7 +82,7 @@ You can view the complete list of supported elements on [MDN's documentation](h
 
 Some real-world use cases for using these validations would be limiting the quantity on a product order form or choosing the number of passengers on a flight booking form.
 
-#### Min Validation
+#### Min validation
 
 To add a minimum value validation, we give the form control a `min` attribute with an integer value which represents the minimum number we want the form control to accept:
 
@@ -95,7 +95,7 @@ To add a minimum value validation, we give the form control a `min` attribute wi
 
 Try submitting the form with a quantity of 0 to see the validation in action.
 
-#### Max Validation
+#### Max validation
 
 To add a maximum value validation, we give the form control a `max` attribute with an integer value which represents the maximum number we want the form control to accept:
 
@@ -108,7 +108,7 @@ To add a maximum value validation, we give the form control a `max` attribute wi
 
 Try submitting the form with seven passengers to see the validation in action.
 
-### Pattern Validations
+### Pattern validations
 
 To ensure we get the correct information from users, we will often want to ensure data matches a particular pattern.
 Real-world applications would be checking if a credit card number or a zipcode is in the correct format.
@@ -143,7 +143,7 @@ The pattern attribute can only be used on `<input>` elements. Some input element
 </p>
 <script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
 
-### Styling Validations
+### Styling validations
 
 We can target form controls that have passed or failed validations using the `:valid` and `:invalid` pseudo-classes.
 
@@ -183,15 +183,26 @@ It's also worth noting client-side validations are not a silver bullet for ensur
 
 </div>
 
-### Knowledge Check
+### Knowledge check
 
-- [What does the <code>required</code> validation do?](#required-validation)
-- [What validations can you use for checking text length?](#text-length-validations)
-- [How can you validate the minimum and maximum of numeric inputs?](#number-range-validations)
-- [What can you use the pattern validation for?](#pattern-validations)
-- [What pseudo CSS selectors are available for styling valid and invalid inputs?](#styling-validations)
+- [Introduction](#introduction)
+- [Learning outcomes](#learning-outcomes)
+- [Required validation](#required-validation)
+- [Text length validations](#text-length-validations)
+  - [Minimum length validation](#minimum-length-validation)
+  - [Maximum length validation](#maximum-length-validation)
+  - [Combining validations](#combining-validations)
+- [Number range validations](#number-range-validations)
+  - [Min validation](#min-validation)
+  - [Max validation](#max-validation)
+- [Pattern validations](#pattern-validations)
+- [Styling validations](#styling-validations)
+- [Conclusion](#conclusion)
+- [Assignment](#assignment)
+- [Knowledge check](#knowledge-check)
+- [Additional resources](#additional-resources)
 
-### Additional Resources
+### Additional resources
 
 - Check out [HTML5Pattern](https://www.html5pattern.com/) for a list of commonly used pattern regular expressions you may find helpful.
 - Look through [this Twitter thread](https://twitter.com/vponamariov/status/1400388896136040454) of the do's and don'ts for form validation UX.

--- a/intermediate_html_css/forms/form_validations.md
+++ b/intermediate_html_css/forms/form_validations.md
@@ -175,6 +175,7 @@ It's also worth noting client-side validations are not a silver bullet for ensur
 <div class="lesson-content__panel" markdown="1">
 
 1. Read and follow along to [MDN's Client-Side Form Validation Guide](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation)
+
    - Skip the section on "Validating forms using JavaScript". This will be covered in a future lesson.
 
 2. Go through SitePoint's [Complete Guide to HTML Forms and Constraint Validation Guide](https://www.sitepoint.com/html-forms-constraint-validation-complete-guide/). You can skip the section on "JavaScript and the Constraint Validation API" and "Creating a Custom Form Validator".
@@ -185,22 +186,11 @@ It's also worth noting client-side validations are not a silver bullet for ensur
 
 ### Knowledge check
 
-- [Introduction](#introduction)
-- [Learning outcomes](#learning-outcomes)
-- [Required validation](#required-validation)
-- [Text length validations](#text-length-validations)
-  - [Minimum length validation](#minimum-length-validation)
-  - [Maximum length validation](#maximum-length-validation)
-  - [Combining validations](#combining-validations)
-- [Number range validations](#number-range-validations)
-  - [Min validation](#min-validation)
-  - [Max validation](#max-validation)
-- [Pattern validations](#pattern-validations)
-- [Styling validations](#styling-validations)
-- [Conclusion](#conclusion)
-- [Assignment](#assignment)
-- [Knowledge check](#knowledge-check)
-- [Additional resources](#additional-resources)
+- [What does the <code>required</code> validation do?](#required-validation)
+- [What validations can you use for checking text length?](#text-length-validations)
+- [How can you validate the minimum and maximum of numeric inputs?](#number-range-validations)
+- [What can you use the pattern validation for?](#pattern-validations)
+- [What pseudo CSS selectors are available for styling valid and invalid inputs?](#styling-validations)
 
 ### Additional resources
 

--- a/intermediate_html_css/forms/form_validations.md
+++ b/intermediate_html_css/forms/form_validations.md
@@ -175,7 +175,6 @@ It's also worth noting client-side validations are not a silver bullet for ensur
 <div class="lesson-content__panel" markdown="1">
 
 1. Read and follow along to [MDN's Client-Side Form Validation Guide](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation)
-
    - Skip the section on "Validating forms using JavaScript". This will be covered in a future lesson.
 
 2. Go through SitePoint's [Complete Guide to HTML Forms and Constraint Validation Guide](https://www.sitepoint.com/html-forms-constraint-validation-complete-guide/). You can skip the section on "JavaScript and the Constraint Validation API" and "Creating a Custom Form Validator".

--- a/intermediate_html_css/forms/project_sign_up_form.md
+++ b/intermediate_html_css/forms/project_sign_up_form.md
@@ -11,13 +11,13 @@ This project is intended to give you a chance to flex some of the new items you'
 2. Set up your HTML and CSS files with some simple dummy content, just to make sure you have everything linked correctly.
 3. Download a full-resolution copy of [the design file](https://cdn.statically.io/gh/TheOdinProject/curriculum/5f37d43908ef92499e95a9b90fc3cc291a95014c/html_css/project-sign-up-form/sign-up-form.png), and get a general idea for how you're going to need to lay things out in your HTML document.
 
-#### Step 2: Gather Assets
+#### Step 2: Gather assets
 
 1. The design has a large background-image, so go find and download an image you want to use for that section. The one in the design can be found on [unsplash.com](https://unsplash.com/photos/25xggax4bSA), but feel free to select your own. Be sure to credit the creator of your image!
 2. Pick an external font for the 'logo' section. We've used [Norse Bold](https://cdn.statically.io/gh/TheOdinProject/theodinproject/efdc2888072f409e687d31dc580595dbe4fe0ff4/app/assets/fonts/Norse-Bold.otf), but you can use any font you like.
 3. For the image-sidebar, we've used [this Odin logo](https://cdn.statically.io/gh/TheOdinProject/curriculum/5f37d43908ef92499e95a9b90fc3cc291a95014c/html_css/project-sign-up-form/odin-lined.png). Again, feel free to replace it.
 
-#### Step 3: Some Tips!
+#### Step 3: Some tips!
 
 1. How you attack this project is mostly up to you, but it is wise to begin by scaffolding out the structure of the page, and then tackle the various sections one by one.
 2. The area behind the "ODIN" logo is a div that has a dark, but semi-transparent background color. This enhances the readability of the text against the busy background image.

--- a/intermediate_html_css/grid/advanced_grid_properties.md
+++ b/intermediate_html_css/grid/advanced_grid_properties.md
@@ -43,10 +43,10 @@ We use the properties `gap` and `padding` to establish a "gutter" area to be abl
 
 The `border` and `background-color` are included to make the container look nicer.
 
-~~~css
+```css
 grid-template-rows: 150px 150px;
 grid-template-columns: 150px 150px 150px 150px 150px;
-~~~
+```
 
 Here is where we want to begin our focus for this lesson. In order to make two rows and five columns, we manually define each row and column's track size individually.
 
@@ -60,21 +60,21 @@ Enter, `repeat()`.
 
 `repeat()` is a CSS function available to the CSS Grid template properties that allows us to define a number of rows or columns and the size we want them to be without having to manually type out each individual track's size. For example, in our setup above:
 
-~~~css
+```css
 .grid-container {
   grid-template-rows: 150px 150px;
   grid-template-columns: 150px 150px 150px 150px 150px;
 }
-~~~
+```
 
 can be rewritten as:
 
-~~~css
+```css
 .grid-container {
   grid-template-rows: repeat(2, 150px);
   grid-template-columns: repeat(5, 150px);
 }
-~~~
+```
 
 Check it out for yourself!
 
@@ -115,9 +115,9 @@ We can also tell our grid items to distribute the remaining space disproportiona
 
 In this example, there's a lot going on in our `grid-template-columns`, but take a minute to understand what is written:
 
-~~~css
+```css
 grid-template-columns: repeat(2, 2fr) repeat(3, 1fr);
-~~~
+```
 
 > Quick note: We continue to use the `repeat()` function here, but this could be written the old-fashioned way too!
 
@@ -144,21 +144,21 @@ We learned about `min()` and `max()` in our previous [lesson on CSS functions](h
 
 You can supply as many arguments to these functions as you want:
 
-~~~css
+```css
 .grid-container {
   grid-template-rows: repeat(2, min(100px, 200px, 300px, 400px, 500px));
   grid-template-columns: repeat(5, max(100px, 200px, 300px, 400px, 500px));
 }
-~~~
+```
 
 Of course, it's silly to give these functions static units because the calculation is meaningless: the smallest or largest value will always be returned. In the above example, the grid rows will always have a size of `100px` (the smallest of the five values) and the grid columns will always have a size of `500px` (the largest of the five). But when we provide a dynamic value as one of these arguments, we unlock the real potential of these functions, especially in the context of Grid:
 
-~~~css
+```css
 .grid-container {
   grid-template-rows: repeat(2, min(200px, 50%));
   grid-template-columns: repeat(5, max(120px, 15%));
 }
-~~~
+```
 
 In this case, the grid row size will be calculated from the values `200px` and `50%` grid container's height. In realtime, the browser will compare both of these values and apply whichever is smallest to the size of our grid row. Essentially, what this tells this grid is that the track size should be 50% of the grid's total vertical space (because we are defining a row size), _unless_ that number would exceed `200px`. Essentially, you're setting a max-height for the track.
 
@@ -189,12 +189,12 @@ It is a relatively straightforward function that only takes in two arguments:
 
 Unlike `min()` and `max()`, it _can_ make sense to use static values for both arguments. Here is an example of the grid we've been using written with `minmax()` and some static values:
 
-~~~css
+```css
 .grid-container {
   grid-template-rows: repeat(2, 1fr);
   grid-template-columns: repeat(5, minmax(150px, 200px));
 }
-~~~
+```
 
 With our `grid-template-columns` set with `minmax()` values, each grid item's width will grow and shrink with the grid container as it resizes horizontally. However, as the grid shrinks, the column tracks will stop shrinking at `150px`, and as the grid grows, they will stop growing at `200px`. Talk about flexibility! Check it out for yourself below:
 
@@ -217,21 +217,21 @@ Since `clamp()`'s purpose is to create a flexibly sized track with constraints, 
 
 Here is a simple non-grid example. We will look back at our grid in a moment:
 
-~~~css
+```css
 .simple-example {
   width: clamp(500px, 80%, 1000px);
 }
-~~~
+```
 
 This element, which we can pretend is just a `div`, will render with a width equal to 80% of its parent's width, unless that number is lower than `500px` or higher than `1000px`, in which case it will use those numbers as its width.
 
 Okay, now back to our grid:
 
-~~~css
+```css
 .grid-container {
   grid-template-columns: repeat(5, clamp(150px, 20%, 200px));
 }
-~~~
+```
 
 <p class="codepen" data-height="300" data-theme-id="dark" data-default-tab="css,result" data-slug-hash="dyVPPEL" data-editable="true" data-user="TheOdinProjectExamples" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;">
   <span>See the Pen <a href="https://codepen.io/TheOdinProjectExamples/pen/dyVPPEL">
@@ -250,23 +250,23 @@ These two values are actually a part of the `repeat()` function specification, b
 
 According to the [W3 specification on auto-fill and auto-fit](https://www.w3.org/TR/css-grid-1/#auto-repeat), both of these functions will return "the largest possible positive integer" without the grid items overflowing their container. Here is a simple example:
 
-~~~css
+```css
 .simple-example {
   display: grid;
   width: 1000px;
   grid-template-columns: repeat(auto-fit, 200px);
 }
-~~~
+```
 
 For this grid, we have a set width of `1000px` and we are telling it to fill in our columns with tracks of `200px` each. As long as there are at least five grid items, this will result in a 5-column layout no matter what. In this case, `auto-fill` would actually do the same thing. We will get into the difference soon.
 
 The real magic of `auto-fit` and `auto-fill` comes when we incorporate `minmax()` into the equation. With `minmax()`, we can tell our grid that we want to have as many columns as possible, using the constraints of our `minmax()` function to determine each column's size, without it overflowing our grid. Check out how cool our grid looks when we resize it now!
 
-~~~css
+```css
 .grid-container {
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
 }
-~~~
+```
 
 <p class="codepen" data-height="300" data-theme-id="dark" data-default-tab="css,result" data-slug-hash="abLzzgR" data-editable="true" data-user="TheOdinProjectExamples" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;">
   <span>See the Pen <a href="https://codepen.io/TheOdinProjectExamples/pen/abLzzgR">
@@ -302,6 +302,7 @@ To see this in action, look at the following 2 examples, the first with `auto-fi
 And that's about it! Congratulations, if you've made it this far, you are well on your way to becoming a Grid Master!
 
 ### Assignment
+
 <div class="lesson-content__panel" markdown="1">
 When doing the following exercises, please use all the documentation and resources you need to accomplish them. You are _not_ intended to have any of this stuff memorized at this point. Check the docs, use google, do what you need to do (besides checking the solutions) to get them done.
 
@@ -315,22 +316,15 @@ Go back to our [CSS exercises repository](https://github.com/TheOdinProject/css-
 
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
-- [Introduction](#introduction)
-- [Learning outcomes](#learning-outcomes)
-- [Setup](#setup)
-  - [`.grid-item, p, img` selectors](#grid-item-p-img-selectors)
-  - [`.grid-container`](#grid-container)
-- [Repeat](#repeat)
-- [Fractional units](#fractional-units)
-- [Minimum and maximum track sizes: min() and max()](#minimum-and-maximum-track-sizes-min-and-max)
-- [Dynamic minimum and maximum sizes](#dynamic-minimum-and-maximum-sizes)
-  - [minmax()](#minmax)
-  - [clamp()](#clamp)
-- [auto-fit and auto-fill](#auto-fit-and-auto-fill)
-  - [What about auto-fill?](#what-about-auto-fill)
-- [Assignment](#assignment)
-- [Knowledge check](#knowledge-check)
-- [Additional resources](#additional-resources)
+- [How do you create several grid tracks of the same size without manually typing each one out?](#repeat)
+- [What is the difference between a static and dynamic size value?](#fractional-units)
+- [How can you assign a grid track a flexible value that changes depending on the remaining space available in the grid?](#fractional-units)
+- [How can you assign grid tracks an uneven distribution of the remaining space in a grid?](#fractional-units)
+- [Which CSS functions will return the _smallest_ or _largest_ value supplied to them?](#minimum-and-maximum-track-sizes-min-and-max)
+- [Which CSS Grid-only function allows you to supply a minimum and maximum track size that is calculated in realtime?](#dynamic-minimum-and-maximum-sizes)
+- [Which global CSS function allows you to supply a minimum, ideal, and maximum value that is calculated in realtime?](#dynamic-minimum-and-maximum-sizes)
+- [What attribute of `repeat()` can be used to fill in as many grid tracks as possible, given certain constraints?](#auto-fit-and-auto-fill)
+- [What is the difference between `auto-fit` and `auto-fill`?](#auto-fit-and-auto-fill)
 
 ### Additional resources
 
@@ -339,4 +333,3 @@ This section contains helpful links to other content. It isn’t required, so co
 - More on `auto-fit` and `auto-fill` [here](https://css-tricks.com/auto-sizing-columns-css-grid-auto-fill-vs-auto-fit/).
 - If videos are more your speed, check out [this one](https://www.youtube.com/watch?v=qjJR3qYCd54).
 - Another great video to summarize what you have learned so far is [this one](https://www.youtube.com/watch?v=EiNiSFIPIQE).
-

--- a/intermediate_html_css/grid/advanced_grid_properties.md
+++ b/intermediate_html_css/grid/advanced_grid_properties.md
@@ -4,7 +4,7 @@ So far, you've learned how to create a grid, adjust the sizes of the tracks, and
 
 In this lesson, you will learn about some more advanced Grid properties that can help you do this.
 
-### Learning Outcomes
+### Learning outcomes
 
 By the end of this lesson, you will be able to:
 
@@ -35,7 +35,7 @@ All the properties here are simply to make our grid items look a bit nicer. They
 
 For our container, we are obviously using `display: grid` to render the container as a CSS Grid. But the next property might be unfamiliar to you: `resize: both`. This is a property that allows the user to resize the container by clicking and dragging from the bottom right corner. This will be beneficial to us when we start using properties that resize our grid tracks based on the size of the grid.
 
-**Change Zoom Levels:** Make sure to view the CodePen embeds at 0.5x or 0.25x so that there's room to resize the container. 
+**Change zoom levels:** Make sure to view the CodePen embeds at 0.5x or 0.25x so that there's room to resize the container.
 
 We use `overflow: auto` to enable scrolling if we resize the container to be smaller than our grid can accommodate.
 
@@ -136,7 +136,7 @@ You can also mix static units (like `px`) and dynamic units (like `fr`):
 
 You may have noticed at this point that when you resize the grid as large as possible, there is no limit to how large the grid items will become. However, when you resize it as small as possible, there is a distinct "smallest" size the grid will allow its items to go. In this case, it's the smallest size either the `<p>` or `<img>` element can be without overflowing. This breakpoint is the item's `min-content` value. This CSS keyword is **very** useful, but it is beyond the scope of this lesson. For more info, check out the [docs](https://developer.mozilla.org/en-US/docs/Web/CSS/min-content).
 
-### Minimum and Maximum Track Sizes: min() and max()
+### Minimum and maximum track sizes: min() and max()
 
 When we resize our grid super small, it is reassuring to know that the browser will stop the item from shrinking beyond the `min-content` value. However, we really don't want to rely on that most of the time. It's much better for you to explicitly decide as a developer how small and large your content should be, even in the most extreme situations.
 
@@ -173,7 +173,7 @@ Conversely, the grid column size will be calculated based on the larger of the t
 
 ### Dynamic minimum and maximum sizes
 
-#### `minmax()`
+#### minmax()
 
 `minmax()` is a CSS function that is specifically used with Grid. It can only be used with the following CSS properties:
 
@@ -205,7 +205,7 @@ With our `grid-template-columns` set with `minmax()` values, each grid item's wi
 </p>
 <script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
 
-#### `clamp()`
+#### clamp()
 
 Unlike `minmax()`, `clamp()` is a CSS function that can be used anywhere, not just within a grid container. As with `min()` and `max()`, we learned about it in a previous lesson, but let's do a quick review. The syntax is as follows:
 
@@ -279,7 +279,7 @@ Notice how when we resize, the columns automagically know how many will fit acro
 
 So what's going on here specifically with `repeat(auto-fit, minmax(150px, 1fr));`? Simple! Remember that `auto-fit` will return the **highest positive integer** without overflowing the grid. So first, the browser has to know how wide our grid is: in this case, it's just the window's width (minus margins) because we didn't explicitly set it. For the sake of this example, let's pretend like our window is currently `500px` wide. Second, the browser needs to know how many grid column tracks could possibly fit in that width. To do this, it uses the minimum value in our `minmax()` function, since that will yield the highest number of items, which is `150px`. If our window is `500px` wide, this means our grid will render 3 columns. But wait, there's more! Once the browser has determined how many columns we can fit, it then resizes our columns up to the maximum value allowed by our `minmax()` function. In this case, our max size is `1fr`, so all three columns will be given an equal allotment of the space available. As we resize our window, these calculations happen in realtime and the result is what you see in the above example!
 
-#### What about `auto-fill`?
+#### What about auto-fill?
 
 In most cases, `auto-fill` is going to work exactly the same way as `auto-fit`. The difference is only noticeable when there are fewer items than can fill up the entirety of the grid row once. When the grid is expanded to a size where another grid item _could_ fit, but there aren't any left, `auto-fit` will keep the grid items at their `max` size. Using `auto-fill`, the grid items will snap back down to their `min` size once the space becomes available to add another grid item, even if there isn't one to be rendered. They will continue their pattern of growing to `max` and snapping back to their `min` as the grid expands and more room becomes available for new grid tracks.
 
@@ -311,21 +311,28 @@ Go back to our [CSS exercises repository](https://github.com/TheOdinProject/css-
 2. grid-layout-3
 </div>
 
-### Knowledge Check
+### Knowledge check
 
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
-- [How do you create several grid tracks of the same size without manually typing each one out?](#repeat)
-- [What is the difference between a static and dynamic size value?](#fractional-units)
-- [How can you assign a grid track a flexible value that changes depending on the remaining space available in the grid?](#fractional-units)
-- [How can you assign grid tracks an uneven distribution of the remaining space in a grid?](#fractional-units)
-- [Which CSS functions will return the _smallest_ or _largest_ value supplied to them?](#minimum-and-maximum-track-sizes-min-and-max)
-- [Which CSS Grid-only function allows you to supply a minimum and maximum track size that is calculated in realtime?](#dynamic-minimum-and-maximum-sizes)
-- [Which global CSS function allows you to supply a minimum, ideal, and maximum value that is calculated in realtime?](#dynamic-minimum-and-maximum-sizes)
-- [What attribute of `repeat()` can be used to fill in as many grid tracks as possible, given certain constraints?](#auto-fit-and-auto-fill)
-- [What is the difference between `auto-fit` and `auto-fill`?](#auto-fit-and-auto-fill)
+- [Introduction](#introduction)
+- [Learning outcomes](#learning-outcomes)
+- [Setup](#setup)
+  - [`.grid-item, p, img` selectors](#grid-item-p-img-selectors)
+  - [`.grid-container`](#grid-container)
+- [Repeat](#repeat)
+- [Fractional units](#fractional-units)
+- [Minimum and maximum track sizes: min() and max()](#minimum-and-maximum-track-sizes-min-and-max)
+- [Dynamic minimum and maximum sizes](#dynamic-minimum-and-maximum-sizes)
+  - [minmax()](#minmax)
+  - [clamp()](#clamp)
+- [auto-fit and auto-fill](#auto-fit-and-auto-fill)
+  - [What about auto-fill?](#what-about-auto-fill)
+- [Assignment](#assignment)
+- [Knowledge check](#knowledge-check)
+- [Additional resources](#additional-resources)
 
-### Additional Resources
+### Additional resources
 
 This section contains helpful links to other content. It isn’t required, so consider it supplemental.
 

--- a/intermediate_html_css/grid/advanced_grid_properties.md
+++ b/intermediate_html_css/grid/advanced_grid_properties.md
@@ -43,10 +43,10 @@ We use the properties `gap` and `padding` to establish a "gutter" area to be abl
 
 The `border` and `background-color` are included to make the container look nicer.
 
-```css
+~~~css
 grid-template-rows: 150px 150px;
 grid-template-columns: 150px 150px 150px 150px 150px;
-```
+~~~
 
 Here is where we want to begin our focus for this lesson. In order to make two rows and five columns, we manually define each row and column's track size individually.
 
@@ -60,21 +60,21 @@ Enter, `repeat()`.
 
 `repeat()` is a CSS function available to the CSS Grid template properties that allows us to define a number of rows or columns and the size we want them to be without having to manually type out each individual track's size. For example, in our setup above:
 
-```css
+~~~css
 .grid-container {
   grid-template-rows: 150px 150px;
   grid-template-columns: 150px 150px 150px 150px 150px;
 }
-```
+~~~
 
 can be rewritten as:
 
-```css
+~~~css
 .grid-container {
   grid-template-rows: repeat(2, 150px);
   grid-template-columns: repeat(5, 150px);
 }
-```
+~~~
 
 Check it out for yourself!
 
@@ -115,9 +115,9 @@ We can also tell our grid items to distribute the remaining space disproportiona
 
 In this example, there's a lot going on in our `grid-template-columns`, but take a minute to understand what is written:
 
-```css
+~~~css
 grid-template-columns: repeat(2, 2fr) repeat(3, 1fr);
-```
+~~~
 
 > Quick note: We continue to use the `repeat()` function here, but this could be written the old-fashioned way too!
 
@@ -144,21 +144,21 @@ We learned about `min()` and `max()` in our previous [lesson on CSS functions](h
 
 You can supply as many arguments to these functions as you want:
 
-```css
+~~~css
 .grid-container {
   grid-template-rows: repeat(2, min(100px, 200px, 300px, 400px, 500px));
   grid-template-columns: repeat(5, max(100px, 200px, 300px, 400px, 500px));
 }
-```
+~~~
 
 Of course, it's silly to give these functions static units because the calculation is meaningless: the smallest or largest value will always be returned. In the above example, the grid rows will always have a size of `100px` (the smallest of the five values) and the grid columns will always have a size of `500px` (the largest of the five). But when we provide a dynamic value as one of these arguments, we unlock the real potential of these functions, especially in the context of Grid:
 
-```css
+~~~css
 .grid-container {
   grid-template-rows: repeat(2, min(200px, 50%));
   grid-template-columns: repeat(5, max(120px, 15%));
 }
-```
+~~~
 
 In this case, the grid row size will be calculated from the values `200px` and `50%` grid container's height. In realtime, the browser will compare both of these values and apply whichever is smallest to the size of our grid row. Essentially, what this tells this grid is that the track size should be 50% of the grid's total vertical space (because we are defining a row size), _unless_ that number would exceed `200px`. Essentially, you're setting a max-height for the track.
 
@@ -189,12 +189,12 @@ It is a relatively straightforward function that only takes in two arguments:
 
 Unlike `min()` and `max()`, it _can_ make sense to use static values for both arguments. Here is an example of the grid we've been using written with `minmax()` and some static values:
 
-```css
+~~~css
 .grid-container {
   grid-template-rows: repeat(2, 1fr);
   grid-template-columns: repeat(5, minmax(150px, 200px));
 }
-```
+~~~
 
 With our `grid-template-columns` set with `minmax()` values, each grid item's width will grow and shrink with the grid container as it resizes horizontally. However, as the grid shrinks, the column tracks will stop shrinking at `150px`, and as the grid grows, they will stop growing at `200px`. Talk about flexibility! Check it out for yourself below:
 
@@ -217,21 +217,21 @@ Since `clamp()`'s purpose is to create a flexibly sized track with constraints, 
 
 Here is a simple non-grid example. We will look back at our grid in a moment:
 
-```css
+~~~css
 .simple-example {
   width: clamp(500px, 80%, 1000px);
 }
-```
+~~~
 
 This element, which we can pretend is just a `div`, will render with a width equal to 80% of its parent's width, unless that number is lower than `500px` or higher than `1000px`, in which case it will use those numbers as its width.
 
 Okay, now back to our grid:
 
-```css
+~~~css
 .grid-container {
   grid-template-columns: repeat(5, clamp(150px, 20%, 200px));
 }
-```
+~~~
 
 <p class="codepen" data-height="300" data-theme-id="dark" data-default-tab="css,result" data-slug-hash="dyVPPEL" data-editable="true" data-user="TheOdinProjectExamples" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;">
   <span>See the Pen <a href="https://codepen.io/TheOdinProjectExamples/pen/dyVPPEL">
@@ -250,23 +250,23 @@ These two values are actually a part of the `repeat()` function specification, b
 
 According to the [W3 specification on auto-fill and auto-fit](https://www.w3.org/TR/css-grid-1/#auto-repeat), both of these functions will return "the largest possible positive integer" without the grid items overflowing their container. Here is a simple example:
 
-```css
+~~~css
 .simple-example {
   display: grid;
   width: 1000px;
   grid-template-columns: repeat(auto-fit, 200px);
 }
-```
+~~~
 
 For this grid, we have a set width of `1000px` and we are telling it to fill in our columns with tracks of `200px` each. As long as there are at least five grid items, this will result in a 5-column layout no matter what. In this case, `auto-fill` would actually do the same thing. We will get into the difference soon.
 
 The real magic of `auto-fit` and `auto-fill` comes when we incorporate `minmax()` into the equation. With `minmax()`, we can tell our grid that we want to have as many columns as possible, using the constraints of our `minmax()` function to determine each column's size, without it overflowing our grid. Check out how cool our grid looks when we resize it now!
 
-```css
+~~~css
 .grid-container {
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
 }
-```
+~~~
 
 <p class="codepen" data-height="300" data-theme-id="dark" data-default-tab="css,result" data-slug-hash="abLzzgR" data-editable="true" data-user="TheOdinProjectExamples" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;">
   <span>See the Pen <a href="https://codepen.io/TheOdinProjectExamples/pen/abLzzgR">

--- a/intermediate_html_css/grid/creating_a_grid.md
+++ b/intermediate_html_css/grid/creating_a_grid.md
@@ -28,15 +28,14 @@ We can think about CSS Grid in terms of a container and items. Simply put, when 
 
 In this example, the parent element marked `class="container"` becomes a grid container and each of the direct child elements below it automatically become grid items. What’s easy about CSS Grid is that you don’t have to assign each child element a property.
 
-Note that only the direct child elements will become grid items here. If we had another element as a child under one of _these_ child elements it would not be a grid item. In the example below, the paragraph element is not a grid item:
+Note that only the direct child elements will become grid items here. If we had another element as a child under one of *these* child elements it would not be a grid item. In the example below, the paragraph element is not a grid item:
 
 ~~~html
 <!-- index.html -->
 
 <div class="container">
   <div>Item 1</div>
-  <div>
-    Item 2
+  <div>Item 2
     <p>I am not a grid item!</p>
   </div>
   <div>Item 3</div>
@@ -44,7 +43,7 @@ Note that only the direct child elements will become grid items here. If we had 
 </div>
 ~~~
 
-But just as you learned in the flexbox lessons, grid items can _also_ be grid containers. So you could make grids inside of grids if you wanted.
+But just as you learned in the flexbox lessons, grid items can *also* be grid containers. So you could make grids inside of grids if you wanted.
 
 #### Lines and tracks in grids, oh my!
 
@@ -126,7 +125,7 @@ Let’s say we want any new rows to stay the same value as our explicit row trac
 }
 ~~~
 
-By default, CSS Grid will add additional content with implicit rows. This means the extra elements would keep being added further down the grid in a vertical fashion. It would be much less common to want extra content added horizontally along the grid, _but_ that can be set using the `grid-auto-flow: column` property and those implicit track sizes can be defined with the `grid-auto-columns` property.
+By default, CSS Grid will add additional content with implicit rows. This means the extra elements would keep being added further down the grid in a vertical fashion. It would be much less common to want extra content added horizontally along the grid, *but* that can be set using the `grid-auto-flow: column` property and those implicit track sizes can be defined with the `grid-auto-columns` property.
 
 ### Gap
 

--- a/intermediate_html_css/grid/creating_a_grid.md
+++ b/intermediate_html_css/grid/creating_a_grid.md
@@ -6,10 +6,10 @@ Now that you know what CSS Grid Layout is, you’ll learn how to create your own
 
 By the end of this lesson, you should be able to:
 
-* Make a grid container
-* Define grid tracks
-* Explain the difference between an implicit and explicit grid
-* Set gaps between grid cells
+- Make a grid container
+- Define grid tracks
+- Explain the difference between an implicit and explicit grid
+- Set gaps between grid cells
 
 ### Setting up a grid
 
@@ -28,22 +28,23 @@ We can think about CSS Grid in terms of a container and items. Simply put, when 
 
 In this example, the parent element marked `class="container"` becomes a grid container and each of the direct child elements below it automatically become grid items. What’s easy about CSS Grid is that you don’t have to assign each child element a property.
 
-Note that only the direct child elements will become grid items here. If we had another element as a child under one of *these* child elements it would not be a grid item. In the example below, the paragraph element is not a grid item:
+Note that only the direct child elements will become grid items here. If we had another element as a child under one of _these_ child elements it would not be a grid item. In the example below, the paragraph element is not a grid item:
 
-~~~html
+```html
 <!-- index.html -->
 
 <div class="container">
   <div>Item 1</div>
-  <div>Item 2
+  <div>
+    Item 2
     <p>I am not a grid item!</p>
   </div>
   <div>Item 3</div>
   <div>Item 4</div>
 </div>
-~~~
+```
 
-But just as you learned in the flexbox lessons, grid items can *also* be grid containers. So you could make grids inside of grids if you wanted.
+But just as you learned in the flexbox lessons, grid items can _also_ be grid containers. So you could make grids inside of grids if you wanted.
 
 #### Lines and tracks in grids, oh my!
 
@@ -77,14 +78,14 @@ If we want to add more columns or rows to our grid, we can simply define these v
 
 CSS Grid also includes a shorthand property for defining rows and columns. In our previous example we can replace the properties for `grid-template-rows` and `grid-template-columns` with the shorthand `grid-template` property. Here we can define our rows and columns all at once. For this property, rows are defined before the slash and columns are defined after the slash. Let’s keep the same column and row values, but use the shorthand property instead:
 
-~~~css
+```css
 /* styles.css */
 
 .container {
   display: grid;
   grid-template: 50px 50px / 50px 50px 50px;
 }
-~~~
+```
 
 Columns and rows don’t have to share all the same values either. Let’s change the property values of our columns so that the first column is five times as wide as the others:
 
@@ -108,13 +109,13 @@ Let's go back to our original example of a simple 2x2 layout for four grid items
 
 You’ll notice our fifth item was placed on the grid and it’s been slotted into a third row we did not define. This is because of the implicit grid concept and it’s how CSS Grid is able to automatically place grid items when we haven’t explicitly defined the layout for them.
 
-When we use the `grid-template-columns` and  `grid-template-rows` properties, we are explicitly defining grid tracks to lay out our grid items. But when the grid needs more tracks for extra content, it will implicitly define new grid tracks. Additionally, the size values established from our `grid-template-columns` or `grid-template-rows` properties are not carried over into these implicit grid tracks. But we can define values for the implicit grid tracks.
+When we use the `grid-template-columns` and `grid-template-rows` properties, we are explicitly defining grid tracks to lay out our grid items. But when the grid needs more tracks for extra content, it will implicitly define new grid tracks. Additionally, the size values established from our `grid-template-columns` or `grid-template-rows` properties are not carried over into these implicit grid tracks. But we can define values for the implicit grid tracks.
 
 We can set the implicit grid track sizes using the `grid-auto-rows` and `grid-auto-columns` properties. In this way we can ensure any new tracks the implicit grid makes for extra content are set at values that we defined.
 
 Let’s say we want any new rows to stay the same value as our explicit row track sizes:
 
-~~~css
+```css
 /* styles.css */
 
 .container {
@@ -123,9 +124,9 @@ Let’s say we want any new rows to stay the same value as our explicit row trac
   grid-template-rows: 50px 50px;
   grid-auto-rows: 50px;
 }
-~~~
+```
 
-By default, CSS Grid will add additional content with implicit rows. This means the extra elements would keep being added further down the grid in a vertical fashion. It would be much less common to want extra content added horizontally along the grid, *but* that can be set using the `grid-auto-flow: column` property and those implicit track sizes can be defined with the `grid-auto-columns` property.
+By default, CSS Grid will add additional content with implicit rows. This means the extra elements would keep being added further down the grid in a vertical fashion. It would be much less common to want extra content added horizontally along the grid, _but_ that can be set using the `grid-auto-flow: column` property and those implicit track sizes can be defined with the `grid-auto-columns` property.
 
 ### Gap
 
@@ -176,22 +177,14 @@ Now that you’ve made a grid you can start to see how easy it is to control the
 
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
-- [Introduction](#introduction)
-- [Learning outcomes](#learning-outcomes)
-- [Setting up a grid](#setting-up-a-grid)
-  - [Grid container](#grid-container)
-  - [Lines and tracks in grids, oh my!](#lines-and-tracks-in-grids-oh-my)
-  - [Columns and rows](#columns-and-rows)
-- [Explicit vs implicit grid](#explicit-vs-implicit-grid)
-- [Gap](#gap)
-- [Wrapping up our first grid](#wrapping-up-our-first-grid)
-- [Assignment](#assignment)
-- [Knowledge check](#knowledge-check)
-- [Additional resources](#additional-resources)
+- [How does an HTML element become a grid item?](#setting-up-a-grid)
+- [What is the space between lines on the grid?](#setting-up-a-grid)
+- [How do you set gutters (also known as alleys) in the grid?](#gap)
+- [Describe what happens when you have more content than defined tracks.](#explicit-vs-implicit-grid)
+- [How could you change the size for those undefined tracks?](#explicit-vs-implicit-grid)
 
 ### Additional resources
 
 This section contains helpful links to other content. It isn’t required, so consider it supplemental.
 
 - The [MDN Basic Concepts of grid layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout) reviews many of the basics and introduces some additional concepts.
-

--- a/intermediate_html_css/grid/creating_a_grid.md
+++ b/intermediate_html_css/grid/creating_a_grid.md
@@ -30,7 +30,7 @@ In this example, the parent element marked `class="container"` becomes a grid co
 
 Note that only the direct child elements will become grid items here. If we had another element as a child under one of _these_ child elements it would not be a grid item. In the example below, the paragraph element is not a grid item:
 
-```html
+~~~html
 <!-- index.html -->
 
 <div class="container">
@@ -42,7 +42,7 @@ Note that only the direct child elements will become grid items here. If we had 
   <div>Item 3</div>
   <div>Item 4</div>
 </div>
-```
+~~~
 
 But just as you learned in the flexbox lessons, grid items can _also_ be grid containers. So you could make grids inside of grids if you wanted.
 
@@ -78,14 +78,14 @@ If we want to add more columns or rows to our grid, we can simply define these v
 
 CSS Grid also includes a shorthand property for defining rows and columns. In our previous example we can replace the properties for `grid-template-rows` and `grid-template-columns` with the shorthand `grid-template` property. Here we can define our rows and columns all at once. For this property, rows are defined before the slash and columns are defined after the slash. Let’s keep the same column and row values, but use the shorthand property instead:
 
-```css
+~~~css
 /* styles.css */
 
 .container {
   display: grid;
   grid-template: 50px 50px / 50px 50px 50px;
 }
-```
+~~~
 
 Columns and rows don’t have to share all the same values either. Let’s change the property values of our columns so that the first column is five times as wide as the others:
 
@@ -115,7 +115,7 @@ We can set the implicit grid track sizes using the `grid-auto-rows` and `grid-au
 
 Let’s say we want any new rows to stay the same value as our explicit row track sizes:
 
-```css
+~~~css
 /* styles.css */
 
 .container {
@@ -124,7 +124,7 @@ Let’s say we want any new rows to stay the same value as our explicit row trac
   grid-template-rows: 50px 50px;
   grid-auto-rows: 50px;
 }
-```
+~~~
 
 By default, CSS Grid will add additional content with implicit rows. This means the extra elements would keep being added further down the grid in a vertical fashion. It would be much less common to want extra content added horizontally along the grid, _but_ that can be set using the `grid-auto-flow: column` property and those implicit track sizes can be defined with the `grid-auto-columns` property.
 

--- a/intermediate_html_css/grid/creating_a_grid.md
+++ b/intermediate_html_css/grid/creating_a_grid.md
@@ -2,7 +2,7 @@
 
 Now that you know what CSS Grid Layout is, you’ll learn how to create your own grid. This lesson will cover making a grid container, adding columns and rows, the explicit and implicit concept behind Grid and how to space out grid gaps.
 
-### Learning Outcomes
+### Learning outcomes
 
 By the end of this lesson, you should be able to:
 
@@ -11,11 +11,11 @@ By the end of this lesson, you should be able to:
 * Explain the difference between an implicit and explicit grid
 * Set gaps between grid cells
 
-### Setting Up a Grid
+### Setting up a grid
 
 This lesson will show you how easy it is to make a grid layout without much work. In upcoming lessons, you will find out more about positioning and how to make complex grids, but for now we’ll start with something simple.
 
-#### Grid Container
+#### Grid container
 
 We can think about CSS Grid in terms of a container and items. Simply put, when you make an element a grid container, it will “contain” the whole grid. In CSS, an element is turned into a grid container with the property `display: grid` or `display: inline-grid`.
 
@@ -45,13 +45,13 @@ Note that only the direct child elements will become grid items here. If we had 
 
 But just as you learned in the flexbox lessons, grid items can *also* be grid containers. So you could make grids inside of grids if you wanted.
 
-#### Lines and Tracks in Grids, Oh My!
+#### Lines and tracks in grids, oh my!
 
 Since you’re coding along with our example (right?) you will notice it doesn’t look very grid-ish yet. A lot of resources on CSS Grid like to show you boxes and outlined grid tables right from the start. But if your grid container and grid items don’t have any borders you won't actually see these lines on the page. So don’t worry, they’re still there!
 
 If you inspect these elements on a webpage using developer tools, you will notice grid badges on the grid elements in the code. The Layout options of the dev tools allows you to select an overlay that can show these invisible lines, tracks and areas of the grid. You will read about using a browser’s developer tools in the assignment below and learn more about lines, tracks, and areas in the next lesson.
 
-#### Columns and Rows
+#### Columns and rows
 
 Now that we have our grid container with several grid items all set up, it’s time to specify our columns and rows. This will define the grid track (the space between lines on a grid). So we could set a column track to give us space between our columns and a row track to give us space between our rows. We will get into the specifics on tracks and lines in the next lesson, but for now let’s just make some columns and rows.
 
@@ -66,7 +66,7 @@ Going back to our grid container from above, let’s define two columns and two 
 </p>
 <script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
 
-If we want to add more columns or rows to our grid, we can simply define these values to make another track. Let's say we wanted to add a third column to our example: 
+If we want to add more columns or rows to our grid, we can simply define these values to make another track. Let's say we wanted to add a third column to our example:
 
 <p class="codepen" data-height="300" data-theme-id="dark" data-default-tab="css,result" data-slug-hash="NWaPqxj" data-editable="true" data-user="TheOdinProjectExamples" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;">
   <span>See the Pen <a href="https://codepen.io/TheOdinProjectExamples/pen/NWaPqxj">
@@ -95,7 +95,7 @@ Columns and rows don’t have to share all the same values either. Let’s chang
 </p>
 <script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
 
-### Explicit vs Implicit Grid
+### Explicit vs implicit grid
 
 Let's go back to our original example of a simple 2x2 layout for four grid items. What happens if we add a fifth item to our container without changing our `grid-template-columns` or `grid-template-rows` properties?
 
@@ -110,7 +110,7 @@ You’ll notice our fifth item was placed on the grid and it’s been slotted in
 
 When we use the `grid-template-columns` and  `grid-template-rows` properties, we are explicitly defining grid tracks to lay out our grid items. But when the grid needs more tracks for extra content, it will implicitly define new grid tracks. Additionally, the size values established from our `grid-template-columns` or `grid-template-rows` properties are not carried over into these implicit grid tracks. But we can define values for the implicit grid tracks.
 
-We can set the implicit grid track sizes using the `grid-auto-rows` and `grid-auto-columns` properties. In this way we can ensure any new tracks the implicit grid makes for extra content are set at values that we defined. 
+We can set the implicit grid track sizes using the `grid-auto-rows` and `grid-auto-columns` properties. In this way we can ensure any new tracks the implicit grid makes for extra content are set at values that we defined.
 
 Let’s say we want any new rows to stay the same value as our explicit row track sizes:
 
@@ -160,7 +160,7 @@ Finally we’ll add a lot of gap to our rows to highlight the difference:
 
 You can also try playing with the shorthand `gap` to set both the `row-gap` and `column-gap` in the above CodePen.
 
-### Wrapping Up Our First Grid
+### Wrapping up our first grid
 
 Now that you’ve made a grid you can start to see how easy it is to control the layout of your elements with CSS Grid. You may also realize how CSS Grid can solve common layout problems. In the next couple lessons we will cover positioning elements and advanced grid attributes. But first, check out the links below that cover making the basics of a grid in more detail.
 
@@ -172,17 +172,24 @@ Now that you’ve made a grid you can start to see how easy it is to control the
 - Look through the developer tools docs on inspecting CSS Grid for [Chrome.](https://developer.chrome.com/docs/devtools/css/grid/)
 </div>
 
-### Knowledge Check
+### Knowledge check
 
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
-- [How does an HTML element become a grid item?](#setting-up-a-grid)
-- [What is the space between lines on the grid?](#setting-up-a-grid)
-- [How do you set gutters (also known as alleys) in the grid?](#gap)
-- [Describe what happens when you have more content than defined tracks.](#explicit-vs-implicit-grid)
-- [How could you change the size for those undefined tracks?](#explicit-vs-implicit-grid)
+- [Introduction](#introduction)
+- [Learning outcomes](#learning-outcomes)
+- [Setting up a grid](#setting-up-a-grid)
+  - [Grid container](#grid-container)
+  - [Lines and tracks in grids, oh my!](#lines-and-tracks-in-grids-oh-my)
+  - [Columns and rows](#columns-and-rows)
+- [Explicit vs implicit grid](#explicit-vs-implicit-grid)
+- [Gap](#gap)
+- [Wrapping up our first grid](#wrapping-up-our-first-grid)
+- [Assignment](#assignment)
+- [Knowledge check](#knowledge-check)
+- [Additional resources](#additional-resources)
 
-### Additional Resources
+### Additional resources
 
 This section contains helpful links to other content. It isn’t required, so consider it supplemental.
 

--- a/intermediate_html_css/grid/introduction_to_grid.md
+++ b/intermediate_html_css/grid/introduction_to_grid.md
@@ -4,14 +4,14 @@ Over the next few lessons we will cover CSS Grid and make page layouts much easi
 
 The following lessons will show you how to create a grid, position grid items and use some advanced properties. Then we will take a deeper look between Flexbox and Grid. Ultimately we are working towards building a dashboard project using Grid.
 
-### Learning Outcomes
+### Learning outcomes
 
 By the end of this lesson, you should be able to:
 
 * Compare the basics between Flexbox and Grid
 * Describe a situation for using Grid over Flexbox
 
-### A Look Back at Flex
+### A look back at flex
 
 In the Foundations course you learned a lot about Flexbox. If you’ve been using Flex here and there along the way, this section will be a quick refresher before we get into Grid. If you’re completely lost on Flex, then it might be helpful to go back through the [Flex lessons](https://www.theodinproject.com/lessons/foundations-introduction-to-flexbox) again to get up to speed.
 
@@ -54,7 +54,7 @@ But setting up a two-dimensional layout of cards would be much simpler using CSS
 </p>
 <script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
 
-### What is Grid?
+### What is grid?
 
 Although Grid is a newer module to CSS, this layout tool has long been in development. Fun fact, CSS co-creator Dr. Bert Bos (no relation to Wes Bos) started working on this layout model in 1996. The idea was inspired by the use of grid-like layouts in other forms of media like newspapers and magazines. After years of thorough demonstrations and development, CSS Grid was finally introduced to all major browsers in 2017.
 
@@ -66,7 +66,7 @@ When reviewing older resources, keep in mind that differences between Flex and G
 
 While some people thought CSS Grid was here to replace Flexbox, you will learn by the end of these lessons that Grid is just another tool for the bag. In fact, not only do each of these modules have their own use cases, but you will also find it helpful to pair Flex and Grid together. But we’ll be covering all of that in the concluding lesson. First you will learn how to actually make a grid!
 
-### Knowledge Check
+### Knowledge check
 
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
@@ -74,7 +74,7 @@ This section contains questions for you to check your understanding of this less
 - [Why was CSS Grid introduced?](#what-is-grid)
 - [Which CSS layout module would you use to easily make equal sized items in a container?](#what-is-grid)
 
-### Additional Resources
+### Additional resources
 
 This section contains helpful links to other content. It isn’t required, so consider it supplemental.
 

--- a/intermediate_html_css/grid/positioning_grid_elements.md
+++ b/intermediate_html_css/grid/positioning_grid_elements.md
@@ -2,7 +2,7 @@
 
 In this lesson we will examine the different parts of a grid and explore common properties that can be used to position grid items.
 
-### Learning Outcomes
+### Learning outcomes
 
 By the end of this lesson, you should be able to:
 
@@ -10,7 +10,7 @@ By the end of this lesson, you should be able to:
 * Position items by defining their start and end lines
 * Use shorthand notation
 
-### Reviewing Tracks
+### Reviewing tracks
 
 Before we dive straight into positioning, let's establish some terminology to better understand the different parts of a grid. In the previous lesson you learned that when you define a grid using `grid-template`, you are defining the *tracks* the grid will have. You can think of a grid track as any single row or column on a grid.
 
@@ -23,7 +23,7 @@ To give an example, if we wanted to create a 3x3 grid with 100 pixel rows and 10
 </p>
 <script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
 
-You will notice two CSS lines have been commented out in this CodePen. Uncomment the property in the `.first-row` class selector to see the grid track between the first and second-row grid lines. 
+You will notice two CSS lines have been commented out in this CodePen. Uncomment the property in the `.first-row` class selector to see the grid track between the first and second-row grid lines.
 
 Next, uncomment the property in the `.last-column` class selector to see the grid track between the third and fourth-column grid lines.
 
@@ -35,7 +35,7 @@ Every track has a start line and an end line. The lines are numbered from left t
 
 Grid lines are what we use to position grid items. We'll get to that in a minute, but first let's take a deeper look at grid lines using our developer tools.
 
-If you open up developer tools in Chrome, you can navigate to the Layout pane and find the Grid overlay display settings. Make sure that _show line numbers_ is enabled. Select the correct element from the Grid overlays (e.g. this might be our `div.container` if you are inspecting our CodePen.) You should now see an overlay of the grid lines. 
+If you open up developer tools in Chrome, you can navigate to the Layout pane and find the Grid overlay display settings. Make sure that _show line numbers_ is enabled. Select the correct element from the Grid overlays (e.g. this might be our `div.container` if you are inspecting our CodePen.) You should now see an overlay of the grid lines.
 
 Notice that the developer tools also show negative lines opposite from the positive lines. You don't have to worry about the negative lines for now, but know that this gives you another option to use when positioning the grid items.
 
@@ -67,13 +67,13 @@ As it stands this is a pretty sad unit. To make it less of an empty box and more
 </p>
 <script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
 
-Most of our rooms represent a single grid cell. But we have given ourselves a large living room. (Yay!) We positioned this item using `grid-column-start` and `grid-column-end`. Their property values represent the column grid lines we wish it to start and end with. 
+Most of our rooms represent a single grid cell. But we have given ourselves a large living room. (Yay!) We positioned this item using `grid-column-start` and `grid-column-end`. Their property values represent the column grid lines we wish it to start and end with.
 
 You will also notice we have commented out property values for this item's grid row positioning. Uncomment the `grid-row-start` and `grid-row-end` properties to see how our living room can get even bigger by taking up the grid track between the first and third-row grid lines.
 
 These properties allow us to use our existing grid lines to tell items how many rows and columns each item should span across. Take a minute to play around with the property values here. If the line numbers are confusing, inspect the container using your dev tools to show the grid overlay.
 
-Next, we need to use our space more efficiently. We will make the rest of our rooms span multiple grid cells and fill out the rest of our apartment. 
+Next, we need to use our space more efficiently. We will make the rest of our rooms span multiple grid cells and fill out the rest of our apartment.
 
 <p class="codepen" data-height="300" data-theme-id="dark" data-default-tab="css,result" data-slug-hash="jOGEbrX" data-editable="true" data-user="TheOdinProjectExamples" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;">
   <span>See the Pen <a href="https://codepen.io/TheOdinProjectExamples/pen/jOGEbrX">
@@ -88,7 +88,7 @@ One problem with our floor plan is that the bathroom and kitchen are on opposite
 
 ### grid-area
 
-You now know how to position your grid items using row and column lines. But there are other ways to position items and this is where things can get a little confusing. 
+You now know how to position your grid items using row and column lines. But there are other ways to position items and this is where things can get a little confusing.
 
 There is an even shorter shorthand for positioning grid items with start and end lines. You can combine `grid-row-start` / `grid-column-start` / `grid-row-end` / `grid-column-end` into one line using `grid-area`.
 
@@ -102,7 +102,7 @@ Our living room above can be written out like this:
 }
 ~~~
 
-But `grid-area` can also refer to a few different things. 
+But `grid-area` can also refer to a few different things.
 
 Instead of using the grid lines to position all the items in a grid, we can create a visual layout of the grid in words. To do this we give each item on the grid a name using `grid-area`.
 
@@ -125,7 +125,7 @@ We could do this to all of our grid items and give each room a `grid-area` value
 </p>
 <script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
 
-Wow! You might want to open up the CodePen browser and make it large enough to really read the `grid-template-areas` layout line by line. But this tool gives us a completely different way to position items. 
+Wow! You might want to open up the CodePen browser and make it large enough to really read the `grid-template-areas` layout line by line. But this tool gives us a completely different way to position items.
 
 We can even use `.` to indicate empty cells. Say our apartment might be getting a water heater and washer/dryer. We might not be sure of the exact layout but we can visualize some space easily by removing more room in the bathroom and kitchen:
 
@@ -138,14 +138,14 @@ We can even use `.` to indicate empty cells. Say our apartment might be getting 
 
 So now you know two very different ways of using `grid-area` on a grid item. You might even see the term "grid area" refer to a group of cells. For example, all the grid cells of the living room together is a grid area. The apartment analogy should help. A grid item can take up multiple cells forming an area of the grid much like a room with four walls in an apartment.
 
-### Wrapping Up
+### Wrapping up
 
 As you go through the assignments you will come across more terminology like `span` and `auto` when positioning grid items across tracks. There are also properties to justify and align grid items similar to Flexbox. The best way to learn all this terminology and how to position items is with lots of practice!
 
 ### Assignment
 <div class="lesson-content__panel" markdown="1">
 - Read MDN's [Line-based Placement with CSS Grid.](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid)
-- Review [Part 4 on Grid Properties](https://css-tricks.com/snippets/css/complete-guide-grid/#grid-properties) from CSS-Tricks. 
+- Review [Part 4 on Grid Properties](https://css-tricks.com/snippets/css/complete-guide-grid/#grid-properties) from CSS-Tricks.
 </div>
 
 ### Practice
@@ -156,7 +156,7 @@ Go back to our [CSS exercises repository](https://github.com/TheOdinProject/css-
 
 1. grid-layout-1
 
-### Knowledge Check
+### Knowledge check
 
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
@@ -166,10 +166,10 @@ This section contains questions for you to check your understanding of this less
 - [Which property can we use to combine all the start and end values for a grid item?](#grid-area)
 - [Which grid container property can map out a visual structure of grid items?](#grid-area)
 
-### Additional Resources
+### Additional resources
 
 This section contains helpful links to other content. It isn’t required, so consider it supplemental.
 
 - Play through levels 1 - 17 of [CSS Grid Garden](https://cssgridgarden.com/) to practice positioning items. Note the rest of the levels go beyond the scope of this lesson.
-- If you want to know more about using `grid-template-areas` check out this [Smashing Magazine article from Rachel Andrew.](https://www.smashingmagazine.com/understanding-css-grid-template-areas) 
+- If you want to know more about using `grid-template-areas` check out this [Smashing Magazine article from Rachel Andrew.](https://www.smashingmagazine.com/understanding-css-grid-template-areas)
 - To learn more about alignment and centering items read through these MDN Docs on [Box Alignment in CSS Grid Layout.](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout)

--- a/intermediate_html_css/grid/project_admin_dashboard.md
+++ b/intermediate_html_css/grid/project_admin_dashboard.md
@@ -8,7 +8,7 @@ Now that you've had plenty of practice using Grid, we are going to build a full 
 
 <div class="lesson-content__panel" markdown="1">
 
-#### Step 1: Set Up and Planning
+#### Step 1: Set up and planning
 
 1. Set up your HTML and CSS files with some simple dummy content, just to make sure you have everything linked correctly.
 2. Set up your Git repository (refer to past projects if you need a refresher).
@@ -27,22 +27,22 @@ Now that you've had plenty of practice using Grid, we are going to build a full 
 4. For the main-content, use more grids to lay out the projects, announcements and trending items.
 5. Fill out some dummy content and placeholder images so you can position all of your grid items.
 
-#### Step 4: Gather Assets
+#### Step 4: Gather assets
 
 1. Once you have your grid layout complete you can either recreate the dashboard example above or style your own design.
 2. Check out some color palettes from [Tailwind.](https://tailwindcss.com/docs/customizing-colors)
 3. All of the icons and more can be downloaded as SVGs from [Material Design Icons.](https://pictogrammers.com/library/mdi/)
 4. Choose your own fonts! The design example uses `Roboto`, which is available with Google fonts.
 
-#### Step 5: Some Tips!
+#### Step 5: Some tips!
 
 1. When building the layout, apply background colors or borders to your containers to help you visualize your grid.
-2. It's up to you whether to use pixels, `fr` units or both for your grid tracks. 
+2. It's up to you whether to use pixels, `fr` units or both for your grid tracks.
 3. This project does not have to be responsive, but if you'd like to you can expand or shrink the project cards section when resizing the browser window.
 4. You don't have to make a pixel perfect match with the design example. Consider this an opportunity to practice your CSS skills with your own designs.
 5. Don't forget to push your finished dashboard to GitHub. Use GitHub Pages to publish it to the world!
 
-#### Step 6: Section Feedback 
+#### Step 6: Section feedback
 
 1. Before you move on, we would like your feedback [here](https://docs.google.com/forms/d/e/1FAIpQLSf_hNwIjvqcPZyl9Lx41mgJNQKp04qOro03SI8ABw4Zp7U_4w/viewform?usp=sf_link). Getting user (you) feedback is important so we can continue to improve the curriculum and get an idea of your experience.
 

--- a/intermediate_html_css/grid/using_flexbox_and_grid.md
+++ b/intermediate_html_css/grid/using_flexbox_and_grid.md
@@ -1,8 +1,8 @@
 ### Introduction
 
-Some may tell you there is a debate on the use of Grid vs. Flexbox and whether or not one is superior to the other. The reality is much simpler - these are complementary tools that can work together, and each has its own place in the world of CSS. 
+Some may tell you there is a debate on the use of Grid vs. Flexbox and whether or not one is superior to the other. The reality is much simpler - these are complementary tools that can work together, and each has its own place in the world of CSS.
 
-### Learning Outcomes
+### Learning outcomes
 
 By the end of this lesson, you should be able to:
 
@@ -10,9 +10,9 @@ By the end of this lesson, you should be able to:
 * Know when you might want to use Grid over Flexbox
 * Know when you might want to use the two together
 
-### Content First vs Layout First Design
+### Content first vs layout first design
 
-A way to decide between Grid and Flexbox is to consider if your design starts from the content, or from the layout. 
+A way to decide between Grid and Flexbox is to consider if your design starts from the content, or from the layout.
 
 In Content First Design, you begin with clarity of how the content should be, and the layout follows. This is a great opportunity to use Flexbox. Its flexible nature gives you control of the *behavior* of items through logical rules. How they grow, shrink, their ideal size and position in relation to each other, all make the layout dynamic. While Flexbox gives you control over its content, the final layout is only a consequence. Depending on the dimensions of the flex container, the general layout can change a lot.
 
@@ -29,7 +29,7 @@ Content or Layout First Design do not force us to use either Flexbox or Grid! Le
 
 It works and looks absolutely *beautiful*! But imagine we would like to move these boxes around in the future. Or, for instance, we wanted the third box to stretch in a second row so that the boxes didn't shrink too much to fit in only one. Both of these things would be *possible* in Grid. But if controlling the layout isn't our priority, Flexbox is more intuitive and fit for the task.
 
-### Combining Flexbox and Grid
+### Combining flexbox and grid
 If you have one-dimensional content, Flexbox can make it easier to control how that content is positioned in a Flex container. If, on the other hand, you want to accurately place content on a complex layout in two-dimensions, Grid can be simpler to use.
 
 Say you want your overall layout to be a grid, but you want the grid items to act as flex parents. This way, the grid items can be moved around using the precise two-dimensional placement Grid allows for, while also allowing the content inside the grid items to be capable of freely moving around using Flex. Check out this example from CSS-Tricks.
@@ -55,7 +55,7 @@ This lesson includes recommendations, not the "right" or "wrong" way of using Fl
 3. To gain some more insight on when to use Grid or Flexbox and why, read through this [article](https://webdesign.tutsplus.com/articles/flexbox-vs-css-grid-which-should-you-use--cms-30184)
 </div>
 
-### Knowledge Check
+### Knowledge check
 
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
@@ -63,7 +63,7 @@ This section contains questions for you to check your understanding of this less
 - [When might you use Grid over Flexbox?](#content-first-vs-layout-first-design)
 - [When might you use the two of these tools together?](#combining-flexbox-and-grid)
 
-### Additional Resources
+### Additional resources
 
 This section contains helpful links to other content. It isn’t required, so consider it supplemental.
 


### PR DESCRIPTION
## Because
Forms and Grid sections contained inconsistent heading styles.

## This PR
- updates headings to be in sentence case format.
- removes code snippets from headings per the Style Guide.

## Issue
Related to #25861

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
