### PR TITLE
Factory functions and the module patterns, objects and object constructors: Move scrims to Additional Resources

### DIFF
--- a/javascript/organizing_your_javascript_code/factory_functions_and_module_pattern.md
+++ b/javascript/organizing_your_javascript_code/factory_functions_and_module_pattern.md
@@ -24,10 +24,6 @@ This section contains a general overview of topics that you will learn in this l
 - Describe IIFE. What does it stand for?
 - Briefly explain namespacing and how it's useful.
 
-For a more interactive explanation and example, try the following Scrim (let us know what you think of these):
-
-<iframe src="https://scrimba.com/scrim/c2aaKzcV?embed=odin,mini-header,no-sidebar,no-next-up" sandbox="allow-scripts allow-same-origin allow-popups" width="100%" height="400"></iframe>
-
 ### Factory function introduction
 
 The factory function pattern is similar to constructors, but instead of using `new` to create an object, factory functions simply set up and return the new object when you call the function. Check out this example:
@@ -305,3 +301,4 @@ This section contains questions for you to check your understanding of this less
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
 - [Learning JavaScript Design Patterns by Addy Osmani and Lydia Hallie](https://www.patterns.dev/)
+- [Interactive explanation of Factory Functions in JavaScript](https://scrimba.com/scrim/c2aaKzcV)

--- a/javascript/organizing_your_javascript_code/factory_functions_and_module_pattern.md
+++ b/javascript/organizing_your_javascript_code/factory_functions_and_module_pattern.md
@@ -301,4 +301,4 @@ This section contains questions for you to check your understanding of this less
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
 - [Learning JavaScript Design Patterns by Addy Osmani and Lydia Hallie](https://www.patterns.dev/)
-- [Interactive explanation of Factory Functions in JavaScript](https://scrimba.com/scrim/c2aaKzcV)
+- [Interactive Scrim on factory functions](https://scrimba.com/scrim/c2aaKzcV)

--- a/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
+++ b/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
@@ -47,10 +47,6 @@ This section contains a general overview of topics that you will learn in this l
 - Explain what `Object.create` does.
 - Explain what the `this` keyword is.
 
-For a more interactive explanation and example, try the following Scrim (let us know what you think of these):
-
-<iframe src="https://scrimba.com/scrim/co2624f87981575448091d5a2?embed=odin,mini-header,no-sidebar,no-next-up" sandbox="allow-scripts allow-same-origin allow-popups" width="100%" height="400"></iframe>
-
 ### Objects as a design pattern
 
 One of the simplest ways you can begin to organize your code is by simply grouping things into objects. Take these examples from a 'tic tac toe' game:
@@ -392,4 +388,5 @@ Nicholas C. Zakas is really great to understand OOP in javascript, which explain
 - [This stack overflow question](https://stackoverflow.com/questions/9772307/declaring-javascript-object-method-in-constructor-function-vs-in-prototype/9772864#9772864) explains the difference between defining methods via the prototype vs defining them in the constructor.
 - [A Beginner’s Guide to JavaScript’s Prototype](https://medium.com/free-code-camp/a-beginners-guide-to-javascript-s-prototype-9c049fe7b34) and [JavaScript Inheritance and the Prototype Chain](https://medium.com/free-code-camp/javascript-inheritance-and-the-prototype-chain-d4298619bdae) from Tyler Mcginnis has great examples to help you understand Prototype and Prototype Chain better from the beginner's perspective.
 - [This video ](https://www.youtube.com/watch?v=wstwjQ1yqWQ) from Akshay Saini is an easy and simple way to understand the concept of Prototype, Prototype Chain and prototypal inheritance.
+- [Interactive tutorial on Objects and Object Constructors.](https://scrimba.com/scrim/co2624f87981575448091d5a2)
 

--- a/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
+++ b/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
@@ -388,5 +388,5 @@ Nicholas C. Zakas is really great to understand OOP in javascript, which explain
 - [This stack overflow question](https://stackoverflow.com/questions/9772307/declaring-javascript-object-method-in-constructor-function-vs-in-prototype/9772864#9772864) explains the difference between defining methods via the prototype vs defining them in the constructor.
 - [A Beginner’s Guide to JavaScript’s Prototype](https://medium.com/free-code-camp/a-beginners-guide-to-javascript-s-prototype-9c049fe7b34) and [JavaScript Inheritance and the Prototype Chain](https://medium.com/free-code-camp/javascript-inheritance-and-the-prototype-chain-d4298619bdae) from Tyler Mcginnis has great examples to help you understand Prototype and Prototype Chain better from the beginner's perspective.
 - [This video ](https://www.youtube.com/watch?v=wstwjQ1yqWQ) from Akshay Saini is an easy and simple way to understand the concept of Prototype, Prototype Chain and prototypal inheritance.
-- [Interactive tutorial on Objects and Object Constructors.](https://scrimba.com/scrim/co2624f87981575448091d5a2)
+- [Interactive Scrim on objects and object constructors.](https://scrimba.com/scrim/co2624f87981575448091d5a2)
 


### PR DESCRIPTION
## Because
This PR moves Scrimba interactive scrim embeds from their current position to the Additional Resources section as a link text as part of [this](https://github.com/TheOdinProject/curriculum/issues/26057) issue.

## This PR
- Moves existing Scrimba embed in [Factory Functions and the Module Pattern](https://www.theodinproject.com/lessons/node-path-javascript-factory-functions-and-the-module-pattern) to the Additional Resources section.
- Moves existing Scrimba embed in [Objects and Object Constructors](https://www.theodinproject.com/lessons/node-path-javascript-objects-and-object-constructors) to the Additional Resources section.

## Issue
Related to #26057 

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

















