### PR TITLE
Change Headers to use spell-case for React Testing and React Ecosystem Sections 

### DIFF
--- a/react/react_testing/introduction_to_react_testing.md
+++ b/react/react_testing/introduction_to_react_testing.md
@@ -191,7 +191,7 @@ The other issue with snapshots is false negatives. Even the most insignificant o
 
 </div>
 
-### Knowledge Check 
+### Knowledge check 
 
 This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
 
@@ -203,7 +203,7 @@ This section contains questions for you to check your understanding of this less
 * [What is the advantage of snapshot tests?](#advantage-snapshot-tests)
 * [What are the disadvantages of snapshot tests?](#disadvantage-snapshot-tests)
 
-### Additional Resources
+### Additional resources
 
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 

--- a/react/react_testing/mocking_callbacks_and_components.md
+++ b/react/react_testing/mocking_callbacks_and_components.md
@@ -4,17 +4,17 @@ We've already covered some basics of React testing. Now's the time to dive deepe
 
 In this lesson, we'll learn about mocking. Furthermore, we'll discuss a React component from this ([theodinproject.com](https://theodinproject.com)) website and understand how React tests are written in a real world application.
 
-### Lesson Overview
+### Lesson overview
 
 This section contains a general overview of topics that you will learn in this lesson.
 
 * Carry out mocks in the context of React testing.
 
-### What is Mocking?
+### What is mocking?
 
 If you've been following along with our lessons so far, the concept of mocking has already been introduced in an earlier section and you might have even incorporated mocks in your [Battleship project in the Testing JavaScript section of this course](https://www.theodinproject.com/lessons/javascript-battleship). Let's look at how mocks will help in testing React components.
 
-#### Testing Callback Handlers
+#### Testing callback handlers
 
 Callbacks are ubiquitous. Every avenue of user interaction involves callbacks. Sometimes they're passed in as props to alter state of the parent component. Consider this simple button component:
 
@@ -82,11 +82,11 @@ But what if you want to set up your mocks in a `beforeEach` block rather than in
 
 It is recommended to invoke `userEvent.setup()` before rendering the component, and it is discouraged to call renders and `userEvent` functions outside of the test itself, (for example, in a `beforeEach` block). If you find yourself repeating the same code in multiple tests, the recommended approach to shorten each test is to write a setup function, as [outlined in the documentation](https://testing-library.com/docs/user-event/intro/#writing-tests-with-userevent).
 
-#### Mocking Child Components
+#### Mocking child components
 
 You might have come across the concept of mocking modules. In React, when the component tree gets large, tests can become convoluted. Especially for components higher up the tree. That's why we mock child components. This is not something you'll come across often, nevertheless, it's beneficial to realize the concept in case you might need it in your own testing pursuits.
 
-### React Testing in the Real World
+### React testing in the real world
 
 If you're logged in on this ([theodinproject.com](https://theodinproject.com)) website, you've probably come across the project submissions list under every project. Those components are written in React and tested with the React Testing Library. This'll be fun. Your task is simple:
 
@@ -133,7 +133,7 @@ Let's move towards our first assertion. Don't worry too much about the `ProjectS
 
 In the first suite, we make some assertions if the user has a submission and then some assertions if the user does not. The other suites follow a similar pattern.
 
-#### Exploring Further
+#### Exploring further
 
 Feel free to flick through the other components and their tests. You'll see mocked functions. You'll see some unseen functions like `act`. You'll see custom render functions. It's fine if you don't understand it all, the goal is to gain familiarity.
 
@@ -149,14 +149,14 @@ The other important thing to note is almost all the tests follow a certain patte
 
 </div>
 
-### Knowledge Check
+### Knowledge check
 
 This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
 
 * [How can you mock a callback handler?](#testing-callback-handlers)
 * [How can you mock a child component?](#mock-child-component)
 
-### Additional Resources
+### Additional resources
 
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 

--- a/react/the_react_ecosystem/react_router.md
+++ b/react/the_react_ecosystem/react_router.md
@@ -144,7 +144,7 @@ export default App;
 
 And now, we don't get the browser reloading every time we click the link on the navbar!
 
-### Nested routes, outlets And dynamic segments
+### Nested routes, outlets and dynamic segments
 
 Now, what if you want to render a section of a page differently, based on different URLs? This is where nested routes into play! We can add routes nested as the children of one another to ensure that the child gets rendered alongside the parent. Create a couple of components, `Popeye.js` and `Spinach.js`.
 

--- a/react/the_react_ecosystem/react_router.md
+++ b/react/the_react_ecosystem/react_router.md
@@ -12,7 +12,7 @@ This section contains a general overview of topics that you will learn in this l
 - How do you add a "catch-all" route?
 - How do you add protected routes?
 
-### Client-Side routing
+### Client-side routing
 
 Client-side routing is the type of routing where Javascript takes over the duty of handling the routes in an application. Client-side routing helps in building single-page applications (SPAs) without refreshing as the user navigates. For example, when a user clicks a navbar element, the URL changes and the view of the page is modified accordingly, within the client.
 

--- a/react/the_react_ecosystem/react_router.md
+++ b/react/the_react_ecosystem/react_router.md
@@ -2,7 +2,7 @@
 
 Up until this point in the curriculum, we have been building one-page applications. However, for any larger scale application, we are going to have multiple pages. Thankfully, the browser allows client-side Javascript to manage the way a user can navigate, with the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API/Working_with_the_History_API). We can leverage the power of this to manage routing in React with the help of a package like React Router.
 
-### Lesson Overview
+### Lesson overview
 
 This section contains a general overview of topics that you will learn in this lesson.
 
@@ -12,7 +12,7 @@ This section contains a general overview of topics that you will learn in this l
 - How do you add a "catch-all" route?
 - How do you add protected routes?
 
-### Client-Side Routing
+### Client-Side routing
 
 Client-side routing is the type of routing where Javascript takes over the duty of handling the routes in an application. Client-side routing helps in building single-page applications (SPAs) without refreshing as the user navigates. For example, when a user clicks a navbar element, the URL changes and the view of the page is modified accordingly, within the client.
 
@@ -31,13 +31,13 @@ This is common to all websites, you set the oven up for what you want (visit any
 
 Here is where we reiterate, **the chicken needs to be reheated**. In a general multi-page application (MPAs), the browser reloads every time you click on a link to navigate. With client-side routing, **you never leave the page you are on** - you bring the microwave to the table to ensure that you don't run into the "missing spices" issues. The link requests are intercepted by the Javascript that you write, instead of letting them go directly to the server.
 
-### A Reactive Solution
+### A Reactive solution
 
 While client-side routing allows for nicer, app-like interactions (since you are controlling the routes, you can make fancy CSS animations across route changes), a lot of caveats can be missed. Browsers reloads notify screen-readers of new content to read, so you will need to notify screen-readers of route updates manually. However, with the help of a robust library, you can often address these concerns!
 
 React Router is a standard routing library for React applications. By using React Router, we can specify React components, that can be rendered based on the route, and so much more. Let's dive in!
 
-### Adding A Router
+### Adding a router
 
 Let's make a small app to understand how this router is implemented. Create a new React project and let's start by adding some mock pages as an example. Create a new `Profile.js` file with the following component:
 
@@ -116,7 +116,7 @@ Once this is done, go ahead and run `npm start` and check out both routes: the h
 3. The configuration array contains objects with two mandatory keys, the path and the corresponding element to be rendered.
 4. This generated configuration is then rendered in, by passing it to the `RouterProvider` component.
 
-### The Link Element
+### The link element
 
 But you may notice, when we click the links in the navbar, the browser is reloading for the next URL instead of using React Router. This isn't what was promised! To help with this, [React Router exports a custom `Link` element](https://reactrouter.com/en/main/components/link) to be used instead of the regular `a` tag. We can replace the `a` tag in our navbar with the `Link` element.
 
@@ -144,7 +144,7 @@ export default App;
 
 And now, we don't get the browser reloading every time we click the link on the navbar!
 
-### Nested Routes, Outlets And Dynamic Segments
+### Nested routes, outlets And dynamic segments
 
 Now, what if you want to render a section of a page differently, based on different URLs? This is where nested routes into play! We can add routes nested as the children of one another to ensure that the child gets rendered alongside the parent. Create a couple of components, `Popeye.js` and `Spinach.js`.
 
@@ -338,7 +338,7 @@ const Profile = () => {
 export default Profile;
 ~~~
 
-### Handling Bad Urls
+### Handling bad urls
 
 But alas, the index path doesn't work with this anymore, as in the `/profile` path, no params are actually passed. Actually, the `/profile` path doesn't make much sense without an actual name, else whose profile is it supposed to show, right? So, the application shows an error! This can't be good, so how do you show a default page in case the user visits a wrong or unused path? You can pass in an `errorElement` argument here! Create a basic "Not Found" page:
 
@@ -388,7 +388,7 @@ ReactDOM.createRoot(document.getElementById("root")).render(
 );
 ~~~
 
-### Refactoring The Routing
+### Refactoring the routing
 
 But before we do that, let us refactor our routes to a component of their own, so that we can add whatever conditional logic we want, if it exists as a hook (remember, we can't use hooks outside of a React component!). Even if you don't have any need for a conditional rendering of routes, it is much neater nonetheless, to have them separate. Create a new `Router.js` component and move your routes to it.
 
@@ -433,7 +433,7 @@ ReactDOM.createRoot(document.getElementById("root")).render(
 
 This seems so much nicer, right?
 
-### Protected Routes And Navigation
+### Protected routes and navigation
 
 Often, you will face a need to decide when a certain route is rendered or not. One use case is authentication, where you may want to render certain routes based on if the user is logged in or not. If they are logged in, you may want to show some information about the user like [here at the dashboard](https://www.theodinproject.com/dashboard). While there are many ways to do so, one of the easiest ways can be to conditionally creating a config for the router.
 
@@ -454,7 +454,7 @@ You should now have enough basics to get started with React routing. There are a
 
 </div>
 
-### Knowledge Check
+### Knowledge check
 
 This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
 
@@ -466,7 +466,7 @@ This section contains questions for you to check your understanding of this less
 - <a class="knowledge-check-link" href="#handling-bad-urls">How do you add a "catch-all" route?</a>
 - <a class="knowledge-check-link" href="#protected-routes-and-navigation">How do you create protected routes?</a>
 
-### Additional Resources
+### Additional resources
 
 This section contains helpful links to related content. It isn’t required, so consider it supplemental.
 

--- a/react/the_react_ecosystem/styling_react_applications.md
+++ b/react/the_react_ecosystem/styling_react_applications.md
@@ -22,7 +22,7 @@ Why even write CSS in CSS when you can write it in JavaScript? Just kidding, of 
 
 CSS-in-JS is a paradigm for styling front-end projects. It allows you to entirely take control of CSS with JavaScript and extends it with various features. Additionally, it also helps to apply styling in a logical fashion i.e. based on state. There are various CSS-in-JS solutions. One of the most popular ones in the React ecosystem is [styled-components](https://styled-components.com/).
 
-### Component Libraries
+### Component libraries
 
 What if everything's already done for you? Styling, behavior, and accessibility are taken care of for you in component libraries. As the name suggests, these libraries provide adaptable and reusable components that you can use directly in your project. These components include, but are not limited to, dropdowns, drawers, calendars, toggles, tabs, and all other components you can think of. 
 

--- a/react/the_react_ecosystem/styling_react_applications.md
+++ b/react/the_react_ecosystem/styling_react_applications.md
@@ -22,7 +22,7 @@ Why even write CSS in CSS when you can write it in JavaScript? Just kidding, of 
 
 CSS-in-JS is a paradigm for styling front-end projects. It allows you to entirely take control of CSS with JavaScript and extends it with various features. Additionally, it also helps to apply styling in a logical fashion i.e. based on state. There are various CSS-in-JS solutions. One of the most popular ones in the React ecosystem is [styled-components](https://styled-components.com/).
 
-### Component libraries
+### Component Libraries
 
 What if everything's already done for you? Styling, behavior, and accessibility are taken care of for you in component libraries. As the name suggests, these libraries provide adaptable and reusable components that you can use directly in your project. These components include, but are not limited to, dropdowns, drawers, calendars, toggles, tabs, and all other components you can think of. 
 

--- a/react/the_react_ecosystem/type_checking_with_proptypes.md
+++ b/react/the_react_ecosystem/type_checking_with_proptypes.md
@@ -71,7 +71,7 @@ export default RenderName;
 
 In this example, with the help of the defaultProps property we are defining a default value for the `name` prop. This way, if the `RenderName` component is called without passing in the `name` prop, it will default to "Zach". When you do pass in props, they will take precedence over the default props.
 
-### What about typeScript?
+### What about TypeScript?
 
 Now is also a good time to mention [TypeScript](typescriptlang.org) - a strongly typed language that builds on JavaScript. We don't cover it in our curriculum yet, but it's worth learning about it if you'd like more safety while writing your code.
 

--- a/react/the_react_ecosystem/type_checking_with_proptypes.md
+++ b/react/the_react_ecosystem/type_checking_with_proptypes.md
@@ -4,14 +4,14 @@ Type Checking is a process of verifying that a piece of code is using the correc
 
 PropTypes is a way to type check the props that a React component receives. It helps to catch potential type errors during development, making it easier to spot and fix bugs. If you have used a linter in your previous React projects, there's a good chance it ended up yelling at you about certain props missing in prop validation, however if that isn't the case- well, lucky you!
 
-### Lesson Overview
+### Lesson overview
 
 This section contains a general overview of topics that you will learn in this lesson.
 
 - Setting up PropTypes.
 - Using common PropTypes features.
 
-### Getting Started
+### Getting started
 
 To start using PropTypes in our React projects, we first need to install the corresponding library. We can do that with `npm`. In your React project run the following command:
 
@@ -71,7 +71,7 @@ export default RenderName;
 
 In this example, with the help of the defaultProps property we are defining a default value for the `name` prop. This way, if the `RenderName` component is called without passing in the `name` prop, it will default to "Zach". When you do pass in props, they will take precedence over the default props.
 
-### What about TypeScript?
+### What about typeScript?
 
 Now is also a good time to mention [TypeScript](typescriptlang.org) - a strongly typed language that builds on JavaScript. We don't cover it in our curriculum yet, but it's worth learning about it if you'd like more safety while writing your code.
 
@@ -87,7 +87,7 @@ Learning TypeScript can be a lot of overhead when you're already learning React.
 
 </div>
 
-### Knowledge Check
+### Knowledge check
 
 This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
 
@@ -95,7 +95,7 @@ This section contains questions for you to check your understanding of this less
 - <a class="knowledge-check-link" href="#using-defaultprops">If we pass in a prop to a component that has a defaultProp defined, what would happen?</a>
 - <a class="knowledge-check-link" href="https://stackoverflow.com/questions/41746028/proptypes-in-a-typescript-react-application">What is the difference between PropTypes and TypeScript?</a>
 
-### Additional Resources
+### Additional resources
 
 This section contains helpful links to related content. It isn’t required, so consider it supplemental.
 


### PR DESCRIPTION
## Because
Changed Headers to use spell-case


## This PR
- Apply's spell-case to headers



## Issue
Related to #25861

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
