### PR TITLE
React Router: Fix npm start as npm run dev for new Vite React

### DIFF
--- a/react/the_react_ecosystem/react_router.md
+++ b/react/the_react_ecosystem/react_router.md
@@ -109,7 +109,7 @@ ReactDOM.createRoot(document.getElementById("root")).render(
 );
 ~~~
 
-Once this is done, go ahead and run `npm start` and check out both routes: the home route `/` and the profile route `/profile` It works! But what is happening here?
+Once this is done, go ahead and run `npm run dev` and check out both routes: the home route `/` and the profile route `/profile` It works! But what is happening here?
 
 1. We import `createBrowserRouter` and `RouterProvider` from React Router.
 2. `createBrowserRouter` is used to create the configuration for a router by simply passing arguments in the form of an array of routes.


### PR DESCRIPTION
Vite React now uses `npm run dev` as opposed to `npm start` as its default dev server npm script.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
Vite React does not use `npm start` as its default dev server npm script unlike Create-React-App previously.

## This PR
Changes `npm start` to `npm run dev` - only one entry requires fix.

## Issue
N/A

## Additional Information
N/A


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
