### PR TITLE
Ruby/Rails Path: Intermediate Git, Testing Ruby with RSpec, Conclusion: Rewrite headings to follow sentence case Style Guide

### DIFF
--- a/git/intermediate_git/a_deeper_look_at_git.md
+++ b/git/intermediate_git/a_deeper_look_at_git.md
@@ -126,7 +126,7 @@ The last part of reset we want to touch upon is `git reset --hard`. What this do
 
 Thus far you've been working with remote repositories each time you've pushed or pulled from your own GitHub repository while working on the curriculum's various projects. In this section we're going to cover some slightly more advanced topics, which you might not have yet encountered or had to use.
 
-#### git push -\-force
+#### Git push -\-force
 
 Let's say you're no longer working on a project all by yourself, but with someone else. You want to push a branch you've made changes on to a remote repository. Normally Git will only let you push your changes if you've already updated your local branch with the latest commits from this remote.
 

--- a/ruby/conclusion/conclusion.md
+++ b/ruby/conclusion/conclusion.md
@@ -7,7 +7,7 @@ If you know Ruby, the world is sort of opened up for you.  Want to learn Python?
 
 Before you move on, we would like your feedback [here](https://docs.google.com/forms/d/e/1FAIpQLSdYksRBRg_0GzcYxzm5Csikfhj2Nceh2ifMYRmfMH6quwRRDw/viewform?usp=sf_link). Getting user (you) feedback is important so we can continue to improve the curriculum and get an idea of your experience. So that's it, you're more than ready to go ahead and take on Rails.  **Congratulations!!!**
 
-### Additional Resources
+### Additional resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
 * [Ruby Best Practices book by Gregory Brown](http://it-ebooks.info/book/178/).

--- a/ruby/conclusion/project_ruby_final.md
+++ b/ruby/conclusion/project_ruby_final.md
@@ -1,4 +1,4 @@
-### You've come a long way.  Now it's time to prove how much you've learned.
+### You've come a long way.  Now it's time to prove how much you've learned
 
 Chess is a classic game that appears very complicated at first but can be broken down into logical steps that make it a great Ruby capstone project.  If you've never played, be sure to read up on the rules (see the [Wikipedia Page](http://en.wikipedia.org/wiki/Chess)) first.
 
@@ -21,7 +21,7 @@ This is a great project to have as a part of your portfolio going forward becaus
   8. (Optional extension) Build a very simple AI computer player (perhaps who does a random legal move)
 </div>
 
-### Additional Resources
+### Additional resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
 * [Illustrated rules of Chess](http://www.chessvariants.org/d.chess/chess.html)

--- a/ruby/testing_ruby_with_rspec/introduction_to_rspec.md
+++ b/ruby/testing_ruby_with_rspec/introduction_to_rspec.md
@@ -2,7 +2,7 @@
 
 In the previous lesson, we established the utility of [test-driven development](https://en.wikipedia.org/wiki/Test-driven_development) (TDD) in maintaining your code and sanity. In this lesson, we'll introduce you to your new best friend, the [RSpec](http://rspec.info/) testing framework. It's one of the most popular testing frameworks, having been downloaded more than [480 million times](https://rubygems.org/gems/rspec), at the time of this writing, and having been ported for use in [Rails testing](https://rubygems.org/gems/rspec-rails).
 
-### Learning Outcomes
+### Learning outcomes
 
 _Look through these now and use them to guide your learning. By the end of this lesson, expect to:_
 
@@ -235,7 +235,7 @@ It's time to put your newfound knowledge to good use. Let's break our `Calculato
 4. RSpec reads command line configurations from `.rspec`, one of the two files generated when RSpec is initialized in a project. If you liked the output you got with `--format documentation`, you can use the `.rspec` file to hold that flag. In doing so, you won't have to type it in every time you run your test suite. Open the file in your text editor and, on a new line, add `--format documentation`. For more information on configuring RSpec, [see the docs here](http://rspec.info/features/3-12/rspec-core/configuration/).
 </div>
 
-### Additional Resources
+### Additional resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
 - [This Youtube video](https://www.youtube.com/watch?v=K6RPMhcRICE) gives an excellent overview of the fundamentals of Rspec, and gives a brief overview of some concepts that will be mentioned in the next lesson.
@@ -245,7 +245,7 @@ This section contains helpful links to other content. It isn't required, so cons
 - [This RSpec Cheat Sheet](https://devhints.io/rspec) should help you avoid Googling every new bit of syntax.
 - Solidify these concepts with a [shameless plug](https://medium.com/@mindovermiles262/getting-started-with-rspec-part-1-9418909f5e53) from another Odin Project contributor.
 
-### Knowledge Checks 
+### Knowledge check
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
 - <a class='knowledge-check-link' href='#tests-folder'>What do you name the folder that contains your test files?</a>

--- a/ruby/testing_ruby_with_rspec/project_connect_four.md
+++ b/ruby/testing_ruby_with_rspec/project_connect_four.md
@@ -1,4 +1,4 @@
-### Warmup: Time Traveling
+### Warmup: time traveling
 
 A good way to get familiar with and begin contributing to a new project is to write tests for it.  It's also the best way to become familiar with a new code base, something you'll have to do when you start working.  It's pretty common for test code to ultimately take up twice as many lines of code as the actual project code!
 
@@ -32,7 +32,7 @@ Only write exactly enough code to make your test pass.  Oftentimes, you'll end u
   1. Build Connect Four!  Just be sure to keep it TDD.
 </div>
 
-### Additional Resources
+### Additional resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
 * [RSpec Mock example SO question](http://stackoverflow.com/questions/3622604/rspec-mock-object-example)

--- a/ruby/testing_ruby_with_rspec/test_driven_development.md
+++ b/ruby/testing_ruby_with_rspec/test_driven_development.md
@@ -4,13 +4,13 @@ Hopefully, you've been having fun developing in Ruby thus far. Perhaps one thing
 
 Folks, we're here to tell you there *IS* a better way. Hoping is for that exam you didn't study for and took by the seat of your pants. **Knowing** is test-driven development.
 
-### Learning Outcomes
+### Learning outcomes
 *Look through these now and use them to guide your learning. By the end of this lesson, expect to:*
 
 * Understand what test-driven development (TDD) is, and why it's important.
 * Understand the three stages of a TDD cycle.
 
-### What is Test-Driven Development?
+### What is test-driven development?
 
 [Test-Driven Development (TDD)](https://en.wikipedia.org/wiki/Test-driven_development) is a process and technique of software development that relies on the repetition of a very short and specific development cycle. In each cycle, requirements (i.e., what you want your code to do) are turned into specific test cases first. These requirements could be anything from an entire feature that requires end-to-end (E2E) testing, such as tests that cover a user logging into your website successfully AND unsuccessfully, to a new Ruby class you've devised, for which unit tests might suffice. Either way, the test suite for these requirements fail initially, since actual code hasn't been written yet. 
 
@@ -18,7 +18,7 @@ Once the code is written and passes our test suite, you can move onto refactorin
 
 Colloquially, this process is often referred to as the "**red-green-refactor**" cycle. That's all it is, in a nutshell: automated tests **drive** the design of software. You don't need to know how the entire architecture of your sweet, new, industry-breaking application will work. Your application only has to be broken down, step-by-step, until small units are identified and covered by tests.
 
-### Why Is It Important?
+### Why is it important?
 
 Even if TDD intuitively seems like good practice, its utility is hotly debated even today. 
 
@@ -41,13 +41,13 @@ As usual, it depends. Still, here are some reasons we think it might be importan
 
 </div>
 
-### Additional Resources
+### Additional resources
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
 * [This video](https://www.youtube.com/watch?v=PCEHRFHKZSk) that provides counter arguments for DHH’s [“TDD is Dead. Long Live Testing”](https://dhh.dk/2014/tdd-is-dead-long-live-testing.html)
 * [This series of talks](https://martinfowler.com/articles/is-tdd-dead/) that provides an even more rounded take on TDD.
    
-### Knowledge Check
+### Knowledge check
 
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 


### PR DESCRIPTION
## Because
Changed sentence case for headings to follow the Style Guide.


## This PR

* Changes headings in Git/Intermediate Git to sentence case
* Changes headings in Ruby/Testing Ruby with RSpec to sentence case
* Changes headings in Ruby/Conclusion with RSpec to sentence case

## Issue

Related to #26169 


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
