### PR TITLE
Ruby on Rails Course - Introduction && Basic Ruby sections: Fix headings to sentence case

### DIFF
--- a/ruby_on_rails/introduction/how_this_course_will_work.md
+++ b/ruby_on_rails/introduction/how_this_course_will_work.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-This portion of the curriculum will be the most build-heavy so far. You will still be asked to read docs, check out blog posts, and watch videos before building, of course, but projects will be the major focus.
+This portion of the curriculum will be the most build-heavy so far.  You will still be asked to read docs, check out blog posts, and watch videos before building, of course, but projects will be the major focus.
 
 After each lesson or two, you'll be asked to build one or more independent projects utilizing the concepts that were just covered (which is exactly what we've been doing up until now).
 
@@ -8,21 +8,21 @@ After each lesson or two, you'll be asked to build one or more independent proje
 
 After preparing for deployment and installing Rails, we'll be starting with an overview of important topics like HTTP, MVC, REST, APIs, Cookies and Authentication for some context before moving into the really fun stuff.
 
-We'll move front-to-back, starting with the routing layer and moving into controllers and views so you can build a functional (if not yet pretty) interface for your data. Next you'll learn about storing and finding data in databases with SQL then how to turn that SQL into Active Record queries. We next cover web forms, an area that has a lot more going on behind the scenes than you might expect, and authentication, which is essential to securing your application. We'll cover some other intermediate topics like state and the asset pipeline to round out your initial understanding of Rails.
+We'll move front-to-back, starting with the routing layer and moving into controllers and views so you can build a functional (if not yet pretty) interface for your data.  Next you'll learn about storing and finding data in databases with SQL then how to turn that SQL into Active Record queries.  We next cover web forms, an area that has a lot more going on behind the scenes than you might expect, and authentication, which is essential to securing your application.  We'll cover some other intermediate topics like state and the asset pipeline to round out your initial understanding of Rails.
 
-But we can't stop there, so we'll get back into ActiveRecord to give you the tools to really make your data dance, as well as the knowledge of the forms that is required to bring that advanced functionality to the user. This is the really important side of Rails, so we'll spend a good bit of time working with it.
+But we can't stop there, so we'll get back into ActiveRecord to give you the tools to really make your data dance, as well as the knowledge of the forms that is required to bring that advanced functionality to the user.  This is the really important side of Rails, so we'll spend a good bit of time working with it.
 
 Finally, we'll cover additional useful topics like how to send emails from your application, building and interfacing with APIs, design patterns, metaprogramming and advanced routing before having you build your final project.
 
 ### Our tools and texts
 
-The most important resource that we'll leverage is [the Rails Guides](http://guides.rubyonrails.org/). We'll use these guides along with [the Rails API](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html), which allows you to search for specific Rails methods.
+The most important resource that we'll leverage is [the Rails Guides](http://guides.rubyonrails.org/).  We'll use these guides along with [the Rails API](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html), which allows you to search for specific Rails methods.
 
-The Rails Guides are so comprehensive that they are essentially a completely open-source textbook and reference manual for Rails. At times, they'll get a bit more technical and in-depth than you might like, and it may be okay to skim at that point. When you Google for help as you build your projects, if you don't find a direct solution on Stack Overflow, then your best bet will be to dive into the relevant Rails Guides links.
+The Rails Guides are so comprehensive that they are essentially a completely open-source textbook and reference manual for Rails.  At times, they'll get a bit more technical and in-depth than you might like, and it may be okay to skim at that point.  When you Google for help as you build your projects, if you don't find a direct solution on Stack Overflow, then your best bet will be to dive into the relevant Rails Guides links.
 
 ### Additional resources
 
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
-- [StackOverflow: Summary of Ruby on Rails Fundamental Concepts](http://stackoverflow.com/questions/5205002/summary-of-ruby-on-rails-fundamental-concepts)
-- [How to study the Rails Guides](http://www.sihui.io/how-to-study-the-rails-guides/)
+* [StackOverflow: Summary of Ruby on Rails Fundamental Concepts](http://stackoverflow.com/questions/5205002/summary-of-ruby-on-rails-fundamental-concepts)
+* [How to study the Rails Guides](http://www.sihui.io/how-to-study-the-rails-guides/)

--- a/ruby_on_rails/introduction/how_this_course_will_work.md
+++ b/ruby_on_rails/introduction/how_this_course_will_work.md
@@ -4,6 +4,7 @@ This portion of the curriculum will be the most build-heavy so far.  You will st
 
 After each lesson or two, you'll be asked to build one or more independent projects utilizing the concepts that were just covered (which is exactly what we've been doing up until now).
 
+
 ### The roadmap
 
 After preparing for deployment and installing Rails, we'll be starting with an overview of important topics like HTTP, MVC, REST, APIs, Cookies and Authentication for some context before moving into the really fun stuff.
@@ -16,12 +17,12 @@ Finally, we'll cover additional useful topics like how to send emails from your 
 
 ### Our tools and texts
 
-The most important resource that we'll leverage is [the Rails Guides](http://guides.rubyonrails.org/).  We'll use these guides along with [the Rails API](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html), which allows you to search for specific Rails methods.
+The most important resource that we'll leverage is [the Rails Guides](http://guides.rubyonrails.org/). We'll use these guides along with [the Rails API](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html), which allows you to search for specific Rails methods.
 
 The Rails Guides are so comprehensive that they are essentially a completely open-source textbook and reference manual for Rails.  At times, they'll get a bit more technical and in-depth than you might like, and it may be okay to skim at that point.  When you Google for help as you build your projects, if you don't find a direct solution on Stack Overflow, then your best bet will be to dive into the relevant Rails Guides links.
 
-### Additional resources
 
+### Additional resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
 * [StackOverflow: Summary of Ruby on Rails Fundamental Concepts](http://stackoverflow.com/questions/5205002/summary-of-ruby-on-rails-fundamental-concepts)

--- a/ruby_on_rails/introduction/how_this_course_will_work.md
+++ b/ruby_on_rails/introduction/how_this_course_will_work.md
@@ -1,29 +1,28 @@
 ### Introduction
 
-This portion of the curriculum will be the most build-heavy so far.  You will still be asked to read docs, check out blog posts, and watch videos before building, of course, but projects will be the major focus.
+This portion of the curriculum will be the most build-heavy so far. You will still be asked to read docs, check out blog posts, and watch videos before building, of course, but projects will be the major focus.
 
 After each lesson or two, you'll be asked to build one or more independent projects utilizing the concepts that were just covered (which is exactly what we've been doing up until now).
 
-
-### The Roadmap
+### The roadmap
 
 After preparing for deployment and installing Rails, we'll be starting with an overview of important topics like HTTP, MVC, REST, APIs, Cookies and Authentication for some context before moving into the really fun stuff.
 
-We'll move front-to-back, starting with the routing layer and moving into controllers and views so you can build a functional (if not yet pretty) interface for your data.  Next you'll learn about storing and finding data in databases with SQL then how to turn that SQL into Active Record queries.  We next cover web forms, an area that has a lot more going on behind the scenes than you might expect, and authentication, which is essential to securing your application.  We'll cover some other intermediate topics like state and the asset pipeline to round out your initial understanding of Rails.
+We'll move front-to-back, starting with the routing layer and moving into controllers and views so you can build a functional (if not yet pretty) interface for your data. Next you'll learn about storing and finding data in databases with SQL then how to turn that SQL into Active Record queries. We next cover web forms, an area that has a lot more going on behind the scenes than you might expect, and authentication, which is essential to securing your application. We'll cover some other intermediate topics like state and the asset pipeline to round out your initial understanding of Rails.
 
-But we can't stop there, so we'll get back into ActiveRecord to give you the tools to really make your data dance, as well as the knowledge of the forms that is required to bring that advanced functionality to the user.  This is the really important side of Rails, so we'll spend a good bit of time working with it.
+But we can't stop there, so we'll get back into ActiveRecord to give you the tools to really make your data dance, as well as the knowledge of the forms that is required to bring that advanced functionality to the user. This is the really important side of Rails, so we'll spend a good bit of time working with it.
 
 Finally, we'll cover additional useful topics like how to send emails from your application, building and interfacing with APIs, design patterns, metaprogramming and advanced routing before having you build your final project.
 
-### Our Tools and Texts
+### Our tools and texts
 
 The most important resource that we'll leverage is [the Rails Guides](http://guides.rubyonrails.org/). We'll use these guides along with [the Rails API](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html), which allows you to search for specific Rails methods.
 
-The Rails Guides are so comprehensive that they are essentially a completely open-source textbook and reference manual for Rails.  At times, they'll get a bit more technical and in-depth than you might like, and it may be okay to skim at that point.  When you Google for help as you build your projects, if you don't find a direct solution on Stack Overflow, then your best bet will be to dive into the relevant Rails Guides links.
+The Rails Guides are so comprehensive that they are essentially a completely open-source textbook and reference manual for Rails. At times, they'll get a bit more technical and in-depth than you might like, and it may be okay to skim at that point. When you Google for help as you build your projects, if you don't find a direct solution on Stack Overflow, then your best bet will be to dive into the relevant Rails Guides links.
 
+### Additional resources
 
-### Additional Resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
-* [StackOverflow: Summary of Ruby on Rails Fundamental Concepts](http://stackoverflow.com/questions/5205002/summary-of-ruby-on-rails-fundamental-concepts)
-* [How to study the Rails Guides](http://www.sihui.io/how-to-study-the-rails-guides/)
+- [StackOverflow: Summary of Ruby on Rails Fundamental Concepts](http://stackoverflow.com/questions/5205002/summary-of-ruby-on-rails-fundamental-concepts)
+- [How to study the Rails Guides](http://www.sihui.io/how-to-study-the-rails-guides/)

--- a/ruby_on_rails/introduction/project_installing_rails.md
+++ b/ruby_on_rails/introduction/project_installing_rails.md
@@ -13,7 +13,7 @@ Before continuing, let's review a few best practices to keep in mind:
 
 In this project, we're going to build a fully functional Rails application. The entire point of this exercise is to make sure that you have everything installed and working correctly on your computer. Do *not* worry if you don't fully understand what you're doing. You'll learn exactly what all of these commands are doing later on in the course. For now, go slowly, and be sure to follow **each and every** step closely. If you run into trouble, don't forget that you can always reach out for help on [Discord](https://discord.gg/fbFCkYabZB). You can also use the [Discord search function](https://support.discordapp.com/hc/en-us/articles/115000468588-Using-Search) to check if someone else had a similar problem and how they solved it.
 
-### Your first Rails app
+### Your first rails app
 
 ### Step 1: Create your first Ruby on Rails web application
 
@@ -127,7 +127,6 @@ Go ahead and create a new car, and then refresh the page to verify it is working
 Like all of the projects you've done so far we need to use Git for our version control and to push our app to different remotes.
 
 #### Step 2.1 Stage and commit local changes
-
 Rails will already have initialized Git for you when it was doing its thing, so just stage and commit all of the work it's done so far.
 
 ~~~bash
@@ -136,7 +135,6 @@ git commit -m "Initial commit"
 ~~~
 
 #### Step 2.2 Initialize on GitHub, add the remote, and push
-
 Make a repo on Github and make sure you **do not** initialize the repository with a README because Rails has created one already. Add this repo as a remote and push your repo to GitHub just like you normally do.
 
 REMINDER: Do not enter the `<` or `>` symbols below. Replace those symbols and everything between them with the URL that you copied from GitHub.
@@ -147,7 +145,6 @@ git push -u origin main
 ~~~
 
 #### Step 2.3 Confirm Git is working correctly
-
 Confirm that the push was successful and on GitHub you see all the folders and files made locally by Rails, starting with a folder called "app".
 
 This marks the start of your Rails journey! Later on, you'll be able to look back at this repository and marvel over how far you've come!

--- a/ruby_on_rails/introduction/project_installing_rails.md
+++ b/ruby_on_rails/introduction/project_installing_rails.md
@@ -13,7 +13,7 @@ Before continuing, let's review a few best practices to keep in mind:
 
 In this project, we're going to build a fully functional Rails application. The entire point of this exercise is to make sure that you have everything installed and working correctly on your computer. Do *not* worry if you don't fully understand what you're doing. You'll learn exactly what all of these commands are doing later on in the course. For now, go slowly, and be sure to follow **each and every** step closely. If you run into trouble, don't forget that you can always reach out for help on [Discord](https://discord.gg/fbFCkYabZB). You can also use the [Discord search function](https://support.discordapp.com/hc/en-us/articles/115000468588-Using-Search) to check if someone else had a similar problem and how they solved it.
 
-### Your first rails app
+### Your first Rails app
 
 ### Step 1: Create your first Ruby on Rails web application
 

--- a/ruby_on_rails/introduction/project_installing_rails.md
+++ b/ruby_on_rails/introduction/project_installing_rails.md
@@ -6,16 +6,16 @@ With Ruby installed, you're all set to install Rails and create our first Rails 
 
 Before continuing, let's review a few best practices to keep in mind:
 
-* Follow the directions closely, and don't skip over any sections.
-* **Do NOT use `sudo` unless The Odin Project specifically says to do so.** Failing to follow this advice can cause *a lot* of headaches. In some instances, you might see a message in the terminal telling you to use `sudo` and/or to install something with `apt`. **Ignore what the terminal says** and follow the instructions below.
-* Copy and paste the commands to avoid typos.
-* If you stop working on this project partway through and come back to it later, be sure to use `cd` to move back inside your project directory so that the commands will work.
+- Follow the directions closely, and don't skip over any sections.
+- **Do NOT use `sudo` unless The Odin Project specifically says to do so.** Failing to follow this advice can cause _a lot_ of headaches. In some instances, you might see a message in the terminal telling you to use `sudo` and/or to install something with `apt`. **Ignore what the terminal says** and follow the instructions below.
+- Copy and paste the commands to avoid typos.
+- If you stop working on this project partway through and come back to it later, be sure to use `cd` to move back inside your project directory so that the commands will work.
 
-In this project, we're going to build a fully functional Rails application. The entire point of this exercise is to make sure that you have everything installed and working correctly on your computer. Do *not* worry if you don't fully understand what you're doing. You'll learn exactly what all of these commands are doing later on in the course. For now, go slowly, and be sure to follow **each and every** step closely. If you run into trouble, don't forget that you can always reach out for help on [Discord](https://discord.gg/fbFCkYabZB). You can also use the [Discord search function](https://support.discordapp.com/hc/en-us/articles/115000468588-Using-Search) to check if someone else had a similar problem and how they solved it.
+In this project, we're going to build a fully functional Rails application. The entire point of this exercise is to make sure that you have everything installed and working correctly on your computer. Do _not_ worry if you don't fully understand what you're doing. You'll learn exactly what all of these commands are doing later on in the course. For now, go slowly, and be sure to follow **each and every** step closely. If you run into trouble, don't forget that you can always reach out for help on [Discord](https://discord.gg/fbFCkYabZB). You can also use the [Discord search function](https://support.discordapp.com/hc/en-us/articles/115000468588-Using-Search) to check if someone else had a similar problem and how they solved it.
 
-### Your First Rails App
+### Your first Rails app
 
-### Step 1: Create Your First Ruby on Rails Web Application
+### Step 1: Create your first Ruby on Rails web application
 
 Don't worry if you don't totally understand what you are doing in these next steps. You will learn what all of this does later in The Odin Project curriculum. As long as the commands complete successfully, just keep going. The main reason we're doing this is to ensure everything is properly installed and configured.
 
@@ -23,15 +23,15 @@ Don't worry if you don't totally understand what you are doing in these next ste
 
 We've previously installed Ruby, and now it's time to install Ruby on Rails. It's as simple as running one command!
 
-~~~bash
+```bash
 gem install rails
-~~~
+```
 
 Once the installation finishes, you can check if everything went well by restarting your terminal and running the following command:
 
-~~~bash
+```bash
 rails -v
-~~~
+```
 
 This should display the version of Rails installed on your system indicating the installation went smoothly.
 
@@ -47,26 +47,26 @@ Visit [The Yarn Download Page](https://classic.yarnpkg.com/en/docs/install#windo
 
 You can verify the install by running the following command:
 
-~~~bash
+```bash
 yarn --version
-~~~
+```
 
 If you don't get a version number drop by the chatrooms for some assistance.
 
-#### Step 1.3: Create the Application
+#### Step 1.3: Create the application
 
 This is where it might start to be difficult to follow just what is happening. If you don't understand what's going on, just double check that you're typing in the correct commands and keep going. This section is meant to expose you to the process and to verify that everything is working. Again, it's OK to not understand what's going on at this point.
 
 We're going to start by navigating to the directory that you house your projects in, then telling Rails to initialize the application for us.
 
-~~~bash
+```bash
 cd ~/your_odin_project_directory
 rails new my_first_rails_app
-~~~
+```
 
 This will do a bunch of things, and you'll see a lot of output in the terminal. If everything worked, you should see something similar to this around the end of the terminal output:
 
-~~~bash
+```bash
 
 Bundle complete! 16 Gemfile dependencies, 76 gems now installed.
 Use `bundle info [gemname]` to see where a bundled gem is installed.
@@ -82,69 +82,72 @@ Import Stimulus controllers
 Pin Stimulus
       append  config/importmap.rb
 
-~~~
+```
 
 In the above process, Rails created a new directory for us. Let's `cd` into it now:
 
-~~~bash
+```bash
 cd my_first_rails_app
-~~~
+```
 
 Now, we're going to tell Rails to generate some templates for us. This will get us up and running in no time at all. If you are using Ruby 2.7 or higher then you may see some deprecation warnings that look like errors in the console. Ruby made some changes in version 2.7 to deprecate using hashes as the last argument of a method call. You can read more about it [here](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/). It will take time for gems to update their codebases to deal with this deprecation, especially if they are as large as Rails. If you do see any deprecation warnings then don't worry, they will get fixed eventually. The warnings will look something like:
 
-~~~bash
+```bash
 warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
-~~~
+```
 
 Run the following in the terminal:
 
-~~~bash
+```bash
 rails generate scaffold car make:string model:string year:integer
-~~~
+```
 
 After generating the scaffolds, we need to migrate the database.
 
-~~~bash
+```bash
 rails db:migrate
-~~~
+```
 
-#### Step 1.4: Start Up Your App
+#### Step 1.4: Start up your app
 
 Now that you have created a Rails application, you can start it up and see if it works!
 
 In the terminal, type
 
-~~~bash
+```bash
 rails server
-~~~
+```
 
 Now, open a browser and visit [http://localhost:3000/cars](http://localhost:3000/cars) to see your application! **Note:** If you're using a VM, you will need to open the browser inside of your VM in order for this to work.
 
 Go ahead and create a new car, and then refresh the page to verify it is working. Add as many cars as you'd like! When you're satisfied, go back to the terminal where the Rails server is running, and type <kbd>Ctrl</kbd> + <kbd>C</kbd> to close the server.
 
-### Step 2: Git Groundwork
+### Step 2: Git groundwork
 
 Like all of the projects you've done so far we need to use Git for our version control and to push our app to different remotes.
 
-#### Step 2.1 Stage and Commit Local Changes
+#### Step 2.1 Stage and commit local changes
+
 Rails will already have initialized Git for you when it was doing its thing, so just stage and commit all of the work it's done so far.
 
-~~~bash
+```bash
 git add .
 git commit -m "Initial commit"
-~~~
+```
 
-#### Step 2.2 Initialize on GitHub, add the remote, and Push
+#### Step 2.2 Initialize on GitHub, add the remote, and push
+
 Make a repo on Github and make sure you **do not** initialize the repository with a README because Rails has created one already. Add this repo as a remote and push your repo to GitHub just like you normally do.
 
 REMINDER: Do not enter the `<` or `>` symbols below. Replace those symbols and everything between them with the URL that you copied from GitHub.
 
-~~~bash
+```bash
 git remote add origin <SSH URL from GitHub>
 git push -u origin main
-~~~
+```
 
-#### Step 2.3 Confirm Git is Working Correctly
+#### Step 2.3 Confirm Git is working correctly
+
 Confirm that the push was successful and on GitHub you see all the folders and files made locally by Rails, starting with a folder called "app".
 
 This marks the start of your Rails journey! Later on, you'll be able to look back at this repository and marvel over how far you've come!

--- a/ruby_on_rails/introduction/project_installing_rails.md
+++ b/ruby_on_rails/introduction/project_installing_rails.md
@@ -6,12 +6,12 @@ With Ruby installed, you're all set to install Rails and create our first Rails 
 
 Before continuing, let's review a few best practices to keep in mind:
 
-- Follow the directions closely, and don't skip over any sections.
-- **Do NOT use `sudo` unless The Odin Project specifically says to do so.** Failing to follow this advice can cause _a lot_ of headaches. In some instances, you might see a message in the terminal telling you to use `sudo` and/or to install something with `apt`. **Ignore what the terminal says** and follow the instructions below.
-- Copy and paste the commands to avoid typos.
-- If you stop working on this project partway through and come back to it later, be sure to use `cd` to move back inside your project directory so that the commands will work.
+* Follow the directions closely, and don't skip over any sections.
+* **Do NOT use `sudo` unless The Odin Project specifically says to do so.** Failing to follow this advice can cause *a lot* of headaches. In some instances, you might see a message in the terminal telling you to use `sudo` and/or to install something with `apt`. **Ignore what the terminal says** and follow the instructions below.
+* Copy and paste the commands to avoid typos.
+* If you stop working on this project partway through and come back to it later, be sure to use `cd` to move back inside your project directory so that the commands will work.
 
-In this project, we're going to build a fully functional Rails application. The entire point of this exercise is to make sure that you have everything installed and working correctly on your computer. Do _not_ worry if you don't fully understand what you're doing. You'll learn exactly what all of these commands are doing later on in the course. For now, go slowly, and be sure to follow **each and every** step closely. If you run into trouble, don't forget that you can always reach out for help on [Discord](https://discord.gg/fbFCkYabZB). You can also use the [Discord search function](https://support.discordapp.com/hc/en-us/articles/115000468588-Using-Search) to check if someone else had a similar problem and how they solved it.
+In this project, we're going to build a fully functional Rails application. The entire point of this exercise is to make sure that you have everything installed and working correctly on your computer. Do *not* worry if you don't fully understand what you're doing. You'll learn exactly what all of these commands are doing later on in the course. For now, go slowly, and be sure to follow **each and every** step closely. If you run into trouble, don't forget that you can always reach out for help on [Discord](https://discord.gg/fbFCkYabZB). You can also use the [Discord search function](https://support.discordapp.com/hc/en-us/articles/115000468588-Using-Search) to check if someone else had a similar problem and how they solved it.
 
 ### Your first Rails app
 
@@ -23,15 +23,15 @@ Don't worry if you don't totally understand what you are doing in these next ste
 
 We've previously installed Ruby, and now it's time to install Ruby on Rails. It's as simple as running one command!
 
-```bash
+~~~bash
 gem install rails
-```
+~~~
 
 Once the installation finishes, you can check if everything went well by restarting your terminal and running the following command:
 
-```bash
+~~~bash
 rails -v
-```
+~~~
 
 This should display the version of Rails installed on your system indicating the installation went smoothly.
 
@@ -47,9 +47,9 @@ Visit [The Yarn Download Page](https://classic.yarnpkg.com/en/docs/install#windo
 
 You can verify the install by running the following command:
 
-```bash
+~~~bash
 yarn --version
-```
+~~~
 
 If you don't get a version number drop by the chatrooms for some assistance.
 
@@ -59,14 +59,14 @@ This is where it might start to be difficult to follow just what is happening. I
 
 We're going to start by navigating to the directory that you house your projects in, then telling Rails to initialize the application for us.
 
-```bash
+~~~bash
 cd ~/your_odin_project_directory
 rails new my_first_rails_app
-```
+~~~
 
 This will do a bunch of things, and you'll see a lot of output in the terminal. If everything worked, you should see something similar to this around the end of the terminal output:
 
-```bash
+~~~bash
 
 Bundle complete! 16 Gemfile dependencies, 76 gems now installed.
 Use `bundle info [gemname]` to see where a bundled gem is installed.
@@ -82,31 +82,31 @@ Import Stimulus controllers
 Pin Stimulus
       append  config/importmap.rb
 
-```
+~~~
 
 In the above process, Rails created a new directory for us. Let's `cd` into it now:
 
-```bash
+~~~bash
 cd my_first_rails_app
-```
+~~~
 
 Now, we're going to tell Rails to generate some templates for us. This will get us up and running in no time at all. If you are using Ruby 2.7 or higher then you may see some deprecation warnings that look like errors in the console. Ruby made some changes in version 2.7 to deprecate using hashes as the last argument of a method call. You can read more about it [here](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/). It will take time for gems to update their codebases to deal with this deprecation, especially if they are as large as Rails. If you do see any deprecation warnings then don't worry, they will get fixed eventually. The warnings will look something like:
 
-```bash
+~~~bash
 warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
-```
+~~~
 
 Run the following in the terminal:
 
-```bash
+~~~bash
 rails generate scaffold car make:string model:string year:integer
-```
+~~~
 
 After generating the scaffolds, we need to migrate the database.
 
-```bash
+~~~bash
 rails db:migrate
-```
+~~~
 
 #### Step 1.4: Start up your app
 
@@ -114,9 +114,9 @@ Now that you have created a Rails application, you can start it up and see if it
 
 In the terminal, type
 
-```bash
+~~~bash
 rails server
-```
+~~~
 
 Now, open a browser and visit [http://localhost:3000/cars](http://localhost:3000/cars) to see your application! **Note:** If you're using a VM, you will need to open the browser inside of your VM in order for this to work.
 
@@ -130,10 +130,10 @@ Like all of the projects you've done so far we need to use Git for our version c
 
 Rails will already have initialized Git for you when it was doing its thing, so just stage and commit all of the work it's done so far.
 
-```bash
+~~~bash
 git add .
 git commit -m "Initial commit"
-```
+~~~
 
 #### Step 2.2 Initialize on GitHub, add the remote, and push
 
@@ -141,10 +141,10 @@ Make a repo on Github and make sure you **do not** initialize the repository wit
 
 REMINDER: Do not enter the `<` or `>` symbols below. Replace those symbols and everything between them with the URL that you copied from GitHub.
 
-```bash
+~~~bash
 git remote add origin <SSH URL from GitHub>
 git push -u origin main
-```
+~~~
 
 #### Step 2.3 Confirm Git is working correctly
 

--- a/ruby_on_rails/introduction/web_refresher.md
+++ b/ruby_on_rails/introduction/web_refresher.md
@@ -17,7 +17,7 @@ This section contains a general overview of topics that you will learn in this l
 
 ### HTTP
 
-HTTP is just a way of structuring the request-and-response conversation between your browser and the server. Actually, it's not even a conversation since it is stateless... it's more of an "ask and receive". The protocol outlines how that brief piece of dialogue should occur.
+HTTP is just a way of structuring the request-and-response conversation between your browser and the server.  Actually, it's not even a conversation since it is stateless... it's more of an "ask and receive".  The protocol outlines how that brief piece of dialogue should occur.
 
 Check out these resources:
 
@@ -25,9 +25,9 @@ Check out these resources:
 2.  This [sniffer tool](http://testuri.org/sniffer) - try retrieving a couple of websites (like http://www.theodinproject.com) on your own.
 3.  This [great video](https://code.tutsplus.com/tutorials/how-the-web-works-http-and-the-web-server--cms-25971) on communications between http requests and the web server.
 
-One key component to pay attention to is the fact that the request and response both have header and (usually) body components. The header contains information about the request or response itself (meta data), including which website to send or return to and what the status of the response is. The body of the request can contain things like data submitted by a form or cookies or authentication tokens while the response will usually contain the HTML page you're trying to access.
+One key component to pay attention to is the fact that the request and response both have header and (usually) body components.  The header contains information about the request or response itself (meta data), including which website to send or return to and what the status of the response is.  The body of the request can contain things like data submitted by a form or cookies or authentication tokens while the response will usually contain the HTML page you're trying to access.
 
-The other key component is that each request uses one of four main "verbs" -- GET, POST, PUT, and DELETE. These days, you almost only see GET and POST requests (even if you're trying to do a delete of something they usually fake it using a POST request), but it's important to understand the difference between the verbs.
+The other key component is that each request uses one of four main "verbs" -- GET, POST, PUT, and DELETE.  These days, you almost only see GET and POST requests (even if you're trying to do a delete of something they usually fake it using a POST request), but it's important to understand the difference between the verbs.
 
 ### REST
 
@@ -43,9 +43,9 @@ REST (short for Representational state transfer) is a term that you'll see comin
 
 The highlighted words correspond to standard Rails controller actions!
 
-Why is this important? Because it gives you a very organized way of thinking about your resources. This is the way to model your requests and should be the ONLY way that those requests are done (e.g. you shouldn't be actually submitting the data for editing a post using a GET request... that should be a POST) If you have a hard time thinking of how those seven scenarios (or at least a subset of them) would apply to a resource you want to create in your database, you may need to rethink how your data is being set up.
+Why is this important?  Because it gives you a very organized way of thinking about your resources.  This is the way to model your requests and should be the ONLY way that those requests are done (e.g. you shouldn't be actually submitting the data for editing a post using a GET request... that should be a POST). If you have a hard time thinking of how those seven scenarios (or at least a subset of them) would apply to a resource you want to create in your database, you may need to rethink how your data is being set up.
 
-It's also important because Rails is structured to follow these conventions in a very straightforward way. As long as you're performing those actions, life is very easy for you and the request that you get from the browser can be easily routed through Rails' guts.
+It's also important because Rails is structured to follow these conventions in a very straightforward way.  As long as you're performing those actions, life is very easy for you and the request that you get from the browser can be easily routed through Rails' guts.
 
 It may seem simplistic to you up front to think of things this way, but once you've got a bit of complexity in your data model, you'll find that falling back on RESTful thinking can help untangle things for you.
 
@@ -63,7 +63,7 @@ The URL is: https://www.google.com/search?q=what+is+a+url
 3.  What is the "Top Level Domain"?
 4.  What is the "Protocol"?
 
-Once you understand what these components are, you can easily use Ruby's libraries to help you build your own and send requests. You also run into specific pieces like the "path" and "parameters" again and again when using Rails.
+Once you understand what these components are, you can easily use Ruby's libraries to help you build your own and send requests.  You also run into specific pieces like the "path" and "parameters" again and again when using Rails.
 
 Answers:
 
@@ -76,9 +76,9 @@ Answers:
 
 You've heard about it again and again, but do you really know what MVC is? Errrrmmmmm, ummm....
 
-MVC is all about organization and Rails is all about MVC. When you build a new Rails project, you get that giant mass of folders and files created. Though it seems like there is an overwhelming number of files inside your `app` directory, they are highly organized and specifically meant to separate the Model, View, and Controller.
+MVC is all about organization and Rails is all about MVC.  When you build a new Rails project, you get that giant mass of folders and files created.  Though it seems like there is an overwhelming number of files inside your `app` directory, they are highly organized and specifically meant to separate the Model, View, and Controller.
 
-The point of MVC is that the functions of a web application can be broken down into more or less distinct parts. Each part gets its own Ruby class. That's great for you the developer because, when you want to tweak a specific part of the code base or fix a bug, you know exactly which file to modify and where it is.
+The point of MVC is that the functions of a web application can be broken down into more or less distinct parts.  Each part gets its own Ruby class.  That's great for you the developer because, when you want to tweak a specific part of the code base or fix a bug, you know exactly which file to modify and where it is.
 
 ### The path through MVC
 
@@ -87,7 +87,7 @@ Once a request from a browser comes into your application, at the most basic lev
 1.  The router figures out which controller to send it to (e.g. for your blog, the Posts controller).
 2.  That controller asks the model (e.g. Post model) for data and any other tough questions it has.
 3.  Then that controller passes off whatever data it needs to the views (e.g. `index.html.erb`), which are basically just HTML templates that are waiting for those variables.
-4.  Once the proper view has been pumped full of the data it needs (like the current user's name), it gets sent back to the client that made the original request. Presto!
+4.  Once the proper view has been pumped full of the data it needs (like the current user's name), it gets sent back to the client that made the original request.  Presto!
 
 Check out a more detailed version of MVC in [betterexplained.com's](http://betterexplained.com/articles/intermediate-rails-understanding-models-views-and-controllers/) article.
 
@@ -97,41 +97,41 @@ Just roll with it, you'll see it in action and learn to love it.
 
 ### APIs
 
-When your computer or a server (which you're programming) wants to make a request to another website, it doesn't bother clicking on things in the browser, it asks that other website for data directly by using that website's API. An API is just an interface. Our web browser goes in the front door to display a bunch of info from Facebook, and our web server goes in the side door for the same data (much faster and more direct) via the API.
+When your computer or a server (which you're programming) wants to make a request to another website, it doesn't bother clicking on things in the browser, it asks that other website for data directly by using that website's API.  An API is just an interface.  Our web browser goes in the front door to display a bunch of info from Facebook, and our web server goes in the side door for the same data (much faster and more direct) via the API.
 
-So you want to get data from Google Maps to display on your webpage? You hit its API using the rules specified in its API documentation. Just about every big website makes some portion of its data available via an API and you can too quite easily using Rails.
+So you want to get data from Google Maps to display on your webpage?  You hit its API using the rules specified in its API documentation.  Just about every big website makes some portion of its data available via an API and you can too quite easily using Rails.
 
 See this explanation (just the first page) on [What APIs are](http://money.howstuffworks.com/business-communications/how-to-leverage-an-api-for-conferencing1.htm) from howstuffworks.
 
-Not all APIs are web-based. Plenty of them use the same HTTP format but are really just designed to pass data between services. In fact, that's how the components of Rails are all strung together -- they use HTTP to communicate with each other.
+Not all APIs are web-based.  Plenty of them use the same HTTP format but are really just designed to pass data between services.  In fact, that's how the components of Rails are all strung together -- they use HTTP to communicate with each other.
 
-You'll actually get a chance to build your own API a little later on, and Rails makes it really easy for you. There's nothing magical about it -- you just tell your controller that you want to respond to requests made by other servers instead of (or in addition to) normal web requests and then specify what exactly you'd like returned (since it probably won't be an HTML view).
+You'll actually get a chance to build your own API a little later on, and Rails makes it really easy for you.  There's nothing magical about it -- you just tell your controller that you want to respond to requests made by other servers instead of (or in addition to) normal web requests and then specify what exactly you'd like returned (since it probably won't be an HTML view).
 
 But we get ahead of ourselves a bit here... the main point is that you'll see "API" come up plenty of times and it's totally harmless and just means the way that two applications talk to each other.
 
 ### Cookies
 
-You've heard about cookies. Cookies are basically a way for websites to remember who you are from one request to another. Remember -- every HTTP request is totally independent of each other. Meaning that when you go to the Home page of a website and then click on a link to their About page, the web server treats you as a completely new user.
+You've heard about cookies.  Cookies are basically a way for websites to remember who you are from one request to another.  Remember -- every HTTP request is totally independent of each other. Meaning that when you go to the Home page of a website and then click on a link to their About page, the web server treats you as a completely new user.
 
-...Unless they've given you some cookies (which they almost certainly have). Cookies are little bits of data that your browser sends to the website every time you make a request to it. From the perspective of the web server, it lets the server identify you as the same person who made any of a series of previous requests. It preserves the _state_ of your session.
+...Unless they've given you some cookies (which they almost certainly have).  Cookies are little bits of data that your browser sends to the website every time you make a request to it.  From the perspective of the web server, it lets the server identify you as the same person who made any of a series of previous requests.  It preserves the *state* of your session.
 
 Check out [allaboutcookies.org](http://www.allaboutcookies.org/) and read the first three sections for some more info about cookies.
 
 The [Wikipedia article on cookies](http://en.wikipedia.org/wiki/HTTP_cookie) may also be helpful reading.
 
-Go to a website you normally frequent, open up your developer tools, and find the cookies. In Chrome, it's by clicking on "Application" tab then "cookies" on the leftmost menu. You'll see them as name-value pairs. Often there will be something like a "user_session" or "token" variable that is some unintelligible string of characters.
+Go to a website you normally frequent, open up your developer tools, and find the cookies.  In Chrome, it's by clicking on "Application" tab then "cookies" on the leftmost menu.  You'll see them as name-value pairs. Often there will be something like a "user_session" or "token" variable that is some unintelligible string of characters.
 
 ### Sessions
 
-Cookies are important because they enable you to have a single continuous "session" while you're interacting with a website. It means you only have to log in once instead of for every single request (which you probably experienced from a broken website at some point in the late 90's).
+Cookies are important because they enable you to have a single continuous "session" while you're interacting with a website.  It means you only have to log in once instead of for every single request (which you probably experienced from a broken website at some point in the late 90's).
 
-Your browser includes all the cookies that a particular website has set along with its normal request and the server uses those strings to figure out which user you are and whether you are logged in, what your settings are (like if you've set up viewing preferences) and things like that. It's also why, when you clear cookies from your browser history, everything seems to get wiped out and go back to the default.
+Your browser includes all the cookies that a particular website has set along with its normal request and the server uses those strings to figure out which user you are and whether you are logged in, what your settings are (like if you've set up viewing preferences) and things like that.  It's also why, when you clear cookies from your browser history, everything seems to get wiped out and go back to the default.
 
 It's also how some ads seem to follow you from one website to another -- another name for them is "tracking cookies".
 
 ### Authentication
 
-On the server side, you'll interact with cookies and session variables quite a bit. As mentioned above, one of the main uses of these is to determine who the user is, or "authentication". You'll basically retrieve the cookie that the user sends you, use it to find that user in your database, and (if the user exists) then you can display the customized web page for that user.
+On the server side, you'll interact with cookies and session variables quite a bit.  As mentioned above, one of the main uses of these is to determine who the user is, or "authentication".  You'll basically retrieve the cookie that the user sends you, use it to find that user in your database, and (if the user exists) then you can display the customized web page for that user.
 
 It's pretty straightforward in theory, but some of the security implications get a bit hairy so luckily some nice folks created a very handy gem called ["Devise"](https://github.com/heartcombo/devise) which takes care of all this stuff for you. In this curriculum (a bit later on), you'll be creating your own authentication system before learning how to use Devise to take care of the heavy lifting.
 

--- a/ruby_on_rails/introduction/web_refresher.md
+++ b/ruby_on_rails/introduction/web_refresher.md
@@ -1,19 +1,18 @@
 ### Introduction
 
-To really understand how Rails works, you need to have a solid base in the guts of the web. You've already covered some of this in previous sections (and if you went through the Ruby curriculum you can just skim it), but this time you'll get a chance (in the project) to reach out and make some real web requests.
+To really understand how Rails works, you need to have a solid base in the guts of the web.  You've already covered some of this in previous sections (and if you went through the Ruby curriculum you can just skim it), but this time you'll get a chance (in the project) to reach out and make some real web requests.
 
 ### Lesson overview
-
 This section contains a general overview of topics that you will learn in this lesson.
 
-- The basics of HTTP.
-- The 4 most commonly used HTTP verbs.
-- The 7 RESTful routes of Rails.
-- The different components of a URL.
-- The basics of MVC.
-- What an API is.
-- What "cookies" and "sessions" are.
-- The difference between "authentication" and "authorization".
+-   The basics of HTTP.
+-   The 4 most commonly used HTTP verbs.
+-   The 7 RESTful routes of Rails.
+-   The different components of a URL.
+-   The basics of MVC.
+-   What an API is.
+-   What "cookies" and "sessions" are.
+-   The difference between "authentication" and "authorization".
 
 ### HTTP
 
@@ -31,7 +30,7 @@ The other key component is that each request uses one of four main "verbs" -- GE
 
 ### REST
 
-REST (short for Representational state transfer) is a term that you'll see coming up again and again because it's a very powerful idea. It basically says that there are really only 7 different types of things that you usually want to do to an individual resource via the web and you can do them by mixing and matching the HTTP verbs we just covered. A "resource" usually means a "thing" in your database or a data model. In this case, we'll assume that resource is a blog Post model that you've set up:
+REST (short for Representational state transfer) is a term that you'll see coming up again and again because it's a very powerful idea.  It basically says that there are really only 7 different types of things that you usually want to do to an individual resource via the web and you can do them by mixing and matching the HTTP verbs we just covered.  A "resource" usually means a "thing" in your database or a data model.  In this case, we'll assume that resource is a blog Post model that you've set up:
 
 1.  GET all the posts (aka **"index"** the posts)
 2.  GET just one specific post (aka **"show"** that post)
@@ -43,7 +42,7 @@ REST (short for Representational state transfer) is a term that you'll see comin
 
 The highlighted words correspond to standard Rails controller actions!
 
-Why is this important?  Because it gives you a very organized way of thinking about your resources.  This is the way to model your requests and should be the ONLY way that those requests are done (e.g. you shouldn't be actually submitting the data for editing a post using a GET request... that should be a POST). If you have a hard time thinking of how those seven scenarios (or at least a subset of them) would apply to a resource you want to create in your database, you may need to rethink how your data is being set up.
+Why is this important?  Because it gives you a very organized way of thinking about your resources.  This is the way to model your requests and should be the ONLY way that those requests are done (e.g. you shouldn't be actually submitting the data for editing a post using a GET request... that should be a POST) If you have a hard time thinking of how those seven scenarios (or at least a subset of them) would apply to a resource you want to create in your database, you may need to rethink how your data is being set up.
 
 It's also important because Rails is structured to follow these conventions in a very straightforward way.  As long as you're performing those actions, life is very easy for you and the request that you get from the browser can be easily routed through Rails' guts.
 
@@ -74,7 +73,7 @@ Answers:
 
 ### MVC
 
-You've heard about it again and again, but do you really know what MVC is? Errrrmmmmm, ummm....
+You've heard about it again and again, but do you really know what MVC is?  Errrrmmmmm, ummm....
 
 MVC is all about organization and Rails is all about MVC.  When you build a new Rails project, you get that giant mass of folders and files created.  Though it seems like there is an overwhelming number of files inside your `app` directory, they are highly organized and specifically meant to separate the Model, View, and Controller.
 
@@ -111,7 +110,7 @@ But we get ahead of ourselves a bit here... the main point is that you'll see "A
 
 ### Cookies
 
-You've heard about cookies.  Cookies are basically a way for websites to remember who you are from one request to another.  Remember -- every HTTP request is totally independent of each other. Meaning that when you go to the Home page of a website and then click on a link to their About page, the web server treats you as a completely new user.
+You've heard about cookies.  Cookies are basically a way for websites to remember who you are from one request to another.  Remember -- every HTTP request is totally independent of each other.  Meaning that when you go to the Home page of a website and then click on a link to their About page, the web server treats you as a completely new user.
 
 ...Unless they've given you some cookies (which they almost certainly have).  Cookies are little bits of data that your browser sends to the website every time you make a request to it.  From the perspective of the web server, it lets the server identify you as the same person who made any of a series of previous requests.  It preserves the *state* of your session.
 
@@ -119,11 +118,11 @@ Check out [allaboutcookies.org](http://www.allaboutcookies.org/) and read the fi
 
 The [Wikipedia article on cookies](http://en.wikipedia.org/wiki/HTTP_cookie) may also be helpful reading.
 
-Go to a website you normally frequent, open up your developer tools, and find the cookies.  In Chrome, it's by clicking on "Application" tab then "cookies" on the leftmost menu.  You'll see them as name-value pairs. Often there will be something like a "user_session" or "token" variable that is some unintelligible string of characters.
+Go to a website you normally frequent, open up your developer tools, and find the cookies.  In Chrome, it's by clicking on "Application" tab then "cookies" on the leftmost menu.  You'll see them as name-value pairs.  Often there will be something like a "user_session" or "token" variable that is some unintelligible string of characters.
 
 ### Sessions
 
-Cookies are important because they enable you to have a single continuous "session" while you're interacting with a website.  It means you only have to log in once instead of for every single request (which you probably experienced from a broken website at some point in the late 90's).
+Cookies are important because they enable you to have a single continuous "session" while you're interacting with a website. It means you only have to log in once instead of for every single request (which you probably experienced from a broken website at some point in the late 90's).
 
 Your browser includes all the cookies that a particular website has set along with its normal request and the server uses those strings to figure out which user you are and whether you are logged in, what your settings are (like if you've set up viewing preferences) and things like that.  It's also why, when you clear cookies from your browser history, everything seems to get wiped out and go back to the default.
 
@@ -137,30 +136,28 @@ It's pretty straightforward in theory, but some of the security implications get
 
 ### Authorization
 
-Authorization is the partner concept to Authentication... Authentication lets you determine WHO the user is, but the idea behind authorization is that you might limit what the person can see based on their permission level. The most common case of this is actually the distinction between a random not-logged-in user and one who is logged in. Another common case of this is the difference between regular users of a website and the admin users who have special privileges.
+Authorization is the partner concept to Authentication... Authentication lets you determine WHO the user is, but the idea behind authorization is that you might limit what the person can see based on their permission level.  The most common case of this is actually the distinction between a random not-logged-in user and one who is logged in.  Another common case of this is the difference between regular users of a website and the admin users who have special privileges.
 
-On the server side, you will end up writing (or using) methods which restrict access to certain types of actions based on who the current user is (or whether the requester is logged in at all). Again, Devise will help you with this by providing some of these helper methods (like for checking whether any user is logged in or who the current user is) for you.
+On the server side, you will end up writing (or using) methods which restrict access to certain types of actions based on who the current user is (or whether the requester is logged in at all).  Again, Devise will help you with this by providing some of these helper methods (like for checking whether any user is logged in or who the current user is) for you.
 
 ### Conclusion
 
-We'll dig into this stuff a bit later, but it's good to understand in the context of what we talked about before in regards to how requests are made because it brings a couple of extra layers onto these formerly-independent HTTP requests. Authentication systems allow you to establish sessions which preserve the user's state (like logged in status) across requests and helps you determine whether the user is authorized to do a particular thing.
+We'll dig into this stuff a bit later, but it's good to understand in the context of what we talked about before in regards to how requests are made because it brings a couple of extra layers onto these formerly-independent HTTP requests.  Authentication systems allow you to establish sessions which preserve the user's state (like logged in status) across requests and helps you determine whether the user is authorized to do a particular thing.
 
 ### Knowledge check
-
 This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
 
-- <a class="knowledge-check-link" href="https://code.tutsplus.com/tutorials/http-the-protocol-every-web-developer-must-know-part-1--net-31177"> What do you call an HTTP message that goes from client to server? </a>
-- <a class="knowledge-check-link" href="https://code.tutsplus.com/tutorials/http-the-protocol-every-web-developer-must-know-part-1--net-31177"> What do you call an HTTP message that goes from server to client? </a>
-- <a class="knowledge-check-link" href="https://code.tutsplus.com/tutorials/http-the-protocol-every-web-developer-must-know-part-1--net-31177"> Which HTTP message would include a status code and which would include an action verb? </a>
-- <a class="knowledge-check-link" href="https://www.mattcutts.com/blog/seo-glossary-url-definitions/"> What is the name of the additional information that is added after the path of a URL? </a>
-- <a class="knowledge-check-link" href="https://betterexplained.com/articles/intermediate-rails-understanding-models-views-and-controllers/"> What does MVC stand for? </a>
-- <a class="knowledge-check-link" href="https://money.howstuffworks.com/business-communications/how-to-leverage-an-api-for-conferencing1.htm"> What is an "API"? </a>
-- <a class="knowledge-check-link" href="https://en.wikipedia.org/wiki/HTTP_cookie#Session_management"> Why do you need "cookies" to continue your "session"? </a>
-- <a class="knowledge-check-link" href="#authorization"> What is the difference between "authentication" and "authorization"? </a>
+-   <a class="knowledge-check-link" href="https://code.tutsplus.com/tutorials/http-the-protocol-every-web-developer-must-know-part-1--net-31177"> What do you call an HTTP message that goes from client to server? </a>
+-   <a class="knowledge-check-link" href="https://code.tutsplus.com/tutorials/http-the-protocol-every-web-developer-must-know-part-1--net-31177"> What do you call an HTTP message that goes from server to client? </a>
+-   <a class="knowledge-check-link" href="https://code.tutsplus.com/tutorials/http-the-protocol-every-web-developer-must-know-part-1--net-31177"> Which HTTP message would include a status code and which would include an action verb? </a>
+-   <a class="knowledge-check-link" href="https://www.mattcutts.com/blog/seo-glossary-url-definitions/"> What is the name of the additional information that is added after the path of a URL? </a>
+-   <a class="knowledge-check-link" href="https://betterexplained.com/articles/intermediate-rails-understanding-models-views-and-controllers/"> What does MVC stand for? </a>
+-   <a class="knowledge-check-link" href="https://money.howstuffworks.com/business-communications/how-to-leverage-an-api-for-conferencing1.htm"> What is an "API"? </a>
+-   <a class="knowledge-check-link" href="https://en.wikipedia.org/wiki/HTTP_cookie#Session_management"> Why do you need "cookies" to continue your "session"? </a>
+-   <a class="knowledge-check-link" href="#authorization"> What is the difference between "authentication" and "authorization"? </a>
 
 ### Additional resources
-
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
-- [HTTP explained by Harvard's David Malan](http://www.youtube.com/watch?v=8KuO4r5CHjM)
-- [HTTP Request/Response Basics](http://justahelp.blogspot.com/2013/09/http-requestresponse-basics.html) from Pralay Roy
+-   [HTTP explained by Harvard's David Malan](http://www.youtube.com/watch?v=8KuO4r5CHjM)
+-   [HTTP Request/Response Basics](http://justahelp.blogspot.com/2013/09/http-requestresponse-basics.html) from Pralay Roy

--- a/ruby_on_rails/introduction/web_refresher.md
+++ b/ruby_on_rails/introduction/web_refresher.md
@@ -1,22 +1,23 @@
 ### Introduction
 
-To really understand how Rails works, you need to have a solid base in the guts of the web.  You've already covered some of this in previous sections (and if you went through the Ruby curriculum you can just skim it), but this time you'll get a chance (in the project) to reach out and make some real web requests.
+To really understand how Rails works, you need to have a solid base in the guts of the web. You've already covered some of this in previous sections (and if you went through the Ruby curriculum you can just skim it), but this time you'll get a chance (in the project) to reach out and make some real web requests.
 
-### Lesson Overview
+### Lesson overview
+
 This section contains a general overview of topics that you will learn in this lesson.
 
--   The basics of HTTP.
--   The 4 most commonly used HTTP verbs.
--   The 7 RESTful routes of Rails.
--   The different components of a URL.
--   The basics of MVC.
--   What an API is.
--   What "cookies" and "sessions" are.
--   The difference between "authentication" and "authorization".
+- The basics of HTTP.
+- The 4 most commonly used HTTP verbs.
+- The 7 RESTful routes of Rails.
+- The different components of a URL.
+- The basics of MVC.
+- What an API is.
+- What "cookies" and "sessions" are.
+- The difference between "authentication" and "authorization".
 
 ### HTTP
 
-HTTP is just a way of structuring the request-and-response conversation between your browser and the server.  Actually, it's not even a conversation since it is stateless... it's more of an "ask and receive".  The protocol outlines how that brief piece of dialogue should occur.
+HTTP is just a way of structuring the request-and-response conversation between your browser and the server. Actually, it's not even a conversation since it is stateless... it's more of an "ask and receive". The protocol outlines how that brief piece of dialogue should occur.
 
 Check out these resources:
 
@@ -24,13 +25,13 @@ Check out these resources:
 2.  This [sniffer tool](http://testuri.org/sniffer) - try retrieving a couple of websites (like http://www.theodinproject.com) on your own.
 3.  This [great video](https://code.tutsplus.com/tutorials/how-the-web-works-http-and-the-web-server--cms-25971) on communications between http requests and the web server.
 
-One key component to pay attention to is the fact that the request and response both have header and (usually) body components.  The header contains information about the request or response itself (meta data), including which website to send or return to and what the status of the response is.  The body of the request can contain things like data submitted by a form or cookies or authentication tokens while the response will usually contain the HTML page you're trying to access.
+One key component to pay attention to is the fact that the request and response both have header and (usually) body components. The header contains information about the request or response itself (meta data), including which website to send or return to and what the status of the response is. The body of the request can contain things like data submitted by a form or cookies or authentication tokens while the response will usually contain the HTML page you're trying to access.
 
-The other key component is that each request uses one of four main "verbs" -- GET, POST, PUT, and DELETE.  These days, you almost only see GET and POST requests (even if you're trying to do a delete of something they usually fake it using a POST request), but it's important to understand the difference between the verbs.
+The other key component is that each request uses one of four main "verbs" -- GET, POST, PUT, and DELETE. These days, you almost only see GET and POST requests (even if you're trying to do a delete of something they usually fake it using a POST request), but it's important to understand the difference between the verbs.
 
 ### REST
 
-REST (short for Representational state transfer) is a term that you'll see coming up again and again because it's a very powerful idea.  It basically says that there are really only 7 different types of things that you usually want to do to an individual resource via the web and you can do them by mixing and matching the HTTP verbs we just covered.  A "resource" usually means a "thing" in your database or a data model.  In this case, we'll assume that resource is a blog Post model that you've set up:
+REST (short for Representational state transfer) is a term that you'll see coming up again and again because it's a very powerful idea. It basically says that there are really only 7 different types of things that you usually want to do to an individual resource via the web and you can do them by mixing and matching the HTTP verbs we just covered. A "resource" usually means a "thing" in your database or a data model. In this case, we'll assume that resource is a blog Post model that you've set up:
 
 1.  GET all the posts (aka **"index"** the posts)
 2.  GET just one specific post (aka **"show"** that post)
@@ -42,9 +43,9 @@ REST (short for Representational state transfer) is a term that you'll see comin
 
 The highlighted words correspond to standard Rails controller actions!
 
-Why is this important?  Because it gives you a very organized way of thinking about your resources.  This is the way to model your requests and should be the ONLY way that those requests are done (e.g. you shouldn't be actually submitting the data for editing a post using a GET request... that should be a POST) If you have a hard time thinking of how those seven scenarios (or at least a subset of them) would apply to a resource you want to create in your database, you may need to rethink how your data is being set up.
+Why is this important? Because it gives you a very organized way of thinking about your resources. This is the way to model your requests and should be the ONLY way that those requests are done (e.g. you shouldn't be actually submitting the data for editing a post using a GET request... that should be a POST) If you have a hard time thinking of how those seven scenarios (or at least a subset of them) would apply to a resource you want to create in your database, you may need to rethink how your data is being set up.
 
-It's also important because Rails is structured to follow these conventions in a very straightforward way.  As long as you're performing those actions, life is very easy for you and the request that you get from the browser can be easily routed through Rails' guts.
+It's also important because Rails is structured to follow these conventions in a very straightforward way. As long as you're performing those actions, life is very easy for you and the request that you get from the browser can be easily routed through Rails' guts.
 
 It may seem simplistic to you up front to think of things this way, but once you've got a bit of complexity in your data model, you'll find that falling back on RESTful thinking can help untangle things for you.
 
@@ -54,7 +55,7 @@ You may think you know what's in a URL, but which part is the host? protocol (ak
 
 Check out this [article by Matt Cutts](http://www.mattcutts.com/blog/seo-glossary-url-definitions/) on how Googlers pick apart URL components.
 
-**Quick Quiz:**
+**Quick quiz:**
 The URL is: https://www.google.com/search?q=what+is+a+url
 
 1.  What is the "Path"?
@@ -62,7 +63,7 @@ The URL is: https://www.google.com/search?q=what+is+a+url
 3.  What is the "Top Level Domain"?
 4.  What is the "Protocol"?
 
-Once you understand what these components are, you can easily use Ruby's libraries to help you build your own and send requests.  You also run into specific pieces like the "path" and "parameters" again and again when using Rails.
+Once you understand what these components are, you can easily use Ruby's libraries to help you build your own and send requests. You also run into specific pieces like the "path" and "parameters" again and again when using Rails.
 
 Answers:
 
@@ -73,20 +74,20 @@ Answers:
 
 ### MVC
 
-You've heard about it again and again, but do you really know what MVC is?  Errrrmmmmm, ummm....
+You've heard about it again and again, but do you really know what MVC is? Errrrmmmmm, ummm....
 
-MVC is all about organization and Rails is all about MVC.  When you build a new Rails project, you get that giant mass of folders and files created.  Though it seems like there is an overwhelming number of files inside your `app` directory, they are highly organized and specifically meant to separate the Model, View, and Controller.
+MVC is all about organization and Rails is all about MVC. When you build a new Rails project, you get that giant mass of folders and files created. Though it seems like there is an overwhelming number of files inside your `app` directory, they are highly organized and specifically meant to separate the Model, View, and Controller.
 
-The point of MVC is that the functions of a web application can be broken down into more or less distinct parts.  Each part gets its own Ruby class.  That's great for you the developer because, when you want to tweak a specific part of the code base or fix a bug, you know exactly which file to modify and where it is.
+The point of MVC is that the functions of a web application can be broken down into more or less distinct parts. Each part gets its own Ruby class. That's great for you the developer because, when you want to tweak a specific part of the code base or fix a bug, you know exactly which file to modify and where it is.
 
-### The Path Through MVC
+### The path through MVC
 
 Once a request from a browser comes into your application, at the most basic level:
 
 1.  The router figures out which controller to send it to (e.g. for your blog, the Posts controller).
 2.  That controller asks the model (e.g. Post model) for data and any other tough questions it has.
 3.  Then that controller passes off whatever data it needs to the views (e.g. `index.html.erb`), which are basically just HTML templates that are waiting for those variables.
-4.  Once the proper view has been pumped full of the data it needs (like the current user's name), it gets sent back to the client that made the original request.  Presto!
+4.  Once the proper view has been pumped full of the data it needs (like the current user's name), it gets sent back to the client that made the original request. Presto!
 
 Check out a more detailed version of MVC in [betterexplained.com's](http://betterexplained.com/articles/intermediate-rails-understanding-models-views-and-controllers/) article.
 
@@ -96,68 +97,70 @@ Just roll with it, you'll see it in action and learn to love it.
 
 ### APIs
 
-When your computer or a server (which you're programming) wants to make a request to another website, it doesn't bother clicking on things in the browser, it asks that other website for data directly by using that website's API.  An API is just an interface.  Our web browser goes in the front door to display a bunch of info from Facebook, and our web server goes in the side door for the same data (much faster and more direct) via the API.
+When your computer or a server (which you're programming) wants to make a request to another website, it doesn't bother clicking on things in the browser, it asks that other website for data directly by using that website's API. An API is just an interface. Our web browser goes in the front door to display a bunch of info from Facebook, and our web server goes in the side door for the same data (much faster and more direct) via the API.
 
-So you want to get data from Google Maps to display on your webpage?  You hit its API using the rules specified in its API documentation.  Just about every big website makes some portion of its data available via an API and you can too quite easily using Rails.
+So you want to get data from Google Maps to display on your webpage? You hit its API using the rules specified in its API documentation. Just about every big website makes some portion of its data available via an API and you can too quite easily using Rails.
 
 See this explanation (just the first page) on [What APIs are](http://money.howstuffworks.com/business-communications/how-to-leverage-an-api-for-conferencing1.htm) from howstuffworks.
 
-Not all APIs are web-based.  Plenty of them use the same HTTP format but are really just designed to pass data between services.  In fact, that's how the components of Rails are all strung together -- they use HTTP to communicate with each other.
+Not all APIs are web-based. Plenty of them use the same HTTP format but are really just designed to pass data between services. In fact, that's how the components of Rails are all strung together -- they use HTTP to communicate with each other.
 
-You'll actually get a chance to build your own API a little later on, and Rails makes it really easy for you.  There's nothing magical about it -- you just tell your controller that you want to respond to requests made by other servers instead of (or in addition to) normal web requests and then specify what exactly you'd like returned (since it probably won't be an HTML view).
+You'll actually get a chance to build your own API a little later on, and Rails makes it really easy for you. There's nothing magical about it -- you just tell your controller that you want to respond to requests made by other servers instead of (or in addition to) normal web requests and then specify what exactly you'd like returned (since it probably won't be an HTML view).
 
 But we get ahead of ourselves a bit here... the main point is that you'll see "API" come up plenty of times and it's totally harmless and just means the way that two applications talk to each other.
 
 ### Cookies
 
-You've heard about cookies.  Cookies are basically a way for websites to remember who you are from one request to another.  Remember -- every HTTP request is totally independent of each other.  Meaning that when you go to the Home page of a website and then click on a link to their About page, the web server treats you as a completely new user.
+You've heard about cookies. Cookies are basically a way for websites to remember who you are from one request to another. Remember -- every HTTP request is totally independent of each other. Meaning that when you go to the Home page of a website and then click on a link to their About page, the web server treats you as a completely new user.
 
-...Unless they've given you some cookies (which they almost certainly have).  Cookies are little bits of data that your browser sends to the website every time you make a request to it.  From the perspective of the web server, it lets the server identify you as the same person who made any of a series of previous requests.  It preserves the *state* of your session.
+...Unless they've given you some cookies (which they almost certainly have). Cookies are little bits of data that your browser sends to the website every time you make a request to it. From the perspective of the web server, it lets the server identify you as the same person who made any of a series of previous requests. It preserves the _state_ of your session.
 
 Check out [allaboutcookies.org](http://www.allaboutcookies.org/) and read the first three sections for some more info about cookies.
 
 The [Wikipedia article on cookies](http://en.wikipedia.org/wiki/HTTP_cookie) may also be helpful reading.
 
-Go to a website you normally frequent, open up your developer tools, and find the cookies.  In Chrome, it's by clicking on "Application" tab then "cookies" on the leftmost menu.  You'll see them as name-value pairs.  Often there will be something like a "user_session" or "token" variable that is some unintelligible string of characters.
+Go to a website you normally frequent, open up your developer tools, and find the cookies. In Chrome, it's by clicking on "Application" tab then "cookies" on the leftmost menu. You'll see them as name-value pairs. Often there will be something like a "user_session" or "token" variable that is some unintelligible string of characters.
 
 ### Sessions
 
 Cookies are important because they enable you to have a single continuous "session" while you're interacting with a website. It means you only have to log in once instead of for every single request (which you probably experienced from a broken website at some point in the late 90's).
 
-Your browser includes all the cookies that a particular website has set along with its normal request and the server uses those strings to figure out which user you are and whether you are logged in, what your settings are (like if you've set up viewing preferences) and things like that.  It's also why, when you clear cookies from your browser history, everything seems to get wiped out and go back to the default.
+Your browser includes all the cookies that a particular website has set along with its normal request and the server uses those strings to figure out which user you are and whether you are logged in, what your settings are (like if you've set up viewing preferences) and things like that. It's also why, when you clear cookies from your browser history, everything seems to get wiped out and go back to the default.
 
 It's also how some ads seem to follow you from one website to another -- another name for them is "tracking cookies".
 
 ### Authentication
 
-On the server side, you'll interact with cookies and session variables quite a bit.  As mentioned above, one of the main uses of these is to determine who the user is, or "authentication".  You'll basically retrieve the cookie that the user sends you, use it to find that user in your database, and (if the user exists) then you can display the customized web page for that user.
+On the server side, you'll interact with cookies and session variables quite a bit. As mentioned above, one of the main uses of these is to determine who the user is, or "authentication". You'll basically retrieve the cookie that the user sends you, use it to find that user in your database, and (if the user exists) then you can display the customized web page for that user.
 
 It's pretty straightforward in theory, but some of the security implications get a bit hairy so luckily some nice folks created a very handy gem called ["Devise"](https://github.com/heartcombo/devise) which takes care of all this stuff for you. In this curriculum (a bit later on), you'll be creating your own authentication system before learning how to use Devise to take care of the heavy lifting.
 
 ### Authorization
 
-Authorization is the partner concept to Authentication... Authentication lets you determine WHO the user is, but the idea behind authorization is that you might limit what the person can see based on their permission level.  The most common case of this is actually the distinction between a random not-logged-in user and one who is logged in.  Another common case of this is the difference between regular users of a website and the admin users who have special privileges.
+Authorization is the partner concept to Authentication... Authentication lets you determine WHO the user is, but the idea behind authorization is that you might limit what the person can see based on their permission level. The most common case of this is actually the distinction between a random not-logged-in user and one who is logged in. Another common case of this is the difference between regular users of a website and the admin users who have special privileges.
 
-On the server side, you will end up writing (or using) methods which restrict access to certain types of actions based on who the current user is (or whether the requester is logged in at all).  Again, Devise will help you with this by providing some of these helper methods (like for checking whether any user is logged in or who the current user is) for you.
+On the server side, you will end up writing (or using) methods which restrict access to certain types of actions based on who the current user is (or whether the requester is logged in at all). Again, Devise will help you with this by providing some of these helper methods (like for checking whether any user is logged in or who the current user is) for you.
 
 ### Conclusion
 
-We'll dig into this stuff a bit later, but it's good to understand in the context of what we talked about before in regards to how requests are made because it brings a couple of extra layers onto these formerly-independent HTTP requests.  Authentication systems allow you to establish sessions which preserve the user's state (like logged in status) across requests and helps you determine whether the user is authorized to do a particular thing.
+We'll dig into this stuff a bit later, but it's good to understand in the context of what we talked about before in regards to how requests are made because it brings a couple of extra layers onto these formerly-independent HTTP requests. Authentication systems allow you to establish sessions which preserve the user's state (like logged in status) across requests and helps you determine whether the user is authorized to do a particular thing.
 
-### Knowledge Check
+### Knowledge check
+
 This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
 
--   <a class="knowledge-check-link" href="https://code.tutsplus.com/tutorials/http-the-protocol-every-web-developer-must-know-part-1--net-31177"> What do you call an HTTP message that goes from client to server? </a>
--   <a class="knowledge-check-link" href="https://code.tutsplus.com/tutorials/http-the-protocol-every-web-developer-must-know-part-1--net-31177"> What do you call an HTTP message that goes from server to client? </a>
--   <a class="knowledge-check-link" href="https://code.tutsplus.com/tutorials/http-the-protocol-every-web-developer-must-know-part-1--net-31177"> Which HTTP message would include a status code and which would include an action verb? </a>
--   <a class="knowledge-check-link" href="https://www.mattcutts.com/blog/seo-glossary-url-definitions/"> What is the name of the additional information that is added after the path of a URL? </a>
--   <a class="knowledge-check-link" href="https://betterexplained.com/articles/intermediate-rails-understanding-models-views-and-controllers/"> What does MVC stand for? </a>
--   <a class="knowledge-check-link" href="https://money.howstuffworks.com/business-communications/how-to-leverage-an-api-for-conferencing1.htm"> What is an "API"? </a>
--   <a class="knowledge-check-link" href="https://en.wikipedia.org/wiki/HTTP_cookie#Session_management"> Why do you need "cookies" to continue your "session"? </a>
--   <a class="knowledge-check-link" href="#authorization"> What is the difference between "authentication" and "authorization"? </a>
+- <a class="knowledge-check-link" href="https://code.tutsplus.com/tutorials/http-the-protocol-every-web-developer-must-know-part-1--net-31177"> What do you call an HTTP message that goes from client to server? </a>
+- <a class="knowledge-check-link" href="https://code.tutsplus.com/tutorials/http-the-protocol-every-web-developer-must-know-part-1--net-31177"> What do you call an HTTP message that goes from server to client? </a>
+- <a class="knowledge-check-link" href="https://code.tutsplus.com/tutorials/http-the-protocol-every-web-developer-must-know-part-1--net-31177"> Which HTTP message would include a status code and which would include an action verb? </a>
+- <a class="knowledge-check-link" href="https://www.mattcutts.com/blog/seo-glossary-url-definitions/"> What is the name of the additional information that is added after the path of a URL? </a>
+- <a class="knowledge-check-link" href="https://betterexplained.com/articles/intermediate-rails-understanding-models-views-and-controllers/"> What does MVC stand for? </a>
+- <a class="knowledge-check-link" href="https://money.howstuffworks.com/business-communications/how-to-leverage-an-api-for-conferencing1.htm"> What is an "API"? </a>
+- <a class="knowledge-check-link" href="https://en.wikipedia.org/wiki/HTTP_cookie#Session_management"> Why do you need "cookies" to continue your "session"? </a>
+- <a class="knowledge-check-link" href="#authorization"> What is the difference between "authentication" and "authorization"? </a>
 
-### Additional Resources
+### Additional resources
+
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
--   [HTTP explained by Harvard's David Malan](http://www.youtube.com/watch?v=8KuO4r5CHjM)
--   [HTTP Request/Response Basics](http://justahelp.blogspot.com/2013/09/http-requestresponse-basics.html) from Pralay Roy
+- [HTTP explained by Harvard's David Malan](http://www.youtube.com/watch?v=8KuO4r5CHjM)
+- [HTTP Request/Response Basics](http://justahelp.blogspot.com/2013/09/http-requestresponse-basics.html) from Pralay Roy

--- a/ruby_on_rails/rails_basics/controllers.md
+++ b/ruby_on_rails/rails_basics/controllers.md
@@ -8,7 +8,7 @@ It's pretty straightforward. Typical controllers are pretty lightweight and don'
 
 The controller's `#index` action would actually look as simple as:
 
-```ruby
+~~~ruby
   PostsController < ApplicationController
     ...
     def index
@@ -16,7 +16,7 @@ The controller's `#index` action would actually look as simple as:
     end
     ...
   end
-```
+~~~
 
 In this simple action, we have the controller asking the model for something ("Hey, give me all the posts!"), packaging them up in an instance variable `@posts` so the view can use them, then will automatically render the view at `app/views/posts/index.html.erb` (we'll talk about that in a minute).
 
@@ -48,7 +48,7 @@ The trick here is that the view page gets passed the instance variables from you
 
 Let's see it in code:
 
-```ruby
+~~~ruby
   # app/controllers/posts_controller.rb
   class PostsController < ApplicationController
     ...
@@ -74,7 +74,7 @@ Let's see it in code:
       end
     end
   end
-```
+~~~
 
 So the thing to pay attention to is that, if we successfully are able to save our new post in the database, we redirect to that post's show page. Note that a shortcut you'll see plenty of times is, instead of writing `redirect_to post_path(@post.id)`, just write `redirect_to @post` because Rails knows people did that so often that they gave you the option of writing it shorthand. We'll use this in the example as we develop it further.
 
@@ -86,7 +86,7 @@ It's important to note that `render` and `redirect_to` do NOT immediately stop y
 
 If you write something like:
 
-```ruby
+~~~ruby
   def show
     @user = User.find(params[:id])
     if @user.is_male?
@@ -94,7 +94,7 @@ If you write something like:
     end
     render "show-girl"
   end
-```
+~~~
 
 In any case where the user is male, you'll get hit with a multiple render error because you've told Rails to render both "show-boy" and "show-girl".
 
@@ -118,11 +118,11 @@ _Note: This used to be done in Rails 3 by setting `attr_accessible` in the model
 
 To explicitly allow parameters, you use the methods `require` and `permit`. Basically, you `require` the name of your array or hash to be in Params (otherwise it'll throw an error), and then you `permit` the individual attributes inside that hash to be used. For example:
 
-```ruby
+~~~ruby
   def allowed_post_params
     params.require(:post).permit(:title,:body,:author_id)
   end
-```
+~~~
 
 This will return the hash of only those params that you explicitly allow (e.g. `{:title => "your title", :body => "your body", :author_id => "1"}` ). If you didn't do this, when you tried to access params[:post] nothing would show up! Also, if there were any additional fields submitted inside the hash, these will be stripped away and made inaccessible (to protect you).
 
@@ -130,7 +130,7 @@ It can be inconvenient, but it's Rails protecting you from bad users. You'll usu
 
 So our `#create` action above can now be filled out a bit more:
 
-```ruby
+~~~ruby
   # app/controllers/posts_controller.rb
   class PostsController < ApplicationController
     ...
@@ -156,7 +156,7 @@ So our `#create` action above can now be filled out a bit more:
       params.require(:post).permit(:title,:body,:author_id)
     end
   end
-```
+~~~
 
 ### Flash
 
@@ -174,7 +174,7 @@ The distinction between `flash` and `flash.now` just lets Rails know when it wil
 
 Now the full controller code can be written out for our `#create` action:
 
-```ruby
+~~~ruby
   # app/controllers/posts_controller.rb
   class PostsController < ApplicationController
     ...
@@ -198,7 +198,7 @@ Now the full controller code can be written out for our `#create` action:
       params.require(:post).permit(:title,:body,:author_id)
     end
   end
-```
+~~~
 
 So that action did a fair bit of stuff -- grab the form data, make a new post, try to save the post, set up a success message and redirect you to the post if it works, and handle the case where it doesn't work by berating you for your foolishness and re-rendering the form. A lot of work for only 10 lines of Ruby. Now that's smart controlling.
 

--- a/ruby_on_rails/rails_basics/controllers.md
+++ b/ruby_on_rails/rails_basics/controllers.md
@@ -8,7 +8,7 @@ It's pretty straightforward. Typical controllers are pretty lightweight and don'
 
 The controller's `#index` action would actually look as simple as:
 
-~~~ruby
+```ruby
   PostsController < ApplicationController
     ...
     def index
@@ -16,11 +16,11 @@ The controller's `#index` action would actually look as simple as:
     end
     ...
   end
-~~~
+```
 
 In this simple action, we have the controller asking the model for something ("Hey, give me all the posts!"), packaging them up in an instance variable `@posts` so the view can use them, then will automatically render the view at `app/views/posts/index.html.erb` (we'll talk about that in a minute).
 
-### Lesson Overview
+### Lesson overview
 
 This section contains a general overview of topics that you will learn in this lesson.
 
@@ -30,13 +30,13 @@ This section contains a general overview of topics that you will learn in this l
 - Handling and restricting parameters and POST-data passed to your controller.
 - The flash message and how to display it.
 
-### Naming Matters
+### Naming matters
 
 One way that Rails makes your life a bit easier is that it assumes things are named a certain way and then executes them behind the scenes based on those names. For instance, your controller and its action have to be named whatever you called them in your `routes.rb` file when you mapped a specific type of HTTP request to them.
 
 The other end of the process is what the controller does when it's done. Once Rails gets to the `end` of that controller action, it grabs all the instance variables from the controller and sends them over the view file _which is named the same thing as the controller action_ and which lives in a folder named after the controller, e.g. `app/views/posts/index.html.erb`. This isn't arbitrary, this is intentional to make your life a lot easier when looking for files later. If you save your files in a different folder or hierarchy, you'll have to explicitly specify which ones you want rendered.
 
-### Rendering and Redirecting
+### Rendering and redirecting
 
 Although Rails will implicitly render a view file that is named the same thing as your controller action, there are plenty of situations when you might want to override it. A main case for this is when you actually want to completely redirect the user to a new page instead of rendering the result of your controller action.
 
@@ -48,7 +48,7 @@ The trick here is that the view page gets passed the instance variables from you
 
 Let's see it in code:
 
-~~~ruby
+```ruby
   # app/controllers/posts_controller.rb
   class PostsController < ApplicationController
     ...
@@ -74,19 +74,19 @@ Let's see it in code:
       end
     end
   end
-~~~
+```
 
 So the thing to pay attention to is that, if we successfully are able to save our new post in the database, we redirect to that post's show page. Note that a shortcut you'll see plenty of times is, instead of writing `redirect_to post_path(@post.id)`, just write `redirect_to @post` because Rails knows people did that so often that they gave you the option of writing it shorthand. We'll use this in the example as we develop it further.
 
 The error condition in the `#create` action above is going to render the same form that we rendered in the `#new` action, though this time `@post` will be the Post object that we tried and failed to save, so it will also have some errors attached to it which can be used to highlight in red which form fields were the culprits.
 
-### Multiple Render/Redirects
+### Multiple render/redirects
 
 It's important to note that `render` and `redirect_to` do NOT immediately stop your controller action like a `return` statement would. So you have to be really careful that your logic doesn't result in you running more than one of those statements. If you do, you'll get hit with an error. They're usually pretty straightforward to debug.
 
 If you write something like:
 
-~~~ruby
+```ruby
   def show
     @user = User.find(params[:id])
     if @user.is_male?
@@ -94,11 +94,11 @@ If you write something like:
     end
     render "show-girl"
   end
-~~~
+```
 
 In any case where the user is male, you'll get hit with a multiple render error because you've told Rails to render both "show-boy" and "show-girl".
 
-### Params and Strong Parameters
+### Params and strong parameters
 
 In the example above, we saw `... code here to set up a new @post based on form info ...`. Okay, how do we grab that info? We keep saying that the router packages up all the parameters that were sent with the original HTTP request, but how do we access them?
 
@@ -106,7 +106,7 @@ With the `params` hash! It acts just like a normal Ruby hash and contains the pa
 
 Some forms will submit every field as a top level scalar entry in the params hash, e.g. `params[:post_title]` might be "My Test Post Title" and `params[:post_body]` might be "Body of post!" etc and these you can access with no issues. You have control over this, as you'll learn in the lessons on forms.
 
-#### Strong Parameters
+#### Strong parameters
 
 Often times, though, you want to send parameters from the browser that are all packaged nicely into a hash or nested into an array. It can make your life a lot easier because you can just pass that hash straight into `Post.new(your_hash_of_attributes_here)` because that's what `Post.new` expects anyway! We won't really get too deep into this stuff until the lessons on Models and Forms, but you should be aware that the structure of the data you're being sent from a form depends entirely on how you choose to set up that form (it's really based on how you choose to name your fields using the HTML `name=''` attribute).
 
@@ -118,11 +118,11 @@ _Note: This used to be done in Rails 3 by setting `attr_accessible` in the model
 
 To explicitly allow parameters, you use the methods `require` and `permit`. Basically, you `require` the name of your array or hash to be in Params (otherwise it'll throw an error), and then you `permit` the individual attributes inside that hash to be used. For example:
 
-~~~ruby
+```ruby
   def allowed_post_params
     params.require(:post).permit(:title,:body,:author_id)
   end
-~~~
+```
 
 This will return the hash of only those params that you explicitly allow (e.g. `{:title => "your title", :body => "your body", :author_id => "1"}` ). If you didn't do this, when you tried to access params[:post] nothing would show up! Also, if there were any additional fields submitted inside the hash, these will be stripped away and made inaccessible (to protect you).
 
@@ -130,7 +130,7 @@ It can be inconvenient, but it's Rails protecting you from bad users. You'll usu
 
 So our `#create` action above can now be filled out a bit more:
 
-~~~ruby
+```ruby
   # app/controllers/posts_controller.rb
   class PostsController < ApplicationController
     ...
@@ -156,7 +156,7 @@ So our `#create` action above can now be filled out a bit more:
       params.require(:post).permit(:title,:body,:author_id)
     end
   end
-~~~
+```
 
 ### Flash
 
@@ -174,7 +174,7 @@ The distinction between `flash` and `flash.now` just lets Rails know when it wil
 
 Now the full controller code can be written out for our `#create` action:
 
-~~~ruby
+```ruby
   # app/controllers/posts_controller.rb
   class PostsController < ApplicationController
     ...
@@ -198,7 +198,7 @@ Now the full controller code can be written out for our `#create` action:
       params.require(:post).permit(:title,:body,:author_id)
     end
   end
-~~~
+```
 
 So that action did a fair bit of stuff -- grab the form data, make a new post, try to save the post, set up a success message and redirect you to the post if it works, and handle the case where it doesn't work by berating you for your foolishness and re-rendering the form. A lot of work for only 10 lines of Ruby. Now that's smart controlling.
 
@@ -210,14 +210,14 @@ That's really just a taste of the Rails controller, but you should have a pretty
   1. Read the [Rails Guides chapter on Controllers](http://guides.rubyonrails.org/action_controller_overview.html), sections 1 - 4.5.3 and 5.2.  We'll cover sessions (section 5.1) more in the future so don't worry about them now.
 </div>
 
-### Additional Resources
+### Additional resources
 
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
 - [Controller & Routes Video Demo](https://vimeo.com/168501163)
 - [Rails 3 Rendering and Partials via YouTube](http://www.youtube.com/watch?v=m-tw2OCHPMI)
 
-### Knowledge Check
+### Knowledge check
 
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 

--- a/ruby_on_rails/rails_basics/deployment.md
+++ b/ruby_on_rails/rails_basics/deployment.md
@@ -1,5 +1,4 @@
 ### Introduction
-
 Before continuing our web development journey, we must address one important task: showcasing our hard work to the world.
 
 Whether it's to share our creations with friends, create a portfolio for future employers, or launch an online business, we need to host our applications somewhere others can publicly access on the internet.
@@ -16,14 +15,12 @@ This section contains a general overview of topics that you will learn in this l
 - How to deploy to a PaaS provider.
 - How to troubleshoot common deployment issues.
 
-### What are hosting providers?
-
+### What are gosting providers?
 Hosting providers are like server landlords. They own servers and rent space on them to customers, who can then use the space to store their websites and make them accessible to anyone on the web.
 
 You've already had some experience using a hosting provider when you deployed projects to Github Pages earlier in the curriculum. GitHub Pages is great for hosting **static** web pages for free, but we won't be able to use it for hosting our **dynamic** Ruby on Rails apps. We're going to need something more powerful.
 
 #### Static vs dynamic sites
-
 Static websites consist of pre-written HTML pages. They are "static" because everyone who visits them will see the same content. To build static sites, you only need HTML, CSS and Javascript.
 
 Dynamic websites, on the other hand, are websites that can change content based on the user who is visiting them. Twitter is a good example; every Twitter user sees different content on their homepage feed based on who they follow. To build dynamic sites, you still need HTML, CSS and JS. But additionally, you need a server-side language such as Ruby and a database.
@@ -33,7 +30,6 @@ This additional tech prohibits us from using GitHub Pages for hosting our Ruby o
 Luckily, many hosting providers do offer everything we need. They range from the big and complex cloud providers like [AWS](https://aws.amazon.com/), [Google Cloud](https://cloud.google.com/) and [Microsoft Azure](https://azure.microsoft.com/) to the more beginner-friendly platform as a service (PaaS) providers like [Heroku](https://www.heroku.com/), [Railway](https://railway.app/) and [Fly.io](https://fly.io/). We will be focusing on and utilizing these latter providers in this lesson.
 
 ### What is a PaaS?
-
 Platform as a Service is a specific kind of hosting provider. The most important thing to know about them is they are much easier to use and more approachable for beginners than other hosting providers. They manage many of the low-level nitty-gritty details with the underlying server infrastructure. Allowing us as developers to focus more of our time on building our applications instead of configuring and managing the servers they run on.
 
 Taking our landlord metaphor a little further, a PaaS platform is like having a landlord who takes care of all the utilities, building maintenance and security. While you, the developer, focus on furnishing, decorating and living in the space.
@@ -43,11 +39,9 @@ It's an incredibly powerful model and perfect for us right now. Using a PaaS pro
 We will provide a list of our recommended PaaS providers later in the lesson. First, let us explore from a high level how PaaS providers work.
 
 ### How do PaaS services work?
-
 PaaS providers work by giving you easy access to a few resources that any Rails app can't live without to function on the web.
 
 #### Instances
-
 The first and most crucial thing PaaS providers give you are virtual "computers" called instances which run your app. Basically, one instance means a single instance of your application running at one time. That's like having a single computer run your app like you do on Localhost. Multiple instances are like having several copies of your app running simultaneously, which allows you to handle more traffic.
 
 The cool thing about Rails is that you can always fire up more instances of your application if you get too much traffic and users have to wait for their requests to be filled.
@@ -55,7 +49,6 @@ The cool thing about Rails is that you can always fire up more instances of your
 For most of your apps, one instance is plenty. You can support a lot of traffic using just a single instance. Many of the PaaS providers we will recommend later in this lesson give you your first one for free.
 
 #### Databases
-
 The second most important thing PaaS providers give you is databases. They make it easy to spin up a new database for each app by doing all the setup and configuration for you.
 
 Many providers even manage the database for you by setting up automatic backups, ensuring the database is constantly updated with the latest critical security patches and ongoing maintenance that keeps your databases up and running smoothly.
@@ -65,7 +58,6 @@ The peace of mind this affords you can't be overstated. You never want to be in 
 With Rails, we will be using PostgreSQL, a popular open-source database. Some PaaS providers like Heroku will automatically create a PostgreSQL database for our application when we first deploy. Others, like Fly.io, will have a few more manual steps involved, but it still beats having to set up a database from scratch.
 
 #### Domain names
-
 PaaS providers will give you a random domain name when you first deploy. In Heroku's case, something zen-like "afternoon-falls-4209". If you want to visit the app, you can go directly to `http://afternoon-falls-4209.herokuapp.com` to see your app live on the web in all its glory.
 
 The domain name will always be yours on a PaaS provider. They give each app a unique domain name that's yours as long as your app lives on their platform.
@@ -77,7 +69,6 @@ To find a new domain, try using [Domainr](https://domainr.com/).
 Once you have your domain, you need to point it to your project. The provider you are using will have exhaustive documentation on using custom domain names on their platform.
 
 ### Our recommended PaaS services
-
 Choosing a PaaS provider was once a simple decision. Heroku had a free tier that gave you everything needed to host as many small apps as you wanted. Unfortunately, they discontinued their free tier in 2022.
 
 Luckily, there are still plenty of other great options out there. The downside is they all have very limited free tiers. For this reason, and to accommodate as many of our learners as possible, we're going to recommend a range of options instead of just one.
@@ -91,7 +82,6 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 ---
 
 ### Fly.io
-
 - Fly.io uses a simple CLI tool for deployment.
 - Pay for what you use with very reasonable rates. Each app should cost around $4 per month.
 - $20 a month should be enough to host eight apps (including three apps for free).
@@ -171,7 +161,6 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 ---
 
 ### Debugging and troubleshooting deployments
-
 Errors are an inevitable part of the software development process. They especially have a habit of popping up when deploying to a new environment like a hosting provider. When this happens, the key is not to panic and to follow a calm, step-by-step debugging process.
 
 In most cases, you'll be running into errors that thousands of developers have encountered before. These errors are well documented and often have simple solutions you can find with a little bit of Google-fu.
@@ -179,7 +168,6 @@ In most cases, you'll be running into errors that thousands of developers have e
 There are two stages of the deployment process where you are most likely to encounter problems. These are during deployment and right after.
 
 #### On deployment
-
 If you run into an error while deploying, the first thing to do is to check the build logs. Finding the build logs should be easy; it's the stream of output you'll see after kicking off a new deployment.
 
 Scroll through these logs and find the point where the deployment encountered the error. It should stand out from the rest of the output and will often look like the stack traces you've already seen with Ruby. The error output will tell you exactly what went wrong.
@@ -189,7 +177,6 @@ If you don't recognize the error or what might cause it, your next step will be 
 Most of the errors you'll face during this stage will be related to properly setting up your app with what your hosting provider needs. Double-checking the deployment guide for your hosting provider is always a good place to start. It's very easy to miss a step or mistype something.
 
 #### After deployment
-
 You've just deployed your app successfully; everything is going your way, and this will be a great day! But then you visit your app... and are greeted with the dreaded 500 page.
 
 Nothing induces panic in a developer quite like a 500 page. It could mean just about anything. Error pages in production are deliberately vague to let users know something went wrong without all the overwhelming technical jargon. Another important reason is to prevent attackers from using errors in your system to their advantage.
@@ -205,13 +192,12 @@ If the logs tell you the application crashes before it even boots and give you n
 A common cause of 500 errors in Rails after deployment is forgetting to migrate the database. If you're getting a 500 error and have new database migrations in the latest changes, run `rails db:migrate` on your production database to get it up and running again.
 
 #### Going further with troubleshooting tools
-
 As your application grows, you'll want to get more sophisticated with your error-tracking tools. For example, you can use services like [Sentry](https://sentry.io/) to track and monitor errors using a slick, easy-to-use interface and get notified when they happen.
 
 These services will give you more information about the error and the request that caused it, saving you a ton of time. But, setting up and using these services are out of the scope of this lesson. You can get by just fine with the logs and the Rails console for your first few apps.
 
-#### One final tip
 
+#### One final tip
 If something has broken in your latest deployment after successful deployments in the past, backtrack to the last working version to determine what changes you made and slowly reintroduce those changes again if you need to.
 
 This will be where the Git skills you've been learning will start to really pay off and save you an immense amount of time. You'll be able to use `git log` to see the history of your latest changes and `git checkout` to revert to a previous working version quickly.
@@ -221,23 +207,24 @@ This will be where the Git skills you've been learning will start to really pay 
 <div class="lesson-content__panel" markdown="1">
 
 1. Deploy your [Blog App project](https://www.theodinproject.com/lessons/ruby-on-rails-blog-app) to one of the hosting providers we've mentioned. If you need help deciding which one to use, we recommend Fly.io. The important thing to take away from this first deployment is getting experience deploying. Don't worry if you don't understand everything that's happening. That will come with time.
-_ Use one of the linked deploy guides for your PaaS provider to help you through the process.
-_ If you're having trouble deploying, check out the [Debugging and Troubleshooting Deployments](#debugging-and-troubleshooting-deployments) section for some tips.
+    * Use one of the linked deploy guides for your PaaS provider to help you through the process.
+    * If you're having trouble deploying, check out the [Debugging and Troubleshooting Deployments](#debugging-and-troubleshooting-deployments) section for some tips.
 </div>
+
 
 ### Knowledge check
 
 This section contains questions for you to check your understanding of this lesson on your own. If you're having trouble answering a question, click it and review the material it links to.
 
-- [What's the difference between static and dynamic websites?](#static-vs-dynamic-sites)
-- [What does 'PaaS' stand for?](#what-is-a-paas)
-- [What are the advantages of using a PaaS hosting provider?](#what-is-a-paas)
-- [What is an instance?](#instances)
-- [What steps can you take to diagnose an issue that arises during deployment?](#on-deployment)
-- [What steps can you take to diagnose an issue that only appears after deployment?](#after-deployment)
+* [What's the difference between static and dynamic websites?](#static-vs-dynamic-sites)
+* [What does 'PaaS' stand for?](#what-is-a-paas)
+* [What are the advantages of using a PaaS hosting provider?](#what-is-a-paas)
+* [What is an instance?](#instances)
+* [What steps can you take to diagnose an issue that arises during deployment?](#on-deployment)
+* [What steps can you take to diagnose an issue that only appears after deployment?](#after-deployment)
 
 ### Additional resources
 
 This section contains helpful links to related content. It isn't required, so consider it supplemental.
 
-- It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.
+* It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.

--- a/ruby_on_rails/rails_basics/deployment.md
+++ b/ruby_on_rails/rails_basics/deployment.md
@@ -1,11 +1,12 @@
 ### Introduction
+
 Before continuing our web development journey, we must address one important task: showcasing our hard work to the world.
 
 Whether it's to share our creations with friends, create a portfolio for future employers, or launch an online business, we need to host our applications somewhere others can publicly access on the internet.
 
 In this lesson, we will learn how to deploy our apps to a hosting provider, allowing us to run, build, and operate our web applications in the cloud.
 
-### Lesson Overview
+### Lesson overview
 
 This section contains a general overview of topics that you will learn in this lesson.
 
@@ -15,12 +16,14 @@ This section contains a general overview of topics that you will learn in this l
 - How to deploy to a PaaS provider.
 - How to troubleshoot common deployment issues.
 
-### What are Hosting Providers?
+### What are hosting providers?
+
 Hosting providers are like server landlords. They own servers and rent space on them to customers, who can then use the space to store their websites and make them accessible to anyone on the web.
 
 You've already had some experience using a hosting provider when you deployed projects to Github Pages earlier in the curriculum. GitHub Pages is great for hosting **static** web pages for free, but we won't be able to use it for hosting our **dynamic** Ruby on Rails apps. We're going to need something more powerful.
 
-#### Static vs Dynamic Sites
+#### Static vs dynamic sites
+
 Static websites consist of pre-written HTML pages. They are "static" because everyone who visits them will see the same content. To build static sites, you only need HTML, CSS and Javascript.
 
 Dynamic websites, on the other hand, are websites that can change content based on the user who is visiting them. Twitter is a good example; every Twitter user sees different content on their homepage feed based on who they follow. To build dynamic sites, you still need HTML, CSS and JS. But additionally, you need a server-side language such as Ruby and a database.
@@ -30,6 +33,7 @@ This additional tech prohibits us from using GitHub Pages for hosting our Ruby o
 Luckily, many hosting providers do offer everything we need. They range from the big and complex cloud providers like [AWS](https://aws.amazon.com/), [Google Cloud](https://cloud.google.com/) and [Microsoft Azure](https://azure.microsoft.com/) to the more beginner-friendly platform as a service (PaaS) providers like [Heroku](https://www.heroku.com/), [Railway](https://railway.app/) and [Fly.io](https://fly.io/). We will be focusing on and utilizing these latter providers in this lesson.
 
 ### What is a PaaS?
+
 Platform as a Service is a specific kind of hosting provider. The most important thing to know about them is they are much easier to use and more approachable for beginners than other hosting providers. They manage many of the low-level nitty-gritty details with the underlying server infrastructure. Allowing us as developers to focus more of our time on building our applications instead of configuring and managing the servers they run on.
 
 Taking our landlord metaphor a little further, a PaaS platform is like having a landlord who takes care of all the utilities, building maintenance and security. While you, the developer, focus on furnishing, decorating and living in the space.
@@ -39,9 +43,11 @@ It's an incredibly powerful model and perfect for us right now. Using a PaaS pro
 We will provide a list of our recommended PaaS providers later in the lesson. First, let us explore from a high level how PaaS providers work.
 
 ### How do PaaS services work?
+
 PaaS providers work by giving you easy access to a few resources that any Rails app can't live without to function on the web.
 
 #### Instances
+
 The first and most crucial thing PaaS providers give you are virtual "computers" called instances which run your app. Basically, one instance means a single instance of your application running at one time. That's like having a single computer run your app like you do on Localhost. Multiple instances are like having several copies of your app running simultaneously, which allows you to handle more traffic.
 
 The cool thing about Rails is that you can always fire up more instances of your application if you get too much traffic and users have to wait for their requests to be filled.
@@ -49,6 +55,7 @@ The cool thing about Rails is that you can always fire up more instances of your
 For most of your apps, one instance is plenty. You can support a lot of traffic using just a single instance. Many of the PaaS providers we will recommend later in this lesson give you your first one for free.
 
 #### Databases
+
 The second most important thing PaaS providers give you is databases. They make it easy to spin up a new database for each app by doing all the setup and configuration for you.
 
 Many providers even manage the database for you by setting up automatic backups, ensuring the database is constantly updated with the latest critical security patches and ongoing maintenance that keeps your databases up and running smoothly.
@@ -57,7 +64,8 @@ The peace of mind this affords you can't be overstated. You never want to be in 
 
 With Rails, we will be using PostgreSQL, a popular open-source database. Some PaaS providers like Heroku will automatically create a PostgreSQL database for our application when we first deploy. Others, like Fly.io, will have a few more manual steps involved, but it still beats having to set up a database from scratch.
 
-#### Domain Names
+#### Domain names
+
 PaaS providers will give you a random domain name when you first deploy. In Heroku's case, something zen-like "afternoon-falls-4209". If you want to visit the app, you can go directly to `http://afternoon-falls-4209.herokuapp.com` to see your app live on the web in all its glory.
 
 The domain name will always be yours on a PaaS provider. They give each app a unique domain name that's yours as long as your app lives on their platform.
@@ -68,7 +76,8 @@ To find a new domain, try using [Domainr](https://domainr.com/).
 
 Once you have your domain, you need to point it to your project. The provider you are using will have exhaustive documentation on using custom domain names on their platform.
 
-### Our Recommended PaaS Services
+### Our recommended PaaS services
+
 Choosing a PaaS provider was once a simple decision. Heroku had a free tier that gave you everything needed to host as many small apps as you wanted. Unfortunately, they discontinued their free tier in 2022.
 
 Luckily, there are still plenty of other great options out there. The downside is they all have very limited free tiers. For this reason, and to accommodate as many of our learners as possible, we're going to recommend a range of options instead of just one.
@@ -82,6 +91,7 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 ---
 
 ### Fly.io
+
 - Fly.io uses a simple CLI tool for deployment.
 - Pay for what you use with very reasonable rates. Each app should cost around $4 per month.
 - $20 a month should be enough to host eight apps (including three apps for free).
@@ -160,14 +170,16 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 
 ---
 
-### Debugging and Troubleshooting Deployments
+### Debugging and troubleshooting deployments
+
 Errors are an inevitable part of the software development process. They especially have a habit of popping up when deploying to a new environment like a hosting provider. When this happens, the key is not to panic and to follow a calm, step-by-step debugging process.
 
 In most cases, you'll be running into errors that thousands of developers have encountered before. These errors are well documented and often have simple solutions you can find with a little bit of Google-fu.
 
 There are two stages of the deployment process where you are most likely to encounter problems. These are during deployment and right after.
 
-#### On Deployment
+#### On deployment
+
 If you run into an error while deploying, the first thing to do is to check the build logs. Finding the build logs should be easy; it's the stream of output you'll see after kicking off a new deployment.
 
 Scroll through these logs and find the point where the deployment encountered the error. It should stand out from the rest of the output and will often look like the stack traces you've already seen with Ruby. The error output will tell you exactly what went wrong.
@@ -176,7 +188,8 @@ If you don't recognize the error or what might cause it, your next step will be 
 
 Most of the errors you'll face during this stage will be related to properly setting up your app with what your hosting provider needs. Double-checking the deployment guide for your hosting provider is always a good place to start. It's very easy to miss a step or mistype something.
 
-#### After Deployment
+#### After deployment
+
 You've just deployed your app successfully; everything is going your way, and this will be a great day! But then you visit your app... and are greeted with the dreaded 500 page.
 
 Nothing induces panic in a developer quite like a 500 page. It could mean just about anything. Error pages in production are deliberately vague to let users know something went wrong without all the overwhelming technical jargon. Another important reason is to prevent attackers from using errors in your system to their advantage.
@@ -191,13 +204,14 @@ If the logs tell you the application crashes before it even boots and give you n
 
 A common cause of 500 errors in Rails after deployment is forgetting to migrate the database. If you're getting a 500 error and have new database migrations in the latest changes, run `rails db:migrate` on your production database to get it up and running again.
 
-#### Going Further with Troubleshooting Tools
+#### Going further with troubleshooting tools
+
 As your application grows, you'll want to get more sophisticated with your error-tracking tools. For example, you can use services like [Sentry](https://sentry.io/) to track and monitor errors using a slick, easy-to-use interface and get notified when they happen.
 
 These services will give you more information about the error and the request that caused it, saving you a ton of time. But, setting up and using these services are out of the scope of this lesson. You can get by just fine with the logs and the Rails console for your first few apps.
 
+#### One final tip
 
-#### One Final Tip
 If something has broken in your latest deployment after successful deployments in the past, backtrack to the last working version to determine what changes you made and slowly reintroduce those changes again if you need to.
 
 This will be where the Git skills you've been learning will start to really pay off and save you an immense amount of time. You'll be able to use `git log` to see the history of your latest changes and `git checkout` to revert to a previous working version quickly.
@@ -207,24 +221,23 @@ This will be where the Git skills you've been learning will start to really pay 
 <div class="lesson-content__panel" markdown="1">
 
 1. Deploy your [Blog App project](https://www.theodinproject.com/lessons/ruby-on-rails-blog-app) to one of the hosting providers we've mentioned. If you need help deciding which one to use, we recommend Fly.io. The important thing to take away from this first deployment is getting experience deploying. Don't worry if you don't understand everything that's happening. That will come with time.
-    * Use one of the linked deploy guides for your PaaS provider to help you through the process.
-    * If you're having trouble deploying, check out the [Debugging and Troubleshooting Deployments](#debugging-and-troubleshooting-deployments) section for some tips.
+_ Use one of the linked deploy guides for your PaaS provider to help you through the process.
+_ If you're having trouble deploying, check out the [Debugging and Troubleshooting Deployments](#debugging-and-troubleshooting-deployments) section for some tips.
 </div>
 
-
-### Knowledge Check
+### Knowledge check
 
 This section contains questions for you to check your understanding of this lesson on your own. If you're having trouble answering a question, click it and review the material it links to.
 
-* [What's the difference between static and dynamic websites?](#static-vs-dynamic-sites)
-* [What does 'PaaS' stand for?](#what-is-a-paas)
-* [What are the advantages of using a PaaS hosting provider?](#what-is-a-paas)
-* [What is an instance?](#instances)
-* [What steps can you take to diagnose an issue that arises during deployment?](#on-deployment)
-* [What steps can you take to diagnose an issue that only appears after deployment?](#after-deployment)
+- [What's the difference between static and dynamic websites?](#static-vs-dynamic-sites)
+- [What does 'PaaS' stand for?](#what-is-a-paas)
+- [What are the advantages of using a PaaS hosting provider?](#what-is-a-paas)
+- [What is an instance?](#instances)
+- [What steps can you take to diagnose an issue that arises during deployment?](#on-deployment)
+- [What steps can you take to diagnose an issue that only appears after deployment?](#after-deployment)
 
-### Additional Resources
+### Additional resources
 
 This section contains helpful links to related content. It isn't required, so consider it supplemental.
 
-* It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.
+- It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.

--- a/ruby_on_rails/rails_basics/project_blog_app.md
+++ b/ruby_on_rails/rails_basics/project_blog_app.md
@@ -1,25 +1,24 @@
 ### Introduction
 
-In this project, you'll get the opportunity to actually build a real Rails application. It's not a trivially simple one either -- it's got a lot of wrinkles and things that you're not going to understand.
+In this project, you'll get the opportunity to actually build a real Rails application.  It's not a trivially simple one either -- it's got a lot of wrinkles and things that you're not going to understand.
 
-To be honest, you're kind of going into the deep end so don't worry if you don't understand what exactly you're doing in all the steps. The point here is to get familiar with the process of creating a Rails app, what things generally look like, and what you don't know. When you get to the end of this project, you can consider yourself remarkably persistent and resilient.
+To be honest, you're kind of going into the deep end so don't worry if you don't understand what exactly you're doing in all the steps.  The point here is to get familiar with the process of creating a Rails app, what things generally look like, and what you don't know.  When you get to the end of this project, you can consider yourself remarkably persistent and resilient.
 
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">
 
-1. Do the [The Ruby on Rails Guides: Getting Started](https://guides.rubyonrails.org/getting_started.html) project up to section 9.2. It ties together the Model-View-Controller and gives a pretty good overview of the common commands you'll use when using Rails. The remainder of the tutorial covers topics that have not been introduced, like concerns and authentication, so it is hard to understand the big picture. In addition, these sections can be confusing because the instructions do not follow the same copy/paste pattern.
-2. You should have Rails installed already so section 3.1 might not be relevant. It might still be prudent to run the `--version` commands to check you have everything you need though.
-3. Make sure you commit to Git regularly so if you run into any issues you can revert to an earlier commit without having to start over from scratch. As a rough guide look to commit at the end of each section.
-4. Pay attention to any error messages you get as you build the app, even though they'll be unplanned. You'll see all these messages again and again when you're building Rails apps, so it's helpful to start getting familiar with which portions of the message you should pay attention to (and maybe put into Google if you can't figure out what caused it).
-5. Try to make a mental note of the commands and generators you can use. Rails provides a lot of very helpful generators taking a lot of the pain out of creating different parts of a web application.
-6. When you're finished, push your code up to [GitHub](https://github.com/).
+  1. Do the [The Ruby on Rails Guides: Getting Started](https://guides.rubyonrails.org/getting_started.html) project up to section 9.2. It ties together the Model-View-Controller and gives a pretty good overview of the common commands you'll use when using Rails. The remainder of the tutorial covers topics that have not been introduced, like concerns and authentication, so it is hard to understand the big picture. In addition, these sections can be confusing because the instructions do not follow the same copy/paste pattern.
+  2. You should have Rails installed already so section 3.1 might not be relevant. It might still be prudent to run the `--version` commands to check you have everything you need though.
+  3. Make sure you commit to Git regularly so if you run into any issues you can revert to an earlier commit without having to start over from scratch. As a rough guide look to commit at the end of each section.
+  4. Pay attention to any error messages you get as you build the app, even though they'll be unplanned.  You'll see all these messages again and again when you're building Rails apps, so it's helpful to start getting familiar with which portions of the message you should pay attention to (and maybe put into Google if you can't figure out what caused it).
+  5. Try to make a mental note of the commands and generators you can use. Rails provides a lot of very helpful generators taking a lot of the pain out of creating different parts of a web application.
+  6. When you're finished, push your code up to [GitHub](https://github.com/).
 </div>
 
 ### Additional resources
-
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
-- The [official Ruby on Rails guides](http://guides.rubyonrails.org/) are an excellent resource if you want to build on your knowledge.
-- You can read the [Introduction to Core Ruby Tools](https://launchschool.com/books/core_ruby_tools/read/introduction) from LaunchSchool to get a better understanding of Ruby and Rails concepts such as gems, version managers, bundler, and rake.
-- The first 30-minutes of this [video](https://youtu.be/rssgWqJq-14) will teach you how to see through of the magical syntax of Ruby on Rails and how to use pry to debug.
+* The [official Ruby on Rails guides](http://guides.rubyonrails.org/) are an excellent resource if you want to build on your knowledge.
+* You can read the [Introduction to Core Ruby Tools](https://launchschool.com/books/core_ruby_tools/read/introduction) from LaunchSchool to get a better understanding of Ruby and Rails concepts such as gems, version managers, bundler, and rake.
+* The first 30-minutes of this [video](https://youtu.be/rssgWqJq-14) will teach you how to see through of the magical syntax of Ruby on Rails and how to use pry to debug.

--- a/ruby_on_rails/rails_basics/project_blog_app.md
+++ b/ruby_on_rails/rails_basics/project_blog_app.md
@@ -1,24 +1,25 @@
 ### Introduction
 
-In this project, you'll get the opportunity to actually build a real Rails application.  It's not a trivially simple one either -- it's got a lot of wrinkles and things that you're not going to understand.
+In this project, you'll get the opportunity to actually build a real Rails application. It's not a trivially simple one either -- it's got a lot of wrinkles and things that you're not going to understand.
 
-To be honest, you're kind of going into the deep end so don't worry if you don't understand what exactly you're doing in all the steps.  The point here is to get familiar with the process of creating a Rails app, what things generally look like, and what you don't know.  When you get to the end of this project, you can consider yourself remarkably persistent and resilient.
+To be honest, you're kind of going into the deep end so don't worry if you don't understand what exactly you're doing in all the steps. The point here is to get familiar with the process of creating a Rails app, what things generally look like, and what you don't know. When you get to the end of this project, you can consider yourself remarkably persistent and resilient.
 
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">
 
-  1. Do the [The Ruby on Rails Guides: Getting Started](https://guides.rubyonrails.org/getting_started.html) project up to section 9.2. It ties together the Model-View-Controller and gives a pretty good overview of the common commands you'll use when using Rails. The remainder of the tutorial covers topics that have not been introduced, like concerns and authentication, so it is hard to understand the big picture. In addition, these sections can be confusing because the instructions do not follow the same copy/paste pattern.
-  2. You should have Rails installed already so section 3.1 might not be relevant. It might still be prudent to run the `--version` commands to check you have everything you need though.
-  3. Make sure you commit to Git regularly so if you run into any issues you can revert to an earlier commit without having to start over from scratch. As a rough guide look to commit at the end of each section.
-  4. Pay attention to any error messages you get as you build the app, even though they'll be unplanned.  You'll see all these messages again and again when you're building Rails apps, so it's helpful to start getting familiar with which portions of the message you should pay attention to (and maybe put into Google if you can't figure out what caused it).
-  5. Try to make a mental note of the commands and generators you can use. Rails provides a lot of very helpful generators taking a lot of the pain out of creating different parts of a web application.
-  6. When you're finished, push your code up to [GitHub](https://github.com/).
+1. Do the [The Ruby on Rails Guides: Getting Started](https://guides.rubyonrails.org/getting_started.html) project up to section 9.2. It ties together the Model-View-Controller and gives a pretty good overview of the common commands you'll use when using Rails. The remainder of the tutorial covers topics that have not been introduced, like concerns and authentication, so it is hard to understand the big picture. In addition, these sections can be confusing because the instructions do not follow the same copy/paste pattern.
+2. You should have Rails installed already so section 3.1 might not be relevant. It might still be prudent to run the `--version` commands to check you have everything you need though.
+3. Make sure you commit to Git regularly so if you run into any issues you can revert to an earlier commit without having to start over from scratch. As a rough guide look to commit at the end of each section.
+4. Pay attention to any error messages you get as you build the app, even though they'll be unplanned. You'll see all these messages again and again when you're building Rails apps, so it's helpful to start getting familiar with which portions of the message you should pay attention to (and maybe put into Google if you can't figure out what caused it).
+5. Try to make a mental note of the commands and generators you can use. Rails provides a lot of very helpful generators taking a lot of the pain out of creating different parts of a web application.
+6. When you're finished, push your code up to [GitHub](https://github.com/).
 </div>
 
-### Additional Resources
+### Additional resources
+
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
-* The [official Ruby on Rails guides](http://guides.rubyonrails.org/) are an excellent resource if you want to build on your knowledge.
-* You can read the [Introduction to Core Ruby Tools](https://launchschool.com/books/core_ruby_tools/read/introduction) from LaunchSchool to get a better understanding of Ruby and Rails concepts such as gems, version managers, bundler, and rake.
-* The first 30-minutes of this [video](https://youtu.be/rssgWqJq-14) will teach you how to see through of the magical syntax of Ruby on Rails and how to use pry to debug.
+- The [official Ruby on Rails guides](http://guides.rubyonrails.org/) are an excellent resource if you want to build on your knowledge.
+- You can read the [Introduction to Core Ruby Tools](https://launchschool.com/books/core_ruby_tools/read/introduction) from LaunchSchool to get a better understanding of Ruby and Rails concepts such as gems, version managers, bundler, and rake.
+- The first 30-minutes of this [video](https://youtu.be/rssgWqJq-14) will teach you how to see through of the magical syntax of Ruby on Rails and how to use pry to debug.

--- a/ruby_on_rails/rails_basics/routing.md
+++ b/ruby_on_rails/rails_basics/routing.md
@@ -1,209 +1,24 @@
 ### Introduction
 
-The router is the doorman of your application. When an HTTP request arrives from the user's browser, it needs to know which controller action (method) should be run. Should we display the "new user" webpage? Should we edit an existing user with whatever data got sent along?
+In this project, you'll get the opportunity to actually build a real Rails application.  It's not a trivially simple one either -- it's got a lot of wrinkles and things that you're not going to understand.
 
-The Router is basically just a matching service. It looks at the HTTP verb (GET, POST, PUT, DELETE) and the URL that is being requested and matches it with the appropriate controller action to run. It's a pretty simple function but an essential one. If it can't find a route that matches the request, your application will throw an error.
-
-The other handy thing that goes on when a request enters your application is that Rails grabs all the parameters that came with it and makes them available for you in a special hash called `params` that you can later use in your controller. That's good for things like form submissions so that you later can use that form data to create or modify objects.
-
-If you open the routes file in your Rails app (located in `config/routes.rb`), you'll see a link to the Rails Guides routing section. This resource does a good job of explaining how it works, so you're never in much danger of losing your way.
-
-Lots of training courses and tutorials kind of gloss over routes, and they seem quite easy in hindsight, but when learning Rails it's easy to get hung up on what exactly is going on. Luckily, typing `$ rails routes` into the command line will give you an output of all the routes that are available to your application. In this section we'll go into what's actually happening with this file.
-
-### Lesson overview
-
-This section contains a general overview of topics that you will learn in this lesson.
-
-- Configuring a root route.
-- Configuring RESTful routes for a resource.
-- Configuring customized routes for a resource.
-- The 7 RESTful controller actions.
-- How to obtain a list of all possible routes for your current Rails application.
-- Helper methods to create a navigation link on your webpage.
-
-### Root
-
-The most important (and simplest) route in your file is the root URL... where should users be deposited when they land on `http://supercutekittenphotos.com`? Just tell Rails which controller and action to map that route to, and it is so:
-
-```ruby
-  root to: "kittens#index"  #kittens controller, index action (method)
-```
-
-Remember, when we say "action" we really mean "the method inside the controller that is called that", e.g. the `index` action is just the `index` method that's defined in the KittensController\*
-
-### RESTful routes
-
-If you recall our earlier discussion about REST, there are basically seven main types of actions that you can (and should) do to a "resource", or an object like a blog post or user... something with its own database model. From that discussion, they are:
-
-1. GET all the posts (aka **"index"** the posts)
-2. GET just one specific post (aka **"show"** that post)
-3. GET the page that lets you create a new post (aka view the **"new"** post page)
-4. POST the data you just filled out for a new post back to the server so it can create that post (aka **"create"** the post)
-5. GET the page that lets you edit an existing post (aka view the **"edit"** post page)
-6. PUT the data you just filled out to edit the post back to the server so it can actually perform the update (aka **"update"** the post)
-7. DELETE one specific post by sending a delete request to the server (aka **"destroy"** the post)
-
-The highlighted words correspond to standard Rails controller actions!
-
-Each of these represents a "RESTful" route, and so it makes sense that you'll need a way to write these in your Router file so the requests they represent are actually routed to the proper action of your controller (in this case, the "Posts" controller). One way to write them out would be the long way:
-
-```ruby
-  get "/posts", to: "posts#index"
-  get "/posts/new", to: "posts#new"
-  get "/posts/:id", to: "posts#show"
-  post "/posts", to: "posts#create"  # usually a submitted form
-  get "/posts/:id/edit", to: "posts#edit"
-  put "/posts/:id", to: "posts#update" # usually a submitted form
-  delete "/posts/:id", to: "posts#destroy"
-```
-
-Each of these routes is basically a Ruby method that matches that particular URL and HTTP verb with the correct controller action. Two things to notice:
-
-1. The first key thing to notice is that several of those routes submit to the SAME URL... they just use different HTTP verbs, so Rails can send them to a different controller action. That trips up a lot of beginners.
-2. The other thing to notice is that the "id" field is prepended by a colon... that just tells Rails "Look for anything here and save it as the ID in the params hash". It lets you submit a GET request for the first post and the fifth post to the same route, just a different ID:
-
-```ruby
-  /posts/1  # going to the #show action of the PostsController
-  /posts/5  # also going to the #show action of PostsController
-```
-
-You will be able to access that ID directly from the controller by tapping into the params hash where it got stored.
-
-### The Rails way to write RESTful routes
-
-Rails knows you want to use those seven actions all the time... so they came up with a handy helper method which lets you do in one line what we just wrote in seven lines in our resources file:
-
-```ruby
-  # in config/routes.rb
-  ...
-  resources :posts
-  ...
-```
-
-That's it. That is a Ruby method which basically just outputs those seven routes we talked about before. No magic. You see it a whole lot, now you know what it does.
-
-### Rails routes and route helpers
-
-With that above line in our routes file, what do our routes look like? If you type `$ rails routes` on the command line, it'll output all the routes your application knows, which look like:
-
-```bash
-  edit_post  GET  /posts/:id/edit(.:format)  posts#edit
-```
-
-You can see the incoming HTTP verb and URL in the middle columns, then the controller action they map to on the right, which should all be quite familiar because you just wrote it in the routes file. The `(.:format)` just means that it's okay but not required to specify a file extension like `.doc` at the end of the route... it will just get saved in the `params` hash for later anyway. But what's on the leftmost column? That's the "name" of the route.
-
-There are a lot of situations where you want to be able to retrieve the URL for a particular route, like when you want to show navigation links on your webpage (do NOT hard code the URLS, because you'll be out of luck when you decide to change the URLs and have to manually go in and change them yourself). Rails gives you a helper method that lets you create links called `link_to`, but you'll need to supply it with the text that you want to show and the URL to link it to.
-
-```ruby
-  link_to "Edit this post", edit_post_path(3) # don't hardcode 3!
-```
-
-We're jumping a little bit ahead, but in this case, the second argument is supposed to be a path or a URL, so we use the path helper method to generate that. `edit_post_path(3)` will generate the path `/posts/3/edit`.
-
-Rails automatically generates helper methods for you which correspond to the names of all your routes. These methods end with `_path` and `_url`. `path`, as in `edit_post_path(3)`, will generate just the path portion of the URL, which is sufficient for most applications. `url` will generate the full URL.
-
-Any routes which require you to specify an ID or other parameters will need you to supply those to the helper methods as well (like we did above for edit). You can also put in a query string by adding an additional parameter:
-
-```ruby
-  post_path(3, :referral_link => "/some/path/or/something")
-```
-
-Now the `:referral_link` parameter would be available in your `params` hash in your controller in addition to the normal set of parameters.
-
-### Routes go to controller actions!
-
-Just to drive home that routes correspond directly to controller actions, a very simple sample controller which would fulfill the above routes generated by `resources :posts` might look like:
-
-```ruby
-  # in app/controllers/posts_controller.rb
-  class PostsController < ApplicationController
-
-    def index
-      # very simple code to grab all posts so they can be
-      # displayed in the Index view (index.html.erb)
-    end
-
-    def show
-      # very simple code to grab the proper Post so it can be
-      # displayed in the Show view (show.html.erb)
-    end
-
-    def new
-      # very simple code to create an empty post and send the user
-      # to the New view for it (new.html.erb), which will have a
-      # form for creating the post
-    end
-
-    def create
-      # code to create a new post based on the parameters that
-      # were submitted with the form (and are now available in the
-      # params hash)
-    end
-
-    def edit
-      # very simple code to find the post we want and send the
-      # user to the Edit view for it (edit.html.erb), which has a
-      # form for editing the post
-    end
-
-    def update
-      # code to figure out which post we're trying to update, then
-      # actually update the attributes of that post. Once that's
-      # done, redirect us to somewhere like the Show page for that
-      # post
-    end
-
-    def destroy
-      # very simple code to find the post we're referring to and
-      # destroy it.  Once that's done, redirect us to somewhere fun.
-    end
-  end
-```
-
-Remember that you can run `$ rails routes` in the project directory to see all of the routes with their corresponding controllers and actions.
-
-### We don't want all seven routes!
-
-Sometimes you just don't want all seven of the RESTful routes that `resources` provides. Easy, either specify just the ones you want using `only` or just the ones you DON'T want using `except`:
-
-```ruby
-  resources :posts, only: [:index, :show]
-  resources :users, except: [:index]
-```
-
-### Non-RESTful routes
-
-Of course, you don't have to do everything the RESTful way. You probably should, but there are times that you want to make up your own route and map it to your own controller action. Just follow the examples we gave at the top for RESTful routes:
-
-```ruby
-  get '/somepath', to: 'somecontroller#someaction'
-```
-
-... of course, the `config/routes.rb` comments should be helpful to you here as well.
+To be honest, you're kind of going into the deep end so don't worry if you don't understand what exactly you're doing in all the steps.  The point here is to get familiar with the process of creating a Rails app, what things generally look like, and what you don't know.  When you get to the end of this project, you can consider yourself remarkably persistent and resilient.
 
 ### Assignment
 
-You should have a good sense of what's going on in the routes file by now but probably also have plenty of questions. The Rails Guides to the rescue!
-
 <div class="lesson-content__panel" markdown="1">
-1. Read the [Rails Guides chapter on Routing](http://guides.rubyonrails.org/routing.html), sections 1-2.5, 3.1-3.4, 4.6, and 6.1
-2. Watch this [Wonderful explanation of how REST and HTTP works](https://www.youtube.com/watch?v=Q-BpqyOT3a8). You can follow the tutorial using `curl https://api.github.com`.
+
+  1. Do the [The Ruby on Rails Guides: Getting Started](https://guides.rubyonrails.org/getting_started.html) project up to section 9.2. It ties together the Model-View-Controller and gives a pretty good overview of the common commands you'll use when using Rails. The remainder of the tutorial covers topics that have not been introduced, like concerns and authentication, so it is hard to understand the big picture. In addition, these sections can be confusing because the instructions do not follow the same copy/paste pattern.
+  2. You should have Rails installed already so section 3.1 might not be relevant. It might still be prudent to run the `--version` commands to check you have everything you need though.
+  3. Make sure you commit to Git regularly so if you run into any issues you can revert to an earlier commit without having to start over from scratch. As a rough guide look to commit at the end of each section.
+  4. Pay attention to any error messages you get as you build the app, even though they'll be unplanned.  You'll see all these messages again and again when you're building Rails apps, so it's helpful to start getting familiar with which portions of the message you should pay attention to (and maybe put into Google if you can't figure out what caused it).
+  5. Try to make a mental note of the commands and generators you can use. Rails provides a lot of very helpful generators taking a lot of the pain out of creating different parts of a web application.
+  6. When you're finished, push your code up to [GitHub](https://github.com/).
 </div>
 
 ### Additional resources
-
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
-- [CodeSchool's Surviving APIs with Rails](https://www.youtube.com/watch?v=99nZVo9amAQ) - Level 1 is free and gets into REST, Routes, Constraints, and Namespaces.
-- [Medium article](https://medium.com/podiihq/understanding-rails-routes-and-restful-design-a192d64cbbb5) on Rails routing. It covers a lot of the same things that the Rails Guides cover but with a little different tone that some people may find easier to digest.
-
-### Knowledge check
-
-This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
-
-- <a class="knowledge-check-link" href="https://guides.rubyonrails.org/routing.html#the-purpose-of-the-rails-router">What is the purpose of the Rails router?</a>
-- <a class="knowledge-check-link" href="#root">How do you assign the root route of your application in the router?</a>
-- <a class="knowledge-check-link" href="https://guides.rubyonrails.org/routing.html#crud-verbs-and-actions">Assuming we have no knowledge of the HTTP-verb, which 3 RESTful controller actions could be triggered by the `/photos/:id` -route?</a>
-- <a class="knowledge-check-link" href="https://guides.rubyonrails.org/routing.html#restricting-the-routes-created">How can you assign all of the RESTful routes for a resource - excluding the destroy-route - in just one line?</a>
-- <a class="knowledge-check-link" href="https://guides.rubyonrails.org/routing.html#path-and-url-helpers">How would you create a link in your app (without hardcoding), that directs you to `/photos/10/edit`?</a>
-- <a class="knowledge-check-link" href="https://youtu.be/Q-BpqyOT3a8?t=886">Which Chrome extension can you use to simulate HTTP-requests with an API?</a>
+* The [official Ruby on Rails guides](http://guides.rubyonrails.org/) are an excellent resource if you want to build on your knowledge.
+* You can read the [Introduction to Core Ruby Tools](https://launchschool.com/books/core_ruby_tools/read/introduction) from LaunchSchool to get a better understanding of Ruby and Rails concepts such as gems, version managers, bundler, and rake.
+* The first 30-minutes of this [video](https://youtu.be/rssgWqJq-14) will teach you how to see through of the magical syntax of Ruby on Rails and how to use pry to debug.

--- a/ruby_on_rails/rails_basics/routing.md
+++ b/ruby_on_rails/rails_basics/routing.md
@@ -1,16 +1,16 @@
 ### Introduction
 
-The router is the doorman of your application.  When an HTTP request arrives from the user's browser, it needs to know which controller action (method) should be run.  Should we display the "new user" webpage?  Should we edit an existing user with whatever data got sent along?
+The router is the doorman of your application. When an HTTP request arrives from the user's browser, it needs to know which controller action (method) should be run. Should we display the "new user" webpage? Should we edit an existing user with whatever data got sent along?
 
-The Router is basically just a matching service.  It looks at the HTTP verb (GET, POST, PUT, DELETE) and the URL that is being requested and matches it with the appropriate controller action to run.  It's a pretty simple function but an essential one.  If it can't find a route that matches the request, your application will throw an error.
+The Router is basically just a matching service. It looks at the HTTP verb (GET, POST, PUT, DELETE) and the URL that is being requested and matches it with the appropriate controller action to run. It's a pretty simple function but an essential one. If it can't find a route that matches the request, your application will throw an error.
 
-The other handy thing that goes on when a request enters your application is that Rails grabs all the parameters that came with it and makes them available for you in a special hash called `params` that you can later use in your controller.  That's good for things like form submissions so that you later can use that form data to create or modify objects.
+The other handy thing that goes on when a request enters your application is that Rails grabs all the parameters that came with it and makes them available for you in a special hash called `params` that you can later use in your controller. That's good for things like form submissions so that you later can use that form data to create or modify objects.
 
 If you open the routes file in your Rails app (located in `config/routes.rb`), you'll see a link to the Rails Guides routing section. This resource does a good job of explaining how it works, so you're never in much danger of losing your way.
 
-Lots of training courses and tutorials kind of gloss over routes, and they seem quite easy in hindsight, but when learning Rails it's easy to get hung up on what exactly is going on. Luckily, typing `$ rails routes` into the command line will give you an output of all the routes that are available to your application.  In this section we'll go into what's actually happening with this file.
+Lots of training courses and tutorials kind of gloss over routes, and they seem quite easy in hindsight, but when learning Rails it's easy to get hung up on what exactly is going on. Luckily, typing `$ rails routes` into the command line will give you an output of all the routes that are available to your application. In this section we'll go into what's actually happening with this file.
 
-### Lesson Overview
+### Lesson overview
 
 This section contains a general overview of topics that you will learn in this lesson.
 
@@ -23,17 +23,17 @@ This section contains a general overview of topics that you will learn in this l
 
 ### Root
 
-The most important (and simplest) route in your file is the root URL... where should users be deposited when they land on `http://supercutekittenphotos.com`?  Just tell Rails which controller and action to map that route to, and it is so:
+The most important (and simplest) route in your file is the root URL... where should users be deposited when they land on `http://supercutekittenphotos.com`? Just tell Rails which controller and action to map that route to, and it is so:
 
-~~~ruby
+```ruby
   root to: "kittens#index"  #kittens controller, index action (method)
-~~~
+```
 
-Remember, when we say "action" we really mean "the method inside the controller that is called that", e.g. the `index` action is just the `index` method that's defined in the KittensController*
+Remember, when we say "action" we really mean "the method inside the controller that is called that", e.g. the `index` action is just the `index` method that's defined in the KittensController\*
 
-### RESTful Routes
+### RESTful routes
 
-If you recall our earlier discussion about REST, there are basically seven main types of actions that you can (and should) do to a "resource", or an object like a blog post or user... something with its own database model.  From that discussion, they are:
+If you recall our earlier discussion about REST, there are basically seven main types of actions that you can (and should) do to a "resource", or an object like a blog post or user... something with its own database model. From that discussion, they are:
 
 1. GET all the posts (aka **"index"** the posts)
 2. GET just one specific post (aka **"show"** that post)
@@ -45,9 +45,9 @@ If you recall our earlier discussion about REST, there are basically seven main 
 
 The highlighted words correspond to standard Rails controller actions!
 
-Each of these represents a "RESTful" route, and so it makes sense that you'll need a way to write these in your Router file so the requests they represent are actually routed to the proper action of your controller (in this case, the "Posts" controller).  One way to write them out would be the long way:
+Each of these represents a "RESTful" route, and so it makes sense that you'll need a way to write these in your Router file so the requests they represent are actually routed to the proper action of your controller (in this case, the "Posts" controller). One way to write them out would be the long way:
 
-~~~ruby
+```ruby
   get "/posts", to: "posts#index"
   get "/posts/new", to: "posts#new"
   get "/posts/:id", to: "posts#show"
@@ -55,66 +55,66 @@ Each of these represents a "RESTful" route, and so it makes sense that you'll ne
   get "/posts/:id/edit", to: "posts#edit"
   put "/posts/:id", to: "posts#update" # usually a submitted form
   delete "/posts/:id", to: "posts#destroy"
-~~~
+```
 
-Each of these routes is basically a Ruby method that matches that particular URL and HTTP verb with the correct controller action.  Two things to notice:
+Each of these routes is basically a Ruby method that matches that particular URL and HTTP verb with the correct controller action. Two things to notice:
 
-1. The first key thing to notice is that several of those routes submit to the SAME URL... they just use different HTTP verbs, so Rails can send them to a different controller action.  That trips up a lot of beginners.  
-2. The other thing to notice is that the "id" field is prepended by a colon... that just tells Rails "Look for anything here and save it as the ID in the params hash".  It lets you submit a GET request for the first post and the fifth post to the same route, just a different ID:
+1. The first key thing to notice is that several of those routes submit to the SAME URL... they just use different HTTP verbs, so Rails can send them to a different controller action. That trips up a lot of beginners.
+2. The other thing to notice is that the "id" field is prepended by a colon... that just tells Rails "Look for anything here and save it as the ID in the params hash". It lets you submit a GET request for the first post and the fifth post to the same route, just a different ID:
 
-~~~ruby
+```ruby
   /posts/1  # going to the #show action of the PostsController
   /posts/5  # also going to the #show action of PostsController
-~~~
+```
 
 You will be able to access that ID directly from the controller by tapping into the params hash where it got stored.
 
-### The Rails Way to Write RESTful Routes
+### The Rails way to write RESTful routes
 
 Rails knows you want to use those seven actions all the time... so they came up with a handy helper method which lets you do in one line what we just wrote in seven lines in our resources file:
 
-~~~ruby
+```ruby
   # in config/routes.rb
   ...
   resources :posts
   ...
-~~~
+```
 
-That's it.  That is a Ruby method which basically just outputs those seven routes we talked about before.  No magic.  You see it a whole lot, now you know what it does.
+That's it. That is a Ruby method which basically just outputs those seven routes we talked about before. No magic. You see it a whole lot, now you know what it does.
 
-### Rails Routes and Route Helpers
+### Rails routes and route helpers
 
-With that above line in our routes file, what do our routes look like?  If you type `$ rails routes` on the command line, it'll output all the routes your application knows, which look like:
+With that above line in our routes file, what do our routes look like? If you type `$ rails routes` on the command line, it'll output all the routes your application knows, which look like:
 
-~~~bash
+```bash
   edit_post  GET  /posts/:id/edit(.:format)  posts#edit
-~~~
+```
 
-You can see the incoming HTTP verb and URL in the middle columns, then the controller action they map to on the right, which should all be quite familiar because you just wrote it in the routes file.  The `(.:format)` just means that it's okay but not required to specify a file extension like `.doc` at the end of the route... it will just get saved in the `params` hash for later anyway.  But what's on the leftmost column?  That's the "name" of the route.
+You can see the incoming HTTP verb and URL in the middle columns, then the controller action they map to on the right, which should all be quite familiar because you just wrote it in the routes file. The `(.:format)` just means that it's okay but not required to specify a file extension like `.doc` at the end of the route... it will just get saved in the `params` hash for later anyway. But what's on the leftmost column? That's the "name" of the route.
 
-There are a lot of situations where you want to be able to retrieve the URL for a particular route, like when you want to show navigation links on your webpage (do NOT hard code the URLS, because you'll be out of luck when you decide to change the URLs and have to manually go in and change them yourself).  Rails gives you a helper method that lets you create links called `link_to`, but you'll need to supply it with the text that you want to show and the URL to link it to.
+There are a lot of situations where you want to be able to retrieve the URL for a particular route, like when you want to show navigation links on your webpage (do NOT hard code the URLS, because you'll be out of luck when you decide to change the URLs and have to manually go in and change them yourself). Rails gives you a helper method that lets you create links called `link_to`, but you'll need to supply it with the text that you want to show and the URL to link it to.
 
-~~~ruby
+```ruby
   link_to "Edit this post", edit_post_path(3) # don't hardcode 3!
-~~~
+```
 
-We're jumping a little bit ahead, but in this case, the second argument is supposed to be a path or a URL, so we use the path helper method to generate that.  `edit_post_path(3)` will generate the path `/posts/3/edit`.
+We're jumping a little bit ahead, but in this case, the second argument is supposed to be a path or a URL, so we use the path helper method to generate that. `edit_post_path(3)` will generate the path `/posts/3/edit`.
 
-Rails automatically generates helper methods for you which correspond to the names of all your routes.  These methods end with `_path` and `_url`.  `path`, as in `edit_post_path(3)`, will generate just the path portion of the URL, which is sufficient for most applications.  `url` will generate the full URL.
+Rails automatically generates helper methods for you which correspond to the names of all your routes. These methods end with `_path` and `_url`. `path`, as in `edit_post_path(3)`, will generate just the path portion of the URL, which is sufficient for most applications. `url` will generate the full URL.
 
-Any routes which require you to specify an ID or other parameters will need you to supply those to the helper methods as well (like we did above for edit).  You can also put in a query string by adding an additional parameter:
+Any routes which require you to specify an ID or other parameters will need you to supply those to the helper methods as well (like we did above for edit). You can also put in a query string by adding an additional parameter:
 
-~~~ruby
+```ruby
   post_path(3, :referral_link => "/some/path/or/something")
-~~~
+```
 
 Now the `:referral_link` parameter would be available in your `params` hash in your controller in addition to the normal set of parameters.
 
-### Routes go to Controller Actions!
+### Routes go to controller actions!
 
 Just to drive home that routes correspond directly to controller actions, a very simple sample controller which would fulfill the above routes generated by `resources :posts` might look like:
 
-~~~ruby
+```ruby
   # in app/controllers/posts_controller.rb
   class PostsController < ApplicationController
 
@@ -158,51 +158,52 @@ Just to drive home that routes correspond directly to controller actions, a very
       # destroy it.  Once that's done, redirect us to somewhere fun.
     end
   end
-~~~
+```
 
 Remember that you can run `$ rails routes` in the project directory to see all of the routes with their corresponding controllers and actions.
 
-### We Don't Want All Seven Routes!
+### We don't want all seven routes!
 
-Sometimes you just don't want all seven of the RESTful routes that `resources` provides.  Easy, either specify just the ones you want using `only` or just the ones you DON'T want using `except`:
+Sometimes you just don't want all seven of the RESTful routes that `resources` provides. Easy, either specify just the ones you want using `only` or just the ones you DON'T want using `except`:
 
-~~~ruby
+```ruby
   resources :posts, only: [:index, :show]
   resources :users, except: [:index]
-~~~
+```
 
-### Non-RESTful Routes
+### Non-RESTful routes
 
-Of course, you don't have to do everything the RESTful way.  You probably should, but there are times that you want to make up your own route and map it to your own controller action.  Just follow the examples we gave at the top for RESTful routes:
+Of course, you don't have to do everything the RESTful way. You probably should, but there are times that you want to make up your own route and map it to your own controller action. Just follow the examples we gave at the top for RESTful routes:
 
-~~~ruby
+```ruby
   get '/somepath', to: 'somecontroller#someaction'
-~~~
+```
 
 ... of course, the `config/routes.rb` comments should be helpful to you here as well.
 
 ### Assignment
 
-You should have a good sense of what's going on in the routes file by now but probably also have plenty of questions.  The Rails Guides to the rescue!
+You should have a good sense of what's going on in the routes file by now but probably also have plenty of questions. The Rails Guides to the rescue!
 
 <div class="lesson-content__panel" markdown="1">
 1. Read the [Rails Guides chapter on Routing](http://guides.rubyonrails.org/routing.html), sections 1-2.5, 3.1-3.4, 4.6, and 6.1
 2. Watch this [Wonderful explanation of how REST and HTTP works](https://www.youtube.com/watch?v=Q-BpqyOT3a8). You can follow the tutorial using `curl https://api.github.com`.
 </div>
 
-### Additional Resources
+### Additional resources
+
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
-* [CodeSchool's Surviving APIs with Rails](https://www.youtube.com/watch?v=99nZVo9amAQ) - Level 1 is free and gets into REST, Routes, Constraints, and Namespaces.
-* [Medium article](https://medium.com/podiihq/understanding-rails-routes-and-restful-design-a192d64cbbb5) on Rails routing. It covers a lot of the same things that the Rails Guides cover but with a little different tone that some people may find easier to digest.
+- [CodeSchool's Surviving APIs with Rails](https://www.youtube.com/watch?v=99nZVo9amAQ) - Level 1 is free and gets into REST, Routes, Constraints, and Namespaces.
+- [Medium article](https://medium.com/podiihq/understanding-rails-routes-and-restful-design-a192d64cbbb5) on Rails routing. It covers a lot of the same things that the Rails Guides cover but with a little different tone that some people may find easier to digest.
 
-### Knowledge Check
+### Knowledge check
+
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
-* <a class="knowledge-check-link" href="https://guides.rubyonrails.org/routing.html#the-purpose-of-the-rails-router">What is the purpose of the Rails router?</a>
-* <a class="knowledge-check-link" href="#root">How do you assign the root route of your application in the router?</a>
-* <a class="knowledge-check-link" href="https://guides.rubyonrails.org/routing.html#crud-verbs-and-actions">Assuming we have no knowledge of the HTTP-verb, which 3 RESTful controller actions could be triggered by the `/photos/:id` -route?</a>
-* <a class="knowledge-check-link" href="https://guides.rubyonrails.org/routing.html#restricting-the-routes-created">How can you assign all of the RESTful routes for a resource - excluding the destroy-route - in just one line?</a>
-* <a class="knowledge-check-link" href="https://guides.rubyonrails.org/routing.html#path-and-url-helpers">How would you create a link in your app (without hardcoding), that directs you to `/photos/10/edit`?</a>
-* <a class="knowledge-check-link" href="https://youtu.be/Q-BpqyOT3a8?t=886">Which Chrome extension can you use to simulate HTTP-requests with an API?</a>
-
+- <a class="knowledge-check-link" href="https://guides.rubyonrails.org/routing.html#the-purpose-of-the-rails-router">What is the purpose of the Rails router?</a>
+- <a class="knowledge-check-link" href="#root">How do you assign the root route of your application in the router?</a>
+- <a class="knowledge-check-link" href="https://guides.rubyonrails.org/routing.html#crud-verbs-and-actions">Assuming we have no knowledge of the HTTP-verb, which 3 RESTful controller actions could be triggered by the `/photos/:id` -route?</a>
+- <a class="knowledge-check-link" href="https://guides.rubyonrails.org/routing.html#restricting-the-routes-created">How can you assign all of the RESTful routes for a resource - excluding the destroy-route - in just one line?</a>
+- <a class="knowledge-check-link" href="https://guides.rubyonrails.org/routing.html#path-and-url-helpers">How would you create a link in your app (without hardcoding), that directs you to `/photos/10/edit`?</a>
+- <a class="knowledge-check-link" href="https://youtu.be/Q-BpqyOT3a8?t=886">Which Chrome extension can you use to simulate HTTP-requests with an API?</a>

--- a/ruby_on_rails/rails_basics/routing.md
+++ b/ruby_on_rails/rails_basics/routing.md
@@ -1,24 +1,207 @@
 ### Introduction
 
-In this project, you'll get the opportunity to actually build a real Rails application.  It's not a trivially simple one either -- it's got a lot of wrinkles and things that you're not going to understand.
+The router is the doorman of your application.  When an HTTP request arrives from the user's browser, it needs to know which controller action (method) should be run.  Should we display the "new user" webpage?  Should we edit an existing user with whatever data got sent along?
 
-To be honest, you're kind of going into the deep end so don't worry if you don't understand what exactly you're doing in all the steps.  The point here is to get familiar with the process of creating a Rails app, what things generally look like, and what you don't know.  When you get to the end of this project, you can consider yourself remarkably persistent and resilient.
+The Router is basically just a matching service.  It looks at the HTTP verb (GET, POST, PUT, DELETE) and the URL that is being requested and matches it with the appropriate controller action to run.  It's a pretty simple function but an essential one.  If it can't find a route that matches the request, your application will throw an error.
+
+The other handy thing that goes on when a request enters your application is that Rails grabs all the parameters that came with it and makes them available for you in a special hash called `params` that you can later use in your controller.  That's good for things like form submissions so that you later can use that form data to create or modify objects.
+
+If you open the routes file in your Rails app (located in `config/routes.rb`), you'll see a link to the Rails Guides routing section. This resource does a good job of explaining how it works, so you're never in much danger of losing your way.
+
+Lots of training courses and tutorials kind of gloss over routes, and they seem quite easy in hindsight, but when learning Rails it's easy to get hung up on what exactly is going on. Luckily, typing `$ rails routes` into the command line will give you an output of all the routes that are available to your application.  In this section we'll go into what's actually happening with this file.
+
+### Lesson overview
+
+This section contains a general overview of topics that you will learn in this lesson.
+
+- Configuring a root route.
+- Configuring RESTful routes for a resource.
+- Configuring customized routes for a resource.
+- The 7 RESTful controller actions.
+- How to obtain a list of all possible routes for your current Rails application.
+- Helper methods to create a navigation link on your webpage.
+
+### Root
+
+The most important (and simplest) route in your file is the root URL... where should users be deposited when they land on `http://supercutekittenphotos.com`?  Just tell Rails which controller and action to map that route to, and it is so:
+
+~~~ruby
+  root to: "kittens#index"  #kittens controller, index action (method)
+~~~
+
+Remember, when we say "action" we really mean "the method inside the controller that is called that", e.g. the `index` action is just the `index` method that's defined in the KittensController*
+
+### RESTful routes
+
+If you recall our earlier discussion about REST, there are basically seven main types of actions that you can (and should) do to a "resource", or an object like a blog post or user... something with its own database model.  From that discussion, they are:
+
+1. GET all the posts (aka **"index"** the posts)
+2. GET just one specific post (aka **"show"** that post)
+3. GET the page that lets you create a new post (aka view the **"new"** post page)
+4. POST the data you just filled out for a new post back to the server so it can create that post (aka **"create"** the post)
+5. GET the page that lets you edit an existing post (aka view the **"edit"** post page)
+6. PUT the data you just filled out to edit the post back to the server so it can actually perform the update (aka **"update"** the post)
+7. DELETE one specific post by sending a delete request to the server (aka **"destroy"** the post)
+
+The highlighted words correspond to standard Rails controller actions!
+
+Each of these represents a "RESTful" route, and so it makes sense that you'll need a way to write these in your Router file so the requests they represent are actually routed to the proper action of your controller (in this case, the "Posts" controller).  One way to write them out would be the long way:
+
+~~~ruby
+  get "/posts", to: "posts#index"
+  get "/posts/new", to: "posts#new"
+  get "/posts/:id", to: "posts#show"
+  post "/posts", to: "posts#create"  # usually a submitted form
+  get "/posts/:id/edit", to: "posts#edit"
+  put "/posts/:id", to: "posts#update" # usually a submitted form
+  delete "/posts/:id", to: "posts#destroy"
+~~~
+
+Each of these routes is basically a Ruby method that matches that particular URL and HTTP verb with the correct controller action.  Two things to notice:
+
+1. The first key thing to notice is that several of those routes submit to the SAME URL... they just use different HTTP verbs, so Rails can send them to a different controller action.  That trips up a lot of beginners.  
+2. The other thing to notice is that the "id" field is prepended by a colon... that just tells Rails "Look for anything here and save it as the ID in the params hash".  It lets you submit a GET request for the first post and the fifth post to the same route, just a different ID:
+
+~~~ruby
+  /posts/1  # going to the #show action of the PostsController
+  /posts/5  # also going to the #show action of PostsController
+~~~
+
+You will be able to access that ID directly from the controller by tapping into the params hash where it got stored.
+
+### The Rails way to write RESTful routes
+
+Rails knows you want to use those seven actions all the time... so they came up with a handy helper method which lets you do in one line what we just wrote in seven lines in our resources file:
+
+~~~ruby
+  # in config/routes.rb
+  ...
+  resources :posts
+  ...
+~~~
+
+That's it.  That is a Ruby method which basically just outputs those seven routes we talked about before.  No magic.  You see it a whole lot, now you know what it does.
+
+### Rails routes and route helpers
+
+With that above line in our routes file, what do our routes look like?  If you type `$ rails routes` on the command line, it'll output all the routes your application knows, which look like:
+
+~~~bash
+  edit_post  GET  /posts/:id/edit(.:format)  posts#edit
+~~~
+
+You can see the incoming HTTP verb and URL in the middle columns, then the controller action they map to on the right, which should all be quite familiar because you just wrote it in the routes file.  The `(.:format)` just means that it's okay but not required to specify a file extension like `.doc` at the end of the route... it will just get saved in the `params` hash for later anyway.  But what's on the leftmost column?  That's the "name" of the route.
+
+There are a lot of situations where you want to be able to retrieve the URL for a particular route, like when you want to show navigation links on your webpage (do NOT hard code the URLS, because you'll be out of luck when you decide to change the URLs and have to manually go in and change them yourself).  Rails gives you a helper method that lets you create links called `link_to`, but you'll need to supply it with the text that you want to show and the URL to link it to.
+
+~~~ruby
+  link_to "Edit this post", edit_post_path(3) # don't hardcode 3!
+~~~
+
+We're jumping a little bit ahead, but in this case, the second argument is supposed to be a path or a URL, so we use the path helper method to generate that.  `edit_post_path(3)` will generate the path `/posts/3/edit`.
+
+Rails automatically generates helper methods for you which correspond to the names of all your routes.  These methods end with `_path` and `_url`.  `path`, as in `edit_post_path(3)`, will generate just the path portion of the URL, which is sufficient for most applications.  `url` will generate the full URL.
+
+Any routes which require you to specify an ID or other parameters will need you to supply those to the helper methods as well (like we did above for edit).  You can also put in a query string by adding an additional parameter:
+
+~~~ruby
+  post_path(3, :referral_link => "/some/path/or/something")
+~~~
+
+Now the `:referral_link` parameter would be available in your `params` hash in your controller in addition to the normal set of parameters.
+
+### Routes go to controller actions!
+
+Just to drive home that routes correspond directly to controller actions, a very simple sample controller which would fulfill the above routes generated by `resources :posts` might look like:
+
+~~~ruby
+  # in app/controllers/posts_controller.rb
+  class PostsController < ApplicationController
+
+    def index
+      # very simple code to grab all posts so they can be
+      # displayed in the Index view (index.html.erb)
+    end
+
+    def show
+      # very simple code to grab the proper Post so it can be
+      # displayed in the Show view (show.html.erb)
+    end
+
+    def new
+      # very simple code to create an empty post and send the user
+      # to the New view for it (new.html.erb), which will have a
+      # form for creating the post
+    end
+
+    def create
+      # code to create a new post based on the parameters that
+      # were submitted with the form (and are now available in the
+      # params hash)
+    end
+
+    def edit
+      # very simple code to find the post we want and send the
+      # user to the Edit view for it (edit.html.erb), which has a
+      # form for editing the post
+    end
+
+    def update
+      # code to figure out which post we're trying to update, then
+      # actually update the attributes of that post. Once that's
+      # done, redirect us to somewhere like the Show page for that
+      # post
+    end
+
+    def destroy
+      # very simple code to find the post we're referring to and
+      # destroy it.  Once that's done, redirect us to somewhere fun.
+    end
+  end
+~~~
+
+Remember that you can run `$ rails routes` in the project directory to see all of the routes with their corresponding controllers and actions.
+
+### We don't want all seven routes!
+
+Sometimes you just don't want all seven of the RESTful routes that `resources` provides.  Easy, either specify just the ones you want using `only` or just the ones you DON'T want using `except`:
+
+~~~ruby
+  resources :posts, only: [:index, :show]
+  resources :users, except: [:index]
+~~~
+
+### Non-RESTful routes
+
+Of course, you don't have to do everything the RESTful way.  You probably should, but there are times that you want to make up your own route and map it to your own controller action.  Just follow the examples we gave at the top for RESTful routes:
+
+~~~ruby
+  get '/somepath', to: 'somecontroller#someaction'
+~~~
+
+... of course, the `config/routes.rb` comments should be helpful to you here as well.
 
 ### Assignment
 
-<div class="lesson-content__panel" markdown="1">
+You should have a good sense of what's going on in the routes file by now but probably also have plenty of questions.  The Rails Guides to the rescue!
 
-  1. Do the [The Ruby on Rails Guides: Getting Started](https://guides.rubyonrails.org/getting_started.html) project up to section 9.2. It ties together the Model-View-Controller and gives a pretty good overview of the common commands you'll use when using Rails. The remainder of the tutorial covers topics that have not been introduced, like concerns and authentication, so it is hard to understand the big picture. In addition, these sections can be confusing because the instructions do not follow the same copy/paste pattern.
-  2. You should have Rails installed already so section 3.1 might not be relevant. It might still be prudent to run the `--version` commands to check you have everything you need though.
-  3. Make sure you commit to Git regularly so if you run into any issues you can revert to an earlier commit without having to start over from scratch. As a rough guide look to commit at the end of each section.
-  4. Pay attention to any error messages you get as you build the app, even though they'll be unplanned.  You'll see all these messages again and again when you're building Rails apps, so it's helpful to start getting familiar with which portions of the message you should pay attention to (and maybe put into Google if you can't figure out what caused it).
-  5. Try to make a mental note of the commands and generators you can use. Rails provides a lot of very helpful generators taking a lot of the pain out of creating different parts of a web application.
-  6. When you're finished, push your code up to [GitHub](https://github.com/).
+<div class="lesson-content__panel" markdown="1">
+1. Read the [Rails Guides chapter on Routing](http://guides.rubyonrails.org/routing.html), sections 1-2.5, 3.1-3.4, 4.6, and 6.1
+2. Watch this [Wonderful explanation of how REST and HTTP works](https://www.youtube.com/watch?v=Q-BpqyOT3a8). You can follow the tutorial using `curl https://api.github.com`.
 </div>
 
 ### Additional resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
-* The [official Ruby on Rails guides](http://guides.rubyonrails.org/) are an excellent resource if you want to build on your knowledge.
-* You can read the [Introduction to Core Ruby Tools](https://launchschool.com/books/core_ruby_tools/read/introduction) from LaunchSchool to get a better understanding of Ruby and Rails concepts such as gems, version managers, bundler, and rake.
-* The first 30-minutes of this [video](https://youtu.be/rssgWqJq-14) will teach you how to see through of the magical syntax of Ruby on Rails and how to use pry to debug.
+* [CodeSchool's Surviving APIs with Rails](https://www.youtube.com/watch?v=99nZVo9amAQ) - Level 1 is free and gets into REST, Routes, Constraints, and Namespaces.
+* [Medium article](https://medium.com/podiihq/understanding-rails-routes-and-restful-design-a192d64cbbb5) on Rails routing. It covers a lot of the same things that the Rails Guides cover but with a little different tone that some people may find easier to digest.
+
+### Knowledge check
+This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
+
+* <a class="knowledge-check-link" href="https://guides.rubyonrails.org/routing.html#the-purpose-of-the-rails-router">What is the purpose of the Rails router?</a>
+* <a class="knowledge-check-link" href="#root">How do you assign the root route of your application in the router?</a>
+* <a class="knowledge-check-link" href="https://guides.rubyonrails.org/routing.html#crud-verbs-and-actions">Assuming we have no knowledge of the HTTP-verb, which 3 RESTful controller actions could be triggered by the `/photos/:id` -route?</a>
+* <a class="knowledge-check-link" href="https://guides.rubyonrails.org/routing.html#restricting-the-routes-created">How can you assign all of the RESTful routes for a resource - excluding the destroy-route - in just one line?</a>
+* <a class="knowledge-check-link" href="https://guides.rubyonrails.org/routing.html#path-and-url-helpers">How would you create a link in your app (without hardcoding), that directs you to `/photos/10/edit`?</a>
+* <a class="knowledge-check-link" href="https://youtu.be/Q-BpqyOT3a8?t=886">Which Chrome extension can you use to simulate HTTP-requests with an API?</a>

--- a/ruby_on_rails/rails_basics/views.md
+++ b/ruby_on_rails/rails_basics/views.md
@@ -1,16 +1,16 @@
 ### Introduction
 
-The view is really the simplest part of the MVC structure -- at the basic level, it's just a bunch of HTML boilerplate into which you insert the variables you've received from your controller and which will be sent to the browser.  It's your actual "webpage".  It will often have some snippets of code designed to properly present the variables it has received, for instance a loop that will display each one of the posts on your blog.  Views are often called view templates.
+The view is really the simplest part of the MVC structure -- at the basic level, it's just a bunch of HTML boilerplate into which you insert the variables you've received from your controller and which will be sent to the browser. It's your actual "webpage". It will often have some snippets of code designed to properly present the variables it has received, for instance a loop that will display each one of the posts on your blog. Views are often called view templates.
 
 Views live in the directory `app/views/controller_name/action_name.html.erb`, where `controller_name` is the name of the controller the view is linked to and `action_name.html.erb` is the corresponding method inside the controller that was run immediately prior to rendering the view.
 
-So the `Posts` controller running the `#index` action will implicitly render the `app/views/posts/index.html.erb` view when it's done.  You can explicitly tell your controller to render a differently named view by passing it as a parameter to the `render` function in your controller, but why?  This directory and naming structure helps you (and Rails) to always know where to find a given view.
+So the `Posts` controller running the `#index` action will implicitly render the `app/views/posts/index.html.erb` view when it's done. You can explicitly tell your controller to render a differently named view by passing it as a parameter to the `render` function in your controller, but why? This directory and naming structure helps you (and Rails) to always know where to find a given view.
 
 To use an instance variable from your view, just call it the same way you would in the controller: `@user.first_name` or `@posts` or `@some_other_variable`.
 
 As always, in this lesson we'll cover the high level stuff then have you read the Rails Guide for a more detailed understanding of how things work.
 
-### Lesson Overview
+### Lesson overview
 
 This section contains a general overview of topics that you will learn in this lesson.
 
@@ -21,25 +21,25 @@ This section contains a general overview of topics that you will learn in this l
 
 ### Layouts
 
-The first thing to note is that the named view template we render from the controller is actually not the entire webpage.  It doesn't contain the `<head>` tags or the `DOCTYPE` declaration or some of the other basic structure that's present in all pages.  Precisely because those things are present in all of your pages, the Rails creators were smart enough to turn that code into its own file called a "layout".  Layouts live in the directory `app/views/layouts`.
+The first thing to note is that the named view template we render from the controller is actually not the entire webpage. It doesn't contain the `<head>` tags or the `DOCTYPE` declaration or some of the other basic structure that's present in all pages. Precisely because those things are present in all of your pages, the Rails creators were smart enough to turn that code into its own file called a "layout". Layouts live in the directory `app/views/layouts`.
 
-For a brand new Rails application, the `application.html.erb` layout is pretty basic.  It's got the basic tags you need in all webpages (e.g. `<html>` and `<body>`) and a couple snippets of code that load up the JavaScript and CSS files your webpage will need.  You'll want to put anything that's needed across all your webpages into the layout.  Usually this is stuff like navbars and footers and snippets of code for displaying flash messages.
+For a brand new Rails application, the `application.html.erb` layout is pretty basic. It's got the basic tags you need in all webpages (e.g. `<html>` and `<body>`) and a couple snippets of code that load up the JavaScript and CSS files your webpage will need. You'll want to put anything that's needed across all your webpages into the layout. Usually this is stuff like navbars and footers and snippets of code for displaying flash messages.
 
-So if a layout is basically just a shell around the individual page, how does the page get inserted?  That brings us back to the magic of the `#yield` method, which you saw when you learned about blocks.  The view template at `app/views/posts/index.html.erb` gets inserted where the yield statement is.  When you get more advanced, you'll be able to play around a bit with that statement but for now it's just that simple.
+So if a layout is basically just a shell around the individual page, how does the page get inserted? That brings us back to the magic of the `#yield` method, which you saw when you learned about blocks. The view template at `app/views/posts/index.html.erb` gets inserted where the yield statement is. When you get more advanced, you'll be able to play around a bit with that statement but for now it's just that simple.
 
 ### Preprocessors
 
-The other thing you've undoubtedly noticed is the odd HTML code that goes inside `<%=` and `%>` tags.  This is Embedded Ruby (ERB).  It's a special way of executing ruby code inside your HTML.  HTML is static, so you need to dial in some Ruby if you want to do anything dynamic like looping, `if` statements or working with variables.  ERB (and another similar language you might see called HAML) do exactly that.
+The other thing you've undoubtedly noticed is the odd HTML code that goes inside `<%=` and `%>` tags. This is Embedded Ruby (ERB). It's a special way of executing ruby code inside your HTML. HTML is static, so you need to dial in some Ruby if you want to do anything dynamic like looping, `if` statements or working with variables. ERB (and another similar language you might see called HAML) do exactly that.
 
-What those tags do is execute whatever you see inside them exactly as if it was normal Ruby.  So `<%= "<em>I am emphasized</em>" %>` will output an emphasized piece of text like <em>I am emphasized</em> and `<%= @user.first_name %>` might output `joe`.
+What those tags do is execute whatever you see inside them exactly as if it was normal Ruby. So `<%= "<em>I am emphasized</em>" %>` will output an emphasized piece of text like <em>I am emphasized</em> and `<%= @user.first_name %>` might output `joe`.
 
-The difference between `<%` and `<%=` is that the `<%=` version actually displays whatever is returned inside the ERB tags.  If you use `<%`, it will execute the code but, no matter what is returned by that line, it will not actually display anything in your HTML template. `<%#` is used to comment and will not execute.
+The difference between `<%` and `<%=` is that the `<%=` version actually displays whatever is returned inside the ERB tags. If you use `<%`, it will execute the code but, no matter what is returned by that line, it will not actually display anything in your HTML template. `<%#` is used to comment and will not execute.
 
-Most of your tags will be `<%=` because you'll find yourself often just outputting important pieces of the instance variables that you received from your controller, like in the `<%= @user.first_name %>` example above.  You use the `<%` for purely code-related stuff like `if` statements and `each` loops, where you don't actually WANT anything displayed (the stuff you display will occur inside the loop).  
+Most of your tags will be `<%=` because you'll find yourself often just outputting important pieces of the instance variables that you received from your controller, like in the `<%= @user.first_name %>` example above. You use the `<%` for purely code-related stuff like `if` statements and `each` loops, where you don't actually WANT anything displayed (the stuff you display will occur inside the loop).
 
-If this is confusing, here's an example:  Say we want to display the first names of all the users in our application, but only if the current user is signed in.  This might look something like:
+If this is confusing, here's an example: Say we want to display the first names of all the users in our application, but only if the current user is signed in. This might look something like:
 
-~~~erb
+```erb
   <% if current_user.signed_in? %>
     <ul>
       <% @users.each do |user| %>
@@ -49,81 +49,80 @@ If this is confusing, here's an example:  Say we want to display the first names
   <% else %>
     <strong>You must sign in!</strong>
   <% end %>
-~~~
+```
 
-Remember to close your statements and loops with `<% end %>`!  (You'll forget a few times.)
+Remember to close your statements and loops with `<% end %>`! (You'll forget a few times.)
 
 In the code above, if the user is signed in it will actually render to the web something like:
 
-~~~html
-  <ul>
-    <li>Bob</li>
-    <li>Joe</li>
-    <li>Nancy</li>
-  </ul>
-~~~
+```html
+<ul>
+  <li>Bob</li>
+  <li>Joe</li>
+  <li>Nancy</li>
+</ul>
+```
 
 If the user isn't signed in, it'll be the much shorter:
 
-~~~html
-  <strong>You must sign in!</strong>
-~~~
+```html
+<strong>You must sign in!</strong>
+```
 
-In the above code, if we had accidentally used `<%=` in the loop line, e.g. `<%= @users.each do |user| %>` it would run the code fine, but because `each` returns the original collection, we'd also see a dump of our `@users` variable on our page (not very professional).  It'll happen to you several times and you'll learn quick.
+In the above code, if we had accidentally used `<%=` in the loop line, e.g. `<%= @users.each do |user| %>` it would run the code fine, but because `each` returns the original collection, we'd also see a dump of our `@users` variable on our page (not very professional). It'll happen to you several times and you'll learn quick.
 
-### How Do Preprocessors Work?
+### How do preprocessors work?
 
-The important thing to note about the above code execution is that it is all done on the server BEFORE the final HTML file is shipped over to the browser (part of the Asset Pipeline, covered in the next lesson).  That's because, when you render your template in Rails, it first runs "preprocessors" like ERB.  It knows you want to preprocess the file because it has the extension `.html.erb`.  
+The important thing to note about the above code execution is that it is all done on the server BEFORE the final HTML file is shipped over to the browser (part of the Asset Pipeline, covered in the next lesson). That's because, when you render your template in Rails, it first runs "preprocessors" like ERB. It knows you want to preprocess the file because it has the extension `.html.erb`.
 
-Rails starts from the outside in with extra extensions.  So it first processes the file using ERB, then treats it as regular HTML.  That's fine because ERB by definition outputs good clean HTML, like we saw above.  
+Rails starts from the outside in with extra extensions. So it first processes the file using ERB, then treats it as regular HTML. That's fine because ERB by definition outputs good clean HTML, like we saw above.
 
-There are other preprocessors you'll run into as well.  `.css.scss` files use the SASS preprocessor and become regular CSS files.  `.js.coffee` files, which use the Coffeescript preprocessor, become regular JavaScript after being run.  In both these cases, the preprocessor's language makes your life easier by giving you some additional tools you can use (like having loops and working with variables) and compiles back down into a plain vanilla CSS or JavaScript or HTML.
+There are other preprocessors you'll run into as well. `.css.scss` files use the SASS preprocessor and become regular CSS files. `.js.coffee` files, which use the Coffeescript preprocessor, become regular JavaScript after being run. In both these cases, the preprocessor's language makes your life easier by giving you some additional tools you can use (like having loops and working with variables) and compiles back down into a plain vanilla CSS or JavaScript or HTML.
 
-The point is, there are many different preprocessors.  They are usually gems that either already come with Rails or can easily be attached to it.  Rails then runs them automatically, so all you have to worry about is whether your file has the right extension(s) to tell the preprocessor to run.  
+The point is, there are many different preprocessors. They are usually gems that either already come with Rails or can easily be attached to it. Rails then runs them automatically, so all you have to worry about is whether your file has the right extension(s) to tell the preprocessor to run.
 
-### View Partials
+### View partials
 
-Another nice thing you can do in Rails is break apart your views into partials.  This helps you on several levels -- it makes your code more concise and easier to read, and also lets you reuse certain common patterns.  One example is the form for creating or editing users.  Both the `#new` and `#edit` actions need to render some sort of form for the user, and usually that form is almost exactly the same.  So often people will turn that form into a new file called something like `_user_form.html.erb` and then just call that in both the `new.html.erb` and `edit.html.erb` view templates where it's needed.
+Another nice thing you can do in Rails is break apart your views into partials. This helps you on several levels -- it makes your code more concise and easier to read, and also lets you reuse certain common patterns. One example is the form for creating or editing users. Both the `#new` and `#edit` actions need to render some sort of form for the user, and usually that form is almost exactly the same. So often people will turn that form into a new file called something like `_user_form.html.erb` and then just call that in both the `new.html.erb` and `edit.html.erb` view templates where it's needed.
 
-Pulling back a bit, partials are just HTML files that aren't meant to be complete but can be shared by other files.  You would call a partial by writing something like:
+Pulling back a bit, partials are just HTML files that aren't meant to be complete but can be shared by other files. You would call a partial by writing something like:
 
-~~~erb
+```erb
   # app/views/users/new.html.erb
   <div class="new-user-form">
     <%= render "user_form" %>
   </div>
-~~~
+```
 
-There are a couple of syntax oddities you need to pay attention to.  The view partial file is named with an underscore like `_user_form.html.erb` but gets called using just the core portion of the name, e.g. `user_form` in the example above.  
+There are a couple of syntax oddities you need to pay attention to. The view partial file is named with an underscore like `_user_form.html.erb` but gets called using just the core portion of the name, e.g. `user_form` in the example above.
 
-If there is no directory specified in partial's name, Rails will only look in the same folder as whichever view called it, e.g. `app/views/users`.  Sometimes it makes sense to share partials across multiple view templates that are in multiple controllers, so you save them in their own folder called `app/views/shared` and would then render them using the code `<%= render "shared/some_partial"%>`.
+If there is no directory specified in partial's name, Rails will only look in the same folder as whichever view called it, e.g. `app/views/users`. Sometimes it makes sense to share partials across multiple view templates that are in multiple controllers, so you save them in their own folder called `app/views/shared` and would then render them using the code `<%= render "shared/some_partial"%>`.
 
-### Passing Local Variables to Partials
+### Passing local variables to partials
 
-There's a lot you can do with partials and we won't dive into it all here, but one thing that you might find yourself doing a lot is passing variables to partials.  A partial has access to all the variables that the calling view template does, but do NOT rely on them!  What if your partial is used by a different controller that uses a different structure for its instance variables?  It's bad code to expect an instance variable like `@user` to be there in the partial all the time. That means you've got to explicitly pass the partial whichever variables you want it to have access to.  
+There's a lot you can do with partials and we won't dive into it all here, but one thing that you might find yourself doing a lot is passing variables to partials. A partial has access to all the variables that the calling view template does, but do NOT rely on them! What if your partial is used by a different controller that uses a different structure for its instance variables? It's bad code to expect an instance variable like `@user` to be there in the partial all the time. That means you've got to explicitly pass the partial whichever variables you want it to have access to.
 
-In the example above, you most likely want to pass the `@user` variable to the partial so your code can render the right kind of form. `render` is just a regular method and it lets you pass it an [options hash](https://stackoverflow.com/questions/18407618/what-are-options-hashes).  One of those options is the `:locals` key, which will contain the variables you want to pass.  Your code might change to look like:
+In the example above, you most likely want to pass the `@user` variable to the partial so your code can render the right kind of form. `render` is just a regular method and it lets you pass it an [options hash](https://stackoverflow.com/questions/18407618/what-are-options-hashes). One of those options is the `:locals` key, which will contain the variables you want to pass. Your code might change to look like:
 
-~~~erb
+```erb
   <%= render partial: "shared/your_partial", :locals => { :user => user } %>
-~~~  
+```
 
-To use the variable in your partial file, you drop the `@` and call it like a normal variable. Note that you should use the `:locals` option if you're calling the `render` method with a `:partial` key. 
+To use the variable in your partial file, you drop the `@` and call it like a normal variable. Note that you should use the `:locals` option if you're calling the `render` method with a `:partial` key.
 
 There is a `render` shortcut that allows you to simply pass in variables without the need of using the `:locals` option:
 
-~~~erb
+```erb
   <%= render "shared/your_partial", :user => user %>
-~~~
+```
 
+### Implicit partials
 
-### Implicit Partials
+As usual, there are some things you would end up doing so many times that Rails has given you a shortcut. One of these is the act of rendering a model object like a User or a Post. If you want a list of all your users, you could write out the HTML and ERB code for displaying a single user's first name, last name, email etc. many times directly in your `app/views/users/index.html.erb` file or you could keep that code in some sort of `each` loop.
 
-As usual, there are some things you would end up doing so many times that Rails has given you a shortcut.  One of these is the act of rendering a model object like a User or a Post.  If you want a list of all your users, you could write out the HTML and ERB code for displaying a single user's first name, last name, email etc. many times directly in your `app/views/users/index.html.erb` file or you could keep that code in some sort of `each` loop.  
+But it's usually best to make the User into its own partial called `_user.html.erb` so you can re-use it in other cases as well. The basic way of calling this might be something just like we saw above, which looks like:
 
-But it's usually best to make the User into its own partial called `_user.html.erb` so you can re-use it in other cases as well.  The basic way of calling this might be something just like we saw above, which looks like:
-
-~~~erb
+```erb
   # app/views/index.html.erb
   <h1>Users</h1>
   <ul>
@@ -131,20 +130,20 @@ But it's usually best to make the User into its own partial called `_user.html.e
       <%= render "user", :locals => {:user => user} %>
     <% end %>
   </ul>
-~~~
+```
 
 And in your partial:
 
-~~~erb
+```erb
   # app/views/_user.html.erb
   <li><%= "#{user.first_name} #{user.last_name}, #{user.email}" %></li>
-~~~
+```
 
 It may seem strange to have only one line in a partial, but trust me that it usually doesn't stay that way for long so it's worth getting the hang of.
 
-So if that's the basic way, what's the magical Rails way?  Just tell it to render the User object directly, e.g.:
+So if that's the basic way, what's the magical Rails way? Just tell it to render the User object directly, e.g.:
 
-~~~erb
+```erb
   # app/views/index.html.erb
   <h1>Users</h1>
   <ul>
@@ -152,59 +151,59 @@ So if that's the basic way, what's the magical Rails way?  Just tell it to rende
       <%= render user %>     <!-- Lots less code -->
     <% end %>
   </ul>
-~~~
+```
 
 Rails then looks for the `_user.html.erb` file in the current directory and passes it the `user` variable automatically.
 
-What if you want to render a whole bunch of users like we just did?  Rails also does that for you the same way, saving you the trouble of writing out your own `each` loop like we did above.  Simply write:
+What if you want to render a whole bunch of users like we just did? Rails also does that for you the same way, saving you the trouble of writing out your own `each` loop like we did above. Simply write:
 
-~~~erb
+```erb
   # app/views/index.html.erb
   <h1>Users</h1>
   <ul>
     <%= render @users %>
   </ul>
-~~~
+```
 
-In that situation, Rails not only finds the `_user.html.erb` file and passes it the correct `user` variable to use, it also loops over all the users in your `@user` collection for you.  Pretty handy.
+In that situation, Rails not only finds the `_user.html.erb` file and passes it the correct `user` variable to use, it also loops over all the users in your `@user` collection for you. Pretty handy.
 
-### Helper Methods
+### Helper methods
 
-`render`ing partials isn't the only method you can call from within a view.  Rails has a bunch of really handy helper methods that are available for you to use in the view.  A few of the most common:
+`render`ing partials isn't the only method you can call from within a view. Rails has a bunch of really handy helper methods that are available for you to use in the view. A few of the most common:
 
 #### `#link_to`
 
-`link_to` creates an anchor tag URL.  Instead of writing:
+`link_to` creates an anchor tag URL. Instead of writing:
 
-~~~erb
+```erb
   <a href="<%= users_path %>">See All Users</a>
-~~~
+```
 
 You write:
 
-~~~erb
+```erb
   <%= link_to "See All Users", users_path %>
-~~~
+```
 
-It's the Rails way.  And recall that `users_path` generates a relative URL like `/users` whereas `users_url` generates a full URL like `http://www.yourapp.com/users`.  In most cases, it isn't an important distinction because your browser can handle both, but make sure you understand the difference.
+It's the Rails way. And recall that `users_path` generates a relative URL like `/users` whereas `users_url` generates a full URL like `http://www.yourapp.com/users`. In most cases, it isn't an important distinction because your browser can handle both, but make sure you understand the difference.
 
-### Asset Tags
+### Asset tags
 
-As you may have seen in the application layout file we talked about above, Rails gives you helper methods that output HTML tags to grab CSS or JavaScript files.  You can also grab images.  These are called Asset Tags.  We'll get into the "Asset Pipeline" a bit later, but basically these tags locate those files for you based on their name and render the proper HTML tag.
+As you may have seen in the application layout file we talked about above, Rails gives you helper methods that output HTML tags to grab CSS or JavaScript files. You can also grab images. These are called Asset Tags. We'll get into the "Asset Pipeline" a bit later, but basically these tags locate those files for you based on their name and render the proper HTML tag.
 
-~~~erb
+```erb
   <%= stylesheet_link_tag "your_stylesheet" %>
   <%= javascript_include_tag "your_javascript" %>
   <%= image_tag "happy_cat.jpg" %>
-~~~
+```
 
 Will render something like:
 
-~~~html
-  <link href="/assets/your_stylesheet.css" media="all" rel="stylesheet">
-  <script src="/assets/your_javascript.js"></script>
-  <img src="/assets/happy_cat.jpg">
-~~~
+```html
+<link href="/assets/your_stylesheet.css" media="all" rel="stylesheet" />
+<script src="/assets/your_javascript.js"></script>
+<img src="/assets/happy_cat.jpg" />
+```
 
 Note: in production, your stylesheet and JavaScript will all get mashed into one strangely-named file, so don't be alarmed if it's named something like `/assets/application-485ea683b962efeaa58dd8e32925dadf`
 
@@ -214,31 +213,33 @@ Rails offers several different helpers that help you create forms, and we'll go 
 
 ### Assignment
 
-Now that you've got a taste of the high-level stuff, read through the Rails Guides for a more detailed look at things.  The chapter below will actually start in the controller, where you need to let it know WHICH view file you want to render.  The second half of the chapter gets more into the view side of things.
+Now that you've got a taste of the high-level stuff, read through the Rails Guides for a more detailed look at things. The chapter below will actually start in the controller, where you need to let it know WHICH view file you want to render. The second half of the chapter gets more into the view side of things.
 
 <div class="lesson-content__panel" markdown="1">
 
-  1. Read the [Rails Guide chapter on Layouts and Rendering](http://guides.rubyonrails.org/layouts_and_rendering.html), sections 1 through 3.4.  You can certainly skim when they start going over all the many different options you can pass to a given function... it's good to know what they are and where you can find them, but you don't need to memorize all of them.  Usually you'll have something that you want to do, Google it, and find a Stack Overflow post that shows you the option you can use.
+1. Read the [Rails Guide chapter on Layouts and Rendering](http://guides.rubyonrails.org/layouts_and_rendering.html), sections 1 through 3.4. You can certainly skim when they start going over all the many different options you can pass to a given function... it's good to know what they are and where you can find them, but you don't need to memorize all of them. Usually you'll have something that you want to do, Google it, and find a Stack Overflow post that shows you the option you can use.
 </div>
 
 ### Conclusion
 
-Views in general make up the user-facing side of your app.  It can be a bit tricky at first to imagine how you choose which view to render, what to include in that view and how to use partials, but a few iterations of working with Rails will show you the conventions pretty quickly.  Views will become second nature to you.
+Views in general make up the user-facing side of your app. It can be a bit tricky at first to imagine how you choose which view to render, what to include in that view and how to use partials, but a few iterations of working with Rails will show you the conventions pretty quickly. Views will become second nature to you.
 
-### Additional Resources
+### Additional resources
+
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
-* [Stack Overflow Post on Views](https://stackoverflow.com/questions/14429910/an-alternate-explanation-to-rails-layouts-rendering-partials-templates-and-v)
-* [Video on the Relationship Between Views and Controllers](https://www.youtube.com/watch?v=mRJSovhdzWc&ab_channel=GoRails)
-* [Video on ERB Tags](https://www.youtube.com/watch?v=na28woOGPUw&ab_channel=NoobandTube) - (this video will require you to turn your volume up)
-* [Introduction to Ruby on Rails from freeCodeCamp](https://youtu.be/fmyvWz5TUWg) - If you'd like a deeper dive into routing, MVC, CRUD and partials watch the first 60 minutes of this video which provides a good wrap up for what we've been learning so far. You'll also get to create a simple Rails app from scratch if you'd like some extra practice.
+- [Stack Overflow Post on Views](https://stackoverflow.com/questions/14429910/an-alternate-explanation-to-rails-layouts-rendering-partials-templates-and-v)
+- [Video on the Relationship Between Views and Controllers](https://www.youtube.com/watch?v=mRJSovhdzWc&ab_channel=GoRails)
+- [Video on ERB Tags](https://www.youtube.com/watch?v=na28woOGPUw&ab_channel=NoobandTube) - (this video will require you to turn your volume up)
+- [Introduction to Ruby on Rails from freeCodeCamp](https://youtu.be/fmyvWz5TUWg) - If you'd like a deeper dive into routing, MVC, CRUD and partials watch the first 60 minutes of this video which provides a good wrap up for what we've been learning so far. You'll also get to create a simple Rails app from scratch if you'd like some extra practice.
 
-### Knowledge Check
+### Knowledge check
+
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
-* <a class="knowledge-check-link" href="#how-do-preprocessors-work">How do you make sure a preprocessor runs on your view file?</a>
-* <a class="knowledge-check-link" href="#preprocessors">What is the difference between `<%`, `<%=` and `<%#`? </a>
-* <a class="knowledge-check-link" href="https://guides.rubyonrails.org/layouts_and_rendering.html#understanding-yield">What does including `<%= yield %>` in a layout do?</a>
-* <a class="knowledge-check-link" href="https://guides.rubyonrails.org/layouts_and_rendering.html#using-partials">Why do we use partials?</a>
-* <a class="knowledge-check-link" href="https://guides.rubyonrails.org/layouts_and_rendering.html#rendering-collections">What is the shortcut for rendering a collection as a series of partials?</a>
-* <a class="knowledge-check-link" href="#linkto">How do you dynamically link to another page of your Rails app?</a>
+- <a class="knowledge-check-link" href="#how-do-preprocessors-work">How do you make sure a preprocessor runs on your view file?</a>
+- <a class="knowledge-check-link" href="#preprocessors">What is the difference between `<%`, `<%=` and `<%#`? </a>
+- <a class="knowledge-check-link" href="https://guides.rubyonrails.org/layouts_and_rendering.html#understanding-yield">What does including `<%= yield %>` in a layout do?</a>
+- <a class="knowledge-check-link" href="https://guides.rubyonrails.org/layouts_and_rendering.html#using-partials">Why do we use partials?</a>
+- <a class="knowledge-check-link" href="https://guides.rubyonrails.org/layouts_and_rendering.html#rendering-collections">What is the shortcut for rendering a collection as a series of partials?</a>
+- <a class="knowledge-check-link" href="#linkto">How do you dynamically link to another page of your Rails app?</a>

--- a/ruby_on_rails/rails_basics/views.md
+++ b/ruby_on_rails/rails_basics/views.md
@@ -1,10 +1,10 @@
 ### Introduction
 
-The view is really the simplest part of the MVC structure -- at the basic level, it's just a bunch of HTML boilerplate into which you insert the variables you've received from your controller and which will be sent to the browser. It's your actual "webpage". It will often have some snippets of code designed to properly present the variables it has received, for instance a loop that will display each one of the posts on your blog. Views are often called view templates.
+The view is really the simplest part of the MVC structure -- at the basic level, it's just a bunch of HTML boilerplate into which you insert the variables you've received from your controller and which will be sent to the browser.  It's your actual "webpage".  It will often have some snippets of code designed to properly present the variables it has received, for instance a loop that will display each one of the posts on your blog.  Views are often called view templates.
 
 Views live in the directory `app/views/controller_name/action_name.html.erb`, where `controller_name` is the name of the controller the view is linked to and `action_name.html.erb` is the corresponding method inside the controller that was run immediately prior to rendering the view.
 
-So the `Posts` controller running the `#index` action will implicitly render the `app/views/posts/index.html.erb` view when it's done. You can explicitly tell your controller to render a differently named view by passing it as a parameter to the `render` function in your controller, but why? This directory and naming structure helps you (and Rails) to always know where to find a given view.
+So the `Posts` controller running the `#index` action will implicitly render the `app/views/posts/index.html.erb` view when it's done.  You can explicitly tell your controller to render a differently named view by passing it as a parameter to the `render` function in your controller, but why?  This directory and naming structure helps you (and Rails) to always know where to find a given view.
 
 To use an instance variable from your view, just call it the same way you would in the controller: `@user.first_name` or `@posts` or `@some_other_variable`.
 
@@ -21,25 +21,25 @@ This section contains a general overview of topics that you will learn in this l
 
 ### Layouts
 
-The first thing to note is that the named view template we render from the controller is actually not the entire webpage. It doesn't contain the `<head>` tags or the `DOCTYPE` declaration or some of the other basic structure that's present in all pages. Precisely because those things are present in all of your pages, the Rails creators were smart enough to turn that code into its own file called a "layout". Layouts live in the directory `app/views/layouts`.
+The first thing to note is that the named view template we render from the controller is actually not the entire webpage.  It doesn't contain the `<head>` tags or the `DOCTYPE` declaration or some of the other basic structure that's present in all pages.  Precisely because those things are present in all of your pages, the Rails creators were smart enough to turn that code into its own file called a "layout".  Layouts live in the directory `app/views/layouts`.
 
-For a brand new Rails application, the `application.html.erb` layout is pretty basic. It's got the basic tags you need in all webpages (e.g. `<html>` and `<body>`) and a couple snippets of code that load up the JavaScript and CSS files your webpage will need. You'll want to put anything that's needed across all your webpages into the layout. Usually this is stuff like navbars and footers and snippets of code for displaying flash messages.
+For a brand new Rails application, the `application.html.erb` layout is pretty basic.  It's got the basic tags you need in all webpages (e.g. `<html>` and `<body>`) and a couple snippets of code that load up the JavaScript and CSS files your webpage will need.  You'll want to put anything that's needed across all your webpages into the layout.  Usually this is stuff like navbars and footers and snippets of code for displaying flash messages.
 
-So if a layout is basically just a shell around the individual page, how does the page get inserted? That brings us back to the magic of the `#yield` method, which you saw when you learned about blocks. The view template at `app/views/posts/index.html.erb` gets inserted where the yield statement is. When you get more advanced, you'll be able to play around a bit with that statement but for now it's just that simple.
+So if a layout is basically just a shell around the individual page, how does the page get inserted?  That brings us back to the magic of the `#yield` method, which you saw when you learned about blocks.  The view template at `app/views/posts/index.html.erb` gets inserted where the yield statement is.  When you get more advanced, you'll be able to play around a bit with that statement but for now it's just that simple.
 
 ### Preprocessors
 
-The other thing you've undoubtedly noticed is the odd HTML code that goes inside `<%=` and `%>` tags. This is Embedded Ruby (ERB). It's a special way of executing ruby code inside your HTML. HTML is static, so you need to dial in some Ruby if you want to do anything dynamic like looping, `if` statements or working with variables. ERB (and another similar language you might see called HAML) do exactly that.
+The other thing you've undoubtedly noticed is the odd HTML code that goes inside `<%=` and `%>` tags.  This is Embedded Ruby (ERB).  It's a special way of executing ruby code inside your HTML.  HTML is static, so you need to dial in some Ruby if you want to do anything dynamic like looping, `if` statements or working with variables.  ERB (and another similar language you might see called HAML) do exactly that.
 
-What those tags do is execute whatever you see inside them exactly as if it was normal Ruby. So `<%= "<em>I am emphasized</em>" %>` will output an emphasized piece of text like <em>I am emphasized</em> and `<%= @user.first_name %>` might output `joe`.
+What those tags do is execute whatever you see inside them exactly as if it was normal Ruby.  So `<%= "<em>I am emphasized</em>" %>` will output an emphasized piece of text like <em>I am emphasized</em> and `<%= @user.first_name %>` might output `joe`.
 
-The difference between `<%` and `<%=` is that the `<%=` version actually displays whatever is returned inside the ERB tags. If you use `<%`, it will execute the code but, no matter what is returned by that line, it will not actually display anything in your HTML template. `<%#` is used to comment and will not execute.
+The difference between `<%` and `<%=` is that the `<%=` version actually displays whatever is returned inside the ERB tags.  If you use `<%`, it will execute the code but, no matter what is returned by that line, it will not actually display anything in your HTML template. `<%#` is used to comment and will not execute.
 
-Most of your tags will be `<%=` because you'll find yourself often just outputting important pieces of the instance variables that you received from your controller, like in the `<%= @user.first_name %>` example above. You use the `<%` for purely code-related stuff like `if` statements and `each` loops, where you don't actually WANT anything displayed (the stuff you display will occur inside the loop).
+Most of your tags will be `<%=` because you'll find yourself often just outputting important pieces of the instance variables that you received from your controller, like in the `<%= @user.first_name %>` example above.  You use the `<%` for purely code-related stuff like `if` statements and `each` loops, where you don't actually WANT anything displayed (the stuff you display will occur inside the loop).  
 
-If this is confusing, here's an example: Say we want to display the first names of all the users in our application, but only if the current user is signed in. This might look something like:
+If this is confusing, here's an example:  Say we want to display the first names of all the users in our application, but only if the current user is signed in.  This might look something like:
 
-```erb
+~~~erb
   <% if current_user.signed_in? %>
     <ul>
       <% @users.each do |user| %>
@@ -49,80 +49,81 @@ If this is confusing, here's an example: Say we want to display the first names 
   <% else %>
     <strong>You must sign in!</strong>
   <% end %>
-```
+~~~
 
-Remember to close your statements and loops with `<% end %>`! (You'll forget a few times.)
+Remember to close your statements and loops with `<% end %>`!  (You'll forget a few times.)
 
 In the code above, if the user is signed in it will actually render to the web something like:
 
-```html
-<ul>
-  <li>Bob</li>
-  <li>Joe</li>
-  <li>Nancy</li>
-</ul>
-```
+~~~html
+  <ul>
+    <li>Bob</li>
+    <li>Joe</li>
+    <li>Nancy</li>
+  </ul>
+~~~
 
 If the user isn't signed in, it'll be the much shorter:
 
-```html
-<strong>You must sign in!</strong>
-```
+~~~html
+  <strong>You must sign in!</strong>
+~~~
 
-In the above code, if we had accidentally used `<%=` in the loop line, e.g. `<%= @users.each do |user| %>` it would run the code fine, but because `each` returns the original collection, we'd also see a dump of our `@users` variable on our page (not very professional). It'll happen to you several times and you'll learn quick.
+In the above code, if we had accidentally used `<%=` in the loop line, e.g. `<%= @users.each do |user| %>` it would run the code fine, but because `each` returns the original collection, we'd also see a dump of our `@users` variable on our page (not very professional).  It'll happen to you several times and you'll learn quick.
 
 ### How do preprocessors work?
 
-The important thing to note about the above code execution is that it is all done on the server BEFORE the final HTML file is shipped over to the browser (part of the Asset Pipeline, covered in the next lesson). That's because, when you render your template in Rails, it first runs "preprocessors" like ERB. It knows you want to preprocess the file because it has the extension `.html.erb`.
+The important thing to note about the above code execution is that it is all done on the server BEFORE the final HTML file is shipped over to the browser (part of the Asset Pipeline, covered in the next lesson).  That's because, when you render your template in Rails, it first runs "preprocessors" like ERB.  It knows you want to preprocess the file because it has the extension `.html.erb`.  
 
-Rails starts from the outside in with extra extensions. So it first processes the file using ERB, then treats it as regular HTML. That's fine because ERB by definition outputs good clean HTML, like we saw above.
+Rails starts from the outside in with extra extensions.  So it first processes the file using ERB, then treats it as regular HTML.  That's fine because ERB by definition outputs good clean HTML, like we saw above.  
 
-There are other preprocessors you'll run into as well. `.css.scss` files use the SASS preprocessor and become regular CSS files. `.js.coffee` files, which use the Coffeescript preprocessor, become regular JavaScript after being run. In both these cases, the preprocessor's language makes your life easier by giving you some additional tools you can use (like having loops and working with variables) and compiles back down into a plain vanilla CSS or JavaScript or HTML.
+There are other preprocessors you'll run into as well.  `.css.scss` files use the SASS preprocessor and become regular CSS files.  `.js.coffee` files, which use the Coffeescript preprocessor, become regular JavaScript after being run.  In both these cases, the preprocessor's language makes your life easier by giving you some additional tools you can use (like having loops and working with variables) and compiles back down into a plain vanilla CSS or JavaScript or HTML.
 
-The point is, there are many different preprocessors. They are usually gems that either already come with Rails or can easily be attached to it. Rails then runs them automatically, so all you have to worry about is whether your file has the right extension(s) to tell the preprocessor to run.
+The point is, there are many different preprocessors.  They are usually gems that either already come with Rails or can easily be attached to it.  Rails then runs them automatically, so all you have to worry about is whether your file has the right extension(s) to tell the preprocessor to run.  
 
 ### View partials
 
-Another nice thing you can do in Rails is break apart your views into partials. This helps you on several levels -- it makes your code more concise and easier to read, and also lets you reuse certain common patterns. One example is the form for creating or editing users. Both the `#new` and `#edit` actions need to render some sort of form for the user, and usually that form is almost exactly the same. So often people will turn that form into a new file called something like `_user_form.html.erb` and then just call that in both the `new.html.erb` and `edit.html.erb` view templates where it's needed.
+Another nice thing you can do in Rails is break apart your views into partials.  This helps you on several levels -- it makes your code more concise and easier to read, and also lets you reuse certain common patterns.  One example is the form for creating or editing users.  Both the `#new` and `#edit` actions need to render some sort of form for the user, and usually that form is almost exactly the same.  So often people will turn that form into a new file called something like `_user_form.html.erb` and then just call that in both the `new.html.erb` and `edit.html.erb` view templates where it's needed.
 
-Pulling back a bit, partials are just HTML files that aren't meant to be complete but can be shared by other files. You would call a partial by writing something like:
+Pulling back a bit, partials are just HTML files that aren't meant to be complete but can be shared by other files.  You would call a partial by writing something like:
 
-```erb
+~~~erb
   # app/views/users/new.html.erb
   <div class="new-user-form">
     <%= render "user_form" %>
   </div>
-```
+~~~
 
-There are a couple of syntax oddities you need to pay attention to. The view partial file is named with an underscore like `_user_form.html.erb` but gets called using just the core portion of the name, e.g. `user_form` in the example above.
+There are a couple of syntax oddities you need to pay attention to.  The view partial file is named with an underscore like `_user_form.html.erb` but gets called using just the core portion of the name, e.g. `user_form` in the example above.  
 
-If there is no directory specified in partial's name, Rails will only look in the same folder as whichever view called it, e.g. `app/views/users`. Sometimes it makes sense to share partials across multiple view templates that are in multiple controllers, so you save them in their own folder called `app/views/shared` and would then render them using the code `<%= render "shared/some_partial"%>`.
+If there is no directory specified in partial's name, Rails will only look in the same folder as whichever view called it, e.g. `app/views/users`.  Sometimes it makes sense to share partials across multiple view templates that are in multiple controllers, so you save them in their own folder called `app/views/shared` and would then render them using the code `<%= render "shared/some_partial"%>`.
 
 ### Passing local variables to partials
 
-There's a lot you can do with partials and we won't dive into it all here, but one thing that you might find yourself doing a lot is passing variables to partials. A partial has access to all the variables that the calling view template does, but do NOT rely on them! What if your partial is used by a different controller that uses a different structure for its instance variables? It's bad code to expect an instance variable like `@user` to be there in the partial all the time. That means you've got to explicitly pass the partial whichever variables you want it to have access to.
+There's a lot you can do with partials and we won't dive into it all here, but one thing that you might find yourself doing a lot is passing variables to partials.  A partial has access to all the variables that the calling view template does, but do NOT rely on them!  What if your partial is used by a different controller that uses a different structure for its instance variables?  It's bad code to expect an instance variable like `@user` to be there in the partial all the time. That means you've got to explicitly pass the partial whichever variables you want it to have access to.  
 
-In the example above, you most likely want to pass the `@user` variable to the partial so your code can render the right kind of form. `render` is just a regular method and it lets you pass it an [options hash](https://stackoverflow.com/questions/18407618/what-are-options-hashes). One of those options is the `:locals` key, which will contain the variables you want to pass. Your code might change to look like:
+In the example above, you most likely want to pass the `@user` variable to the partial so your code can render the right kind of form. `render` is just a regular method and it lets you pass it an [options hash](https://stackoverflow.com/questions/18407618/what-are-options-hashes).  One of those options is the `:locals` key, which will contain the variables you want to pass.  Your code might change to look like:
 
-```erb
+~~~erb
   <%= render partial: "shared/your_partial", :locals => { :user => user } %>
-```
+~~~  
 
-To use the variable in your partial file, you drop the `@` and call it like a normal variable. Note that you should use the `:locals` option if you're calling the `render` method with a `:partial` key.
+To use the variable in your partial file, you drop the `@` and call it like a normal variable. Note that you should use the `:locals` option if you're calling the `render` method with a `:partial` key. 
 
 There is a `render` shortcut that allows you to simply pass in variables without the need of using the `:locals` option:
 
-```erb
+~~~erb
   <%= render "shared/your_partial", :user => user %>
-```
+~~~
+
 
 ### Implicit partials
 
-As usual, there are some things you would end up doing so many times that Rails has given you a shortcut. One of these is the act of rendering a model object like a User or a Post. If you want a list of all your users, you could write out the HTML and ERB code for displaying a single user's first name, last name, email etc. many times directly in your `app/views/users/index.html.erb` file or you could keep that code in some sort of `each` loop.
+As usual, there are some things you would end up doing so many times that Rails has given you a shortcut.  One of these is the act of rendering a model object like a User or a Post.  If you want a list of all your users, you could write out the HTML and ERB code for displaying a single user's first name, last name, email etc. many times directly in your `app/views/users/index.html.erb` file or you could keep that code in some sort of `each` loop.  
 
-But it's usually best to make the User into its own partial called `_user.html.erb` so you can re-use it in other cases as well. The basic way of calling this might be something just like we saw above, which looks like:
+But it's usually best to make the User into its own partial called `_user.html.erb` so you can re-use it in other cases as well.  The basic way of calling this might be something just like we saw above, which looks like:
 
-```erb
+~~~erb
   # app/views/index.html.erb
   <h1>Users</h1>
   <ul>
@@ -130,20 +131,20 @@ But it's usually best to make the User into its own partial called `_user.html.e
       <%= render "user", :locals => {:user => user} %>
     <% end %>
   </ul>
-```
+~~~
 
 And in your partial:
 
-```erb
+~~~erb
   # app/views/_user.html.erb
   <li><%= "#{user.first_name} #{user.last_name}, #{user.email}" %></li>
-```
+~~~
 
 It may seem strange to have only one line in a partial, but trust me that it usually doesn't stay that way for long so it's worth getting the hang of.
 
-So if that's the basic way, what's the magical Rails way? Just tell it to render the User object directly, e.g.:
+So if that's the basic way, what's the magical Rails way?  Just tell it to render the User object directly, e.g.:
 
-```erb
+~~~erb
   # app/views/index.html.erb
   <h1>Users</h1>
   <ul>
@@ -151,59 +152,59 @@ So if that's the basic way, what's the magical Rails way? Just tell it to render
       <%= render user %>     <!-- Lots less code -->
     <% end %>
   </ul>
-```
+~~~
 
 Rails then looks for the `_user.html.erb` file in the current directory and passes it the `user` variable automatically.
 
-What if you want to render a whole bunch of users like we just did? Rails also does that for you the same way, saving you the trouble of writing out your own `each` loop like we did above. Simply write:
+What if you want to render a whole bunch of users like we just did?  Rails also does that for you the same way, saving you the trouble of writing out your own `each` loop like we did above.  Simply write:
 
-```erb
+~~~erb
   # app/views/index.html.erb
   <h1>Users</h1>
   <ul>
     <%= render @users %>
   </ul>
-```
+~~~
 
-In that situation, Rails not only finds the `_user.html.erb` file and passes it the correct `user` variable to use, it also loops over all the users in your `@user` collection for you. Pretty handy.
+In that situation, Rails not only finds the `_user.html.erb` file and passes it the correct `user` variable to use, it also loops over all the users in your `@user` collection for you.  Pretty handy.
 
 ### Helper methods
 
-`render`ing partials isn't the only method you can call from within a view. Rails has a bunch of really handy helper methods that are available for you to use in the view. A few of the most common:
+`render`ing partials isn't the only method you can call from within a view.  Rails has a bunch of really handy helper methods that are available for you to use in the view.  A few of the most common:
 
 #### `#link_to`
 
-`link_to` creates an anchor tag URL. Instead of writing:
+`link_to` creates an anchor tag URL.  Instead of writing:
 
-```erb
+~~~erb
   <a href="<%= users_path %>">See All Users</a>
-```
+~~~
 
 You write:
 
-```erb
+~~~erb
   <%= link_to "See All Users", users_path %>
-```
+~~~
 
-It's the Rails way. And recall that `users_path` generates a relative URL like `/users` whereas `users_url` generates a full URL like `http://www.yourapp.com/users`. In most cases, it isn't an important distinction because your browser can handle both, but make sure you understand the difference.
+It's the Rails way.  And recall that `users_path` generates a relative URL like `/users` whereas `users_url` generates a full URL like `http://www.yourapp.com/users`.  In most cases, it isn't an important distinction because your browser can handle both, but make sure you understand the difference.
 
 ### Asset tags
 
-As you may have seen in the application layout file we talked about above, Rails gives you helper methods that output HTML tags to grab CSS or JavaScript files. You can also grab images. These are called Asset Tags. We'll get into the "Asset Pipeline" a bit later, but basically these tags locate those files for you based on their name and render the proper HTML tag.
+As you may have seen in the application layout file we talked about above, Rails gives you helper methods that output HTML tags to grab CSS or JavaScript files.  You can also grab images.  These are called Asset Tags.  We'll get into the "Asset Pipeline" a bit later, but basically these tags locate those files for you based on their name and render the proper HTML tag.
 
-```erb
+~~~erb
   <%= stylesheet_link_tag "your_stylesheet" %>
   <%= javascript_include_tag "your_javascript" %>
   <%= image_tag "happy_cat.jpg" %>
-```
+~~~
 
 Will render something like:
 
-```html
-<link href="/assets/your_stylesheet.css" media="all" rel="stylesheet" />
-<script src="/assets/your_javascript.js"></script>
-<img src="/assets/happy_cat.jpg" />
-```
+~~~html
+  <link href="/assets/your_stylesheet.css" media="all" rel="stylesheet">
+  <script src="/assets/your_javascript.js"></script>
+  <img src="/assets/happy_cat.jpg">
+~~~
 
 Note: in production, your stylesheet and JavaScript will all get mashed into one strangely-named file, so don't be alarmed if it's named something like `/assets/application-485ea683b962efeaa58dd8e32925dadf`
 
@@ -213,33 +214,31 @@ Rails offers several different helpers that help you create forms, and we'll go 
 
 ### Assignment
 
-Now that you've got a taste of the high-level stuff, read through the Rails Guides for a more detailed look at things. The chapter below will actually start in the controller, where you need to let it know WHICH view file you want to render. The second half of the chapter gets more into the view side of things.
+Now that you've got a taste of the high-level stuff, read through the Rails Guides for a more detailed look at things.  The chapter below will actually start in the controller, where you need to let it know WHICH view file you want to render.  The second half of the chapter gets more into the view side of things.
 
 <div class="lesson-content__panel" markdown="1">
 
-1. Read the [Rails Guide chapter on Layouts and Rendering](http://guides.rubyonrails.org/layouts_and_rendering.html), sections 1 through 3.4. You can certainly skim when they start going over all the many different options you can pass to a given function... it's good to know what they are and where you can find them, but you don't need to memorize all of them. Usually you'll have something that you want to do, Google it, and find a Stack Overflow post that shows you the option you can use.
+  1. Read the [Rails Guide chapter on Layouts and Rendering](http://guides.rubyonrails.org/layouts_and_rendering.html), sections 1 through 3.4.  You can certainly skim when they start going over all the many different options you can pass to a given function... it's good to know what they are and where you can find them, but you don't need to memorize all of them.  Usually you'll have something that you want to do, Google it, and find a Stack Overflow post that shows you the option you can use.
 </div>
 
 ### Conclusion
 
-Views in general make up the user-facing side of your app. It can be a bit tricky at first to imagine how you choose which view to render, what to include in that view and how to use partials, but a few iterations of working with Rails will show you the conventions pretty quickly. Views will become second nature to you.
+Views in general make up the user-facing side of your app.  It can be a bit tricky at first to imagine how you choose which view to render, what to include in that view and how to use partials, but a few iterations of working with Rails will show you the conventions pretty quickly.  Views will become second nature to you.
 
 ### Additional resources
-
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
-- [Stack Overflow Post on Views](https://stackoverflow.com/questions/14429910/an-alternate-explanation-to-rails-layouts-rendering-partials-templates-and-v)
-- [Video on the Relationship Between Views and Controllers](https://www.youtube.com/watch?v=mRJSovhdzWc&ab_channel=GoRails)
-- [Video on ERB Tags](https://www.youtube.com/watch?v=na28woOGPUw&ab_channel=NoobandTube) - (this video will require you to turn your volume up)
-- [Introduction to Ruby on Rails from freeCodeCamp](https://youtu.be/fmyvWz5TUWg) - If you'd like a deeper dive into routing, MVC, CRUD and partials watch the first 60 minutes of this video which provides a good wrap up for what we've been learning so far. You'll also get to create a simple Rails app from scratch if you'd like some extra practice.
+* [Stack Overflow Post on Views](https://stackoverflow.com/questions/14429910/an-alternate-explanation-to-rails-layouts-rendering-partials-templates-and-v)
+* [Video on the Relationship Between Views and Controllers](https://www.youtube.com/watch?v=mRJSovhdzWc&ab_channel=GoRails)
+* [Video on ERB Tags](https://www.youtube.com/watch?v=na28woOGPUw&ab_channel=NoobandTube) - (this video will require you to turn your volume up)
+* [Introduction to Ruby on Rails from freeCodeCamp](https://youtu.be/fmyvWz5TUWg) - If you'd like a deeper dive into routing, MVC, CRUD and partials watch the first 60 minutes of this video which provides a good wrap up for what we've been learning so far. You'll also get to create a simple Rails app from scratch if you'd like some extra practice.
 
 ### Knowledge check
-
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
-- <a class="knowledge-check-link" href="#how-do-preprocessors-work">How do you make sure a preprocessor runs on your view file?</a>
-- <a class="knowledge-check-link" href="#preprocessors">What is the difference between `<%`, `<%=` and `<%#`? </a>
-- <a class="knowledge-check-link" href="https://guides.rubyonrails.org/layouts_and_rendering.html#understanding-yield">What does including `<%= yield %>` in a layout do?</a>
-- <a class="knowledge-check-link" href="https://guides.rubyonrails.org/layouts_and_rendering.html#using-partials">Why do we use partials?</a>
-- <a class="knowledge-check-link" href="https://guides.rubyonrails.org/layouts_and_rendering.html#rendering-collections">What is the shortcut for rendering a collection as a series of partials?</a>
-- <a class="knowledge-check-link" href="#linkto">How do you dynamically link to another page of your Rails app?</a>
+* <a class="knowledge-check-link" href="#how-do-preprocessors-work">How do you make sure a preprocessor runs on your view file?</a>
+* <a class="knowledge-check-link" href="#preprocessors">What is the difference between `<%`, `<%=` and `<%#`? </a>
+* <a class="knowledge-check-link" href="https://guides.rubyonrails.org/layouts_and_rendering.html#understanding-yield">What does including `<%= yield %>` in a layout do?</a>
+* <a class="knowledge-check-link" href="https://guides.rubyonrails.org/layouts_and_rendering.html#using-partials">Why do we use partials?</a>
+* <a class="knowledge-check-link" href="https://guides.rubyonrails.org/layouts_and_rendering.html#rendering-collections">What is the shortcut for rendering a collection as a series of partials?</a>
+* <a class="knowledge-check-link" href="#linkto">How do you dynamically link to another page of your Rails app?</a>


### PR DESCRIPTION
## Because
Changes the headings to sentence case to follow the Style Guide requirements.

## This PR
* Change the headings in the Introduction section of the Ruby on Rails course to sentence case.
* Change the headings in the Rails Basics section of the Ruby on Rails course to sentence case.

## Issue
Related to https://github.com/TheOdinProject/curriculum/issues/26169


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
