### PR TITLE
Type Checking With PropTypes: Update section about warning

### DIFF
--- a/react/the_react_ecosystem/type_checking_with_proptypes.md
+++ b/react/the_react_ecosystem/type_checking_with_proptypes.md
@@ -44,7 +44,14 @@ RenderName.propTypes = {
 export default RenderName;
 ~~~
 
-In this example, the component RenderName expects to receive a prop called `name` which is a string. If this prop is not passed, or if it is not a string, a warning will be displayed.
+In this example, the component RenderName expects to receive a prop called `name` which is a string. If this prop is not a string, a warning will be displayed. 
+If you want to make sure a prop is passed in, use `isRequired` like so:
+
+~~~javascript
+RenderName.propTypes = {
+  name: PropTypes.string.isRequired,
+};
+~~~
 
 ### Using defaultProps
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Previously it was stated that a warning will be displayed if props are not passed in or will be of different type than expected by propTypes. In the case of improper type a warning is displayed, but in the case of not passing in props no warning is displayed. If there's a need to make sure a prop is passed at all, isRequired is needed.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- deleted a sentence stating that non passing props will result in an error being displayed
- added example with `isRequired` that displays an error in the case of props not passed in

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
