### PR TITLE
revised explanation on proptypes to specify that a warning will only …

### DIFF
--- a/react/the_react_ecosystem/type_checking_with_proptypes.md
+++ b/react/the_react_ecosystem/type_checking_with_proptypes.md
@@ -1,5 +1,3 @@
-Certainly, here's the corrected version of your document using tildes (~) instead of backticks (`) for code blocks:
-
 Type Checking is a process of verifying that a piece of code is using the correct data types for variables, function parameters and return values. In the context of React applications, we are going to use PropTypes to do that job.
 
 PropTypes is a way to type check the props that a React component receives. It helps to catch potential type errors during development, making it easier to spot and fix bugs. If you have used a linter in your previous React projects, there's a good chance it ended up yelling at you about certain props missing in prop validation, however if that isn't the case- well, lucky you!
@@ -8,21 +6,21 @@ PropTypes is a way to type check the props that a React component receives. It h
 
 To start using PropTypes in our React projects, we first need to install the corresponding library. We can do that with npm. In your React project run the following command:
 
-```
+~~~
 npm install --save prop-types
-```
+~~~
 
 Next, we want to import the PropTypes package in the component whose props we want to validate.
 
-```javascript
+~~~javascript
 import PropTypes from "prop-types";
-```
+~~~
 
 ### Using propTypes
 
 Here is a very basic example of how we would use it in a simple component that renders out a name prop.
 
-```javascript
+~~~javascript
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -35,11 +33,11 @@ RenderName.propTypes = {
 };
 
 export default RenderName;
-```
+~~~
 
 In this example, the component RenderName must receive a prop called `name` since the `isRequired` flag is set to true. It also must be a string. If the the `name` prop is not passed, or if it is not a string, a warning will be displayed.
 
-```javascript
+~~~javascript
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -52,7 +50,7 @@ RenderName.propTypes = {
 };
 
 export default RenderName;
-```
+~~~
 
 Here, if no `name` prop is passed, no error will be displayed because the `isRequired` flag is set to false. Still however, if anything other than type string is passed, a warning will be displayed.
 
@@ -60,14 +58,14 @@ Here, if no `name` prop is passed, no error will be displayed because the `isReq
 
 Another cool thing we can do with PropTypes is passing in default props:
 
-```javascript
+~~~javascript
 import React from "react";
 import PropTypes from "prop-types";
 
 const RenderName = (props) => {
   return <div>{props.name}</div>;
 };
-```
+~~~
 
 RenderName.propTypes = {
 };

--- a/react/the_react_ecosystem/type_checking_with_proptypes.md
+++ b/react/the_react_ecosystem/type_checking_with_proptypes.md
@@ -1,3 +1,5 @@
+### Introduction
+
 Type Checking is a process of verifying that a piece of code is using the correct data types for variables, function parameters and return values. In the context of React applications, we are going to use PropTypes to do that job.
 
 PropTypes is a way to type check the props that a React component receives. It helps to catch potential type errors during development, making it easier to spot and fix bugs. If you have used a linter in your previous React projects, there's a good chance it ended up yelling at you about certain props missing in prop validation, however if that isn't the case- well, lucky you!
@@ -77,3 +79,58 @@ name: "Zach",
 export default RenderName;
 
 In this example, with the help of the defaultProps property we are defining a default value for the `name` prop. This way, if the `RenderName` component is called without passing in the `name` prop, it will default to "Zach". When you do pass in props, they will take precedence over the default props.
+
+### Using defaultProps
+
+Another cool thing we can do with PropTypes is passing in default props:
+
+~~~javascript
+import React from "react";
+import PropTypes from "prop-types";
+
+const RenderName = (props) => {
+  return <div>{props.name}</div>;
+};
+
+RenderName.propTypes = {
+  name: PropTypes.string,
+};
+
+RenderName.defaultProps = {
+  name: "Zach",
+};
+
+export default RenderName;
+~~~
+
+In this example, with the help of the defaultProps property we are defining a default value for the `name` prop. This way, if the `RenderName` component is called without passing in the `name` prop, it will default to "Zach". When you do pass in props, they will take precedence over the default props.
+
+### What about TypeScript?
+
+Now is also a good time to mention [TypeScript](https://www.typescriptlang.org/) - a strongly typed language that builds on JavaScript. We don't cover it in our curriculum yet, but it's worth learning about it if you'd like more safety while writing your code.
+
+Learning TypeScript can be a lot of overhead when you're already learning React. Although, once you're comfortable navigating the ins and outs of React, you'll have a better time learning and applying TypeScript to your projects. If you go in the direction of learning TypeScript, our recommendation would be picking up a previous project and refactoring the components one by one to TypeScript. Learn by doing!
+
+### Assignment
+
+<div class="lesson-content__panel" markdown="1">
+
+1. Read through the [PropTypes documentation](https://reactjs.org/docs/typechecking-with-proptypes.html). It shows all of the types you can specify and some other useful things that can be done with it!
+2. You can even set up custom validators in PropTypes. Read [this article on using PropTypes on LogRocket](https://blog.logrocket.com/validate-react-props-proptypes/) for a more in-depth look into the benefits and use cases of PropTypes.
+3. [This StackOverflow thread goes into the differences of TypeScript and PropTypes. ](https://stackoverflow.com/questions/41746028/proptypes-in-a-typescript-react-application)Give it a read!
+
+</div>
+
+### Knowledge check
+
+This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
+
+- <a class="knowledge-check-link" href="#using-proptypes">How would we set up a basic implementation of PropTypes?</a>
+- <a class="knowledge-check-link" href="#using-defaultprops">If we pass in a prop to a component that has a defaultProp defined, what would happen?</a>
+- <a class="knowledge-check-link" href="https://stackoverflow.com/questions/41746028/proptypes-in-a-typescript-react-application">What is the difference between PropTypes and TypeScript?</a>
+
+### Additional resources
+
+This section contains helpful links to related content. It isn’t required, so consider it supplemental.
+
+- It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.

--- a/react/the_react_ecosystem/type_checking_with_proptypes.md
+++ b/react/the_react_ecosystem/type_checking_with_proptypes.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-Type Checking is a process of verifying that a piece of code is using the correct data types for variables, function parameters and return values. In the context of React applications, we are going to use PropTypes to do that job. 
+Type Checking is a process of verifying that a piece of code is using the correct data types for variables, function parameters and return values. In the context of React applications, we are going to use PropTypes to do that job.
 
 PropTypes is a way to type check the props that a React component receives. It helps to catch potential type errors during development, making it easier to spot and fix bugs. If you have used a linter in your previous React projects, there's a good chance it ended up yelling at you about certain props missing in prop validation, however if that isn't the case- well, lucky you!
 
@@ -15,44 +15,61 @@ This section contains a general overview of topics that you will learn in this l
 
 To start using PropTypes in our React projects, we first need to install the corresponding library. We can do that with `npm`. In your React project run the following command:
 
-~~~
+```
 npm install --save prop-types
-~~~
+```
 
 Next, we want to import the PropTypes package in the component whose props we want to validate.
 
-~~~javascript
-import PropTypes from 'prop-types';
-~~~
+```javascript
+import PropTypes from "prop-types";
+```
 
 ### Using propTypes
 
 Here is a very basic example of how we would use it in a simple component that renders out a name prop.
 
-~~~javascript
-import PropTypes from 'prop-types';
-import React from 'react';
+```javascript
+import PropTypes from "prop-types";
+import React from "react";
 
 const RenderName = (props) => {
   return <div>{props.name}</div>;
 };
 
 RenderName.propTypes = {
-  name: PropTypes.string,
+  name: PropTypes.string.isRequired, //isRequired flag set to true for `name` prop
 };
 
 export default RenderName;
-~~~
+```
 
-In this example, the component RenderName expects to receive a prop called `name` which is a string. If this prop is not passed, or if it is not a string, a warning will be displayed.
+In this example, the component RenderName must receive a prop called `name` since the `isRequired` flag is set to true. It also must be a string. If the the `name` prop is not passed, or if it is not a string, a warning will be displayed.
+
+```javascript
+import PropTypes from "prop-types";
+import React from "react";
+
+const RenderName = (props) => {
+  return <div>{props.name}</div>;
+};
+
+RenderName.propTypes = {
+  name: PropTypes.string, //isRequired flag set to false for `name` prop
+};
+
+export default RenderName;
+```
+
+Here, if no `name` prop is passed, no error will be displayed because the `isRequired` flag is set to false. Still however, if anything other than type string is passed, a warning will be displayed.
 
 ### Using defaultProps
 
 Another cool thing we can do with PropTypes is passing in default props:
 
-~~~javascript
-import React from 'react';
-import PropTypes from 'prop-types';
+```javascript
+import React from "react";
+import PropTypes from "prop-types";
 
 const RenderName = (props) => {
   return <div>{props.name}</div>;
@@ -63,11 +80,11 @@ RenderName.propTypes = {
 };
 
 RenderName.defaultProps = {
-  name: 'Zach',
+  name: "Zach",
 };
 
 export default RenderName;
-~~~
+```
 
 In this example, with the help of the defaultProps property we are defining a default value for the `name` prop. This way, if the `RenderName` component is called without passing in the `name` prop, it will default to "Zach". When you do pass in props, they will take precedence over the default props.
 

--- a/react/the_react_ecosystem/type_checking_with_proptypes.md
+++ b/react/the_react_ecosystem/type_checking_with_proptypes.md
@@ -1,19 +1,12 @@
-### Introduction
+Certainly, here's the corrected version of your document using tildes (~) instead of backticks (`) for code blocks:
 
 Type Checking is a process of verifying that a piece of code is using the correct data types for variables, function parameters and return values. In the context of React applications, we are going to use PropTypes to do that job.
 
 PropTypes is a way to type check the props that a React component receives. It helps to catch potential type errors during development, making it easier to spot and fix bugs. If you have used a linter in your previous React projects, there's a good chance it ended up yelling at you about certain props missing in prop validation, however if that isn't the case- well, lucky you!
 
-### Lesson overview
+    @@ -15,44 +15,61 @@ This section contains a general overview of topics that you will learn in this l
 
-This section contains a general overview of topics that you will learn in this lesson.
-
-- Setting up PropTypes.
-- Using common PropTypes features.
-
-### Getting started
-
-To start using PropTypes in our React projects, we first need to install the corresponding library. We can do that with `npm`. In your React project run the following command:
+To start using PropTypes in our React projects, we first need to install the corresponding library. We can do that with npm. In your React project run the following command:
 
 ```
 npm install --save prop-types
@@ -74,46 +67,15 @@ import PropTypes from "prop-types";
 const RenderName = (props) => {
   return <div>{props.name}</div>;
 };
+```
 
 RenderName.propTypes = {
-  name: PropTypes.string,
 };
 
 RenderName.defaultProps = {
-  name: "Zach",
+name: "Zach",
 };
 
 export default RenderName;
-```
 
 In this example, with the help of the defaultProps property we are defining a default value for the `name` prop. This way, if the `RenderName` component is called without passing in the `name` prop, it will default to "Zach". When you do pass in props, they will take precedence over the default props.
-
-### What about TypeScript?
-
-Now is also a good time to mention [TypeScript](https://www.typescriptlang.org/) - a strongly typed language that builds on JavaScript. We don't cover it in our curriculum yet, but it's worth learning about it if you'd like more safety while writing your code.
-
-Learning TypeScript can be a lot of overhead when you're already learning React. Although, once you're comfortable navigating the ins and outs of React, you'll have a better time learning and applying TypeScript to your projects. If you go in the direction of learning TypeScript, our recommendation would be picking up a previous project and refactoring the components one by one to TypeScript. Learn by doing!
-
-### Assignment
-
-<div class="lesson-content__panel" markdown="1">
-
-1. Read through the [PropTypes documentation](https://reactjs.org/docs/typechecking-with-proptypes.html). It shows all of the types you can specify and some other useful things that can be done with it!
-2. You can even set up custom validators in PropTypes. Read [this article on using PropTypes on LogRocket](https://blog.logrocket.com/validate-react-props-proptypes/) for a more in-depth look into the benefits and use cases of PropTypes.
-3. [This StackOverflow thread goes into the differences of TypeScript and PropTypes. ](https://stackoverflow.com/questions/41746028/proptypes-in-a-typescript-react-application)Give it a read!
-
-</div>
-
-### Knowledge check
-
-This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
-
-- <a class="knowledge-check-link" href="#using-proptypes">How would we set up a basic implementation of PropTypes?</a>
-- <a class="knowledge-check-link" href="#using-defaultprops">If we pass in a prop to a component that has a defaultProp defined, what would happen?</a>
-- <a class="knowledge-check-link" href="https://stackoverflow.com/questions/41746028/proptypes-in-a-typescript-react-application">What is the difference between PropTypes and TypeScript?</a>
-
-### Additional resources
-
-This section contains helpful links to related content. It isn’t required, so consider it supplemental.
-
-- It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.

--- a/react/the_react_ecosystem/type_checking_with_proptypes.md
+++ b/react/the_react_ecosystem/type_checking_with_proptypes.md
@@ -2,7 +2,7 @@ Type Checking is a process of verifying that a piece of code is using the correc
 
 PropTypes is a way to type check the props that a React component receives. It helps to catch potential type errors during development, making it easier to spot and fix bugs. If you have used a linter in your previous React projects, there's a good chance it ended up yelling at you about certain props missing in prop validation, however if that isn't the case- well, lucky you!
 
-    @@ -15,44 +15,61 @@ This section contains a general overview of topics that you will learn in this l
+    @@ -15,44 +15,61 @@ This section contains a general overview of topics that you will learn in this lesson.
 
 To start using PropTypes in our React projects, we first need to install the corresponding library. We can do that with npm. In your React project run the following command:
 


### PR DESCRIPTION
…be displayed if a prop isnt passed and it has its 'isRequired' flag set to true. Warnings for wrong prop types (e.g. string instead of number) will be displayed regardless, as we are declaring what type our props should be.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
There is a small error in the way proptypes are explained for this lesson

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
* Made it clear that props that are not passed will only display a warning in the console if 'isRequired' is set to true. Provided an additional example.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
