### PR TITLE
Foundations Course, The cascade lesson: interactive screencast (scrim)

### DIFF
--- a/foundations/html_css/css-foundations/the-cascade.md
+++ b/foundations/html_css/css-foundations/the-cascade.md
@@ -10,6 +10,10 @@ This section contains a general overview of topics that you will learn in this l
 *   Specificity and combining CSS selectors.
 *   How inheritance affects certain properties.
 
+For a more interactive explanation and example, try the following Scrim (let us know what you think of these):
+
+<iframe src="https://scrimba.com/scrim/c9gwmnAR?embed=odin,mini-header,no-next-up" sandbox="allow-scripts allow-same-origin allow-popups" width="100%" height="400"></iframe>
+
 ### The cascade of CSS
 
 Sometimes we may have rules that conflict with one another, and we end up with some unexpected results. "But I wanted *these* paragraphs to be blue, why are they red like these other paragraphs?!" As frustrating as this can be, it's important to understand that CSS doesn't just *do* things against our wishes. CSS only does what we tell it to do. One exception to this is the default styles that are provided by a browser. These default styles vary from browser to browser, and they are why some elements create a large "gap" between themselves and other elements, or why buttons look the way they do, despite us not writing any CSS rules to style them that way.


### PR DESCRIPTION
Interactive embeds from [Scrimba](https://www.scrimba.com/) for CSS Foundations section. Fixes earlier issue.

## Because
- Fixes issue in previously published scrim (interactive screencast) - incorrect information on specificity levels
identified in this issue: #25800

## This PR
- Screencast now correctly identifies specificity weight for ids, classes and elements
- Now script includes this (taken from TOP lesson)
"An ID selector will always beat any number of class selectors, a class selector will always beat any number of type selectors, and a type selector will always beat any number of anything less specific than it."


## Issue
Related to #25800

## Additional Information
- Part of prior agreement between Per Borgen at Scrimba to add interactive screencasts to The Odin Project  lessons


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
