### PR TITLE
Typo in "Bad vs Good Commits" Section

### DIFF
--- a/git/foundations_git/commit_messages.md
+++ b/git/foundations_git/commit_messages.md
@@ -57,7 +57,7 @@ Screen readers won't read the images to users with disabilities without this inf
 
 Ahh, that's better! :) Now, developers can gain a better understanding of this commit message because it does the following:
 
-* Provides a subject that specifies your code's action (e.g., "Add missing link and alt text the company's logo")
+* Provides a subject that specifies your code's action (e.g., "Add missing link and alt text to the company's logo")
 * Contains a body that provides a concise yet clear description of why the commit needed to be made (e.g., "Screen readers won't read the images to users with disabilities without this information")
 * Separates the subject from the body with a new/blank line. This is a best practice we highly recommend following. It makes commit messages easier for other developers to read. 
 


### PR DESCRIPTION
Added a word under "Body". This line is missing the word 'to' after 'alt text': 

Provides a subject that specifies your code’s action (e.g., “Add missing link and alt text the company’s logo”)

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The first list item under "Body" in the "Bad vs Good Commits" section is missing a word: 'to'. 

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
-  Adding a word to a typo. 
- Original: "Provides a subject that specifies your code’s action (e.g., “Add missing link and alt text the company’s logo”)"
- Change: "Provides a subject that specifies your code’s action (e.g., “Add missing link and alt text to the company’s logo”)"

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
