### PR TITLE
Fix: grammar an vs a useEffect

### DIFF
--- a/react/states_and_effects/how_to_deal_with_side_effects.md
+++ b/react/states_and_effects/how_to_deal_with_side_effects.md
@@ -12,7 +12,7 @@ This section contains a general overview of topics that you will learn in this l
 
 *   What are effects?
 *   How are effects used in React?
-*   What are the different parts of an `useEffect` hook?
+*   What are the different parts of a `useEffect` hook?
 *   When should I use an effect?
 
 ### Using effect saves the day
@@ -39,7 +39,7 @@ export default function Clock() {
 
 Alas, we see our counter going berserk. The reason this occurs is that we try to **manipulate the state during render**. As we know, the component gets torn down and re-rendered every time the state updates, and we are updating the state every second, thus incrementing rapidly.
 
-This is where the `useEffect` hook swoops in to save us. We can wrap this calculation inside an `useEffect` hook to move it outside the rendering calculation. It accepts a callback function with all the calculations.
+This is where the `useEffect` hook swoops in to save us. We can wrap this calculation inside a `useEffect` hook to move it outside the rendering calculation. It accepts a callback function with all the calculations.
 
 ~~~jsx
 import React, { useEffect, useState } from "react";
@@ -230,7 +230,7 @@ Let us address a few cases where `useEffect` does not need to be used.
 This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
 
 *   <a class="knowledge-check-link" href="#introduction">What is an effect?</a>
-*   <a class="knowledge-check-link" href="#body-of-an-useEffect">What constitutes an `useEffect` hook?</a>
+*   <a class="knowledge-check-link" href="#body-of-an-useEffect">What constitutes a `useEffect` hook?</a>
 *   <a class="knowledge-check-link" href="#but-do-we-need-the-effect">What is the one question we can ask to know when to use an effect?</a>
 *   <a class="knowledge-check-link" href="#lifting-the-state">What do we mean by lifting up the state?</a>
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
It should be "a useEffect" instead of "an useEffect"

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- changes "an useEffect" to "a useEffect" throughout the lesson

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
