### PR TITLE
JS Battleships: Reword instructions for choice between class/factory

### DIFF
--- a/javascript/testing_javascript/project_battleship.md
+++ b/javascript/testing_javascript/project_battleship.md
@@ -8,12 +8,12 @@ We have not yet discussed testing the appearance of a webpage.  Doing this requi
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">
-1. Begin your app by creating the `Ship` factory function.
+1. Begin your app by creating the `Ship` class/factory (your choice).
    1. Your 'ships' will be objects that include their length, the number of times they've been hit and whether or not they've been sunk.
    2. __REMEMBER__ you only have to test your object's public interface.  Only methods or properties that are used outside of your 'ship' object need unit tests.
    3. Ships should have a `hit()` function that increases the number of 'hits' in your ship.
    4. `isSunk()` should be a function that calculates it based on their length and the number of 'hits'.
-2. Create `Gameboard` factory.
+2. Create `Gameboard` class/factory.
    1. Note that we have not yet created any User Interface.  We should know our code is coming together by running the tests.  You shouldn't be relying on `console.log` or DOM methods to make sure your code is doing what you expect it to.
    2. Gameboards should be able to place ships at specific coordinates by calling the ship factory function.
    3. Gameboards should have a `receiveAttack` function that takes a pair of coordinates, determines whether or not the attack hit a ship and then sends the 'hit' function to the correct ship, or records the coordinates of the missed shot.
@@ -21,11 +21,11 @@ We have not yet discussed testing the appearance of a webpage.  Doing this requi
    5. Gameboards should be able to report whether or not all of their ships have been sunk.
 3. Create `Player`.
    1. Players can take turns playing the game by attacking the enemy Gameboard.
-   2. The game is played against the computer, so make the 'computer' capable of making random plays.  The AI does not have to be smart, but it should know whether or not a given move is legal. (i.e. it shouldn't shoot the same coordinate twice).
+   2. The game is played against the computer, so make the 'computer' capable of making random plays.  The AI does not have to be smart, but it should know whether or not a given move is legal (i.e. it shouldn't shoot the same coordinate twice).
 4. Create the main game loop and a module for DOM interaction.
    1. At _this_ point it is appropriate to begin crafting your User Interface.
    2. The game loop should set up a new game by creating Players and Gameboards.  For now just populate each Gameboard with predetermined coordinates.  You can implement a system for allowing players to place their ships later.
-   3. We'll leave the HTML implementation up to you for now, but you should display both the player's boards and render them using information from the Gameboard class.
+   3. We'll leave the HTML implementation up to you for now, but you should display both the player's boards and render them using information from the Gameboard class/factory.
       1. You need methods to render the gameboards and to take user input for attacking.  For attacks, let the user click on a coordinate in the enemy Gameboard.
    4. The game loop should step through the game turn by turn using only methods from other objects.  If at any point you are tempted to write a new function inside the game loop, step back and figure out which class or module that function should belong to.
    5. Create conditions so that the game ends once one player's ships have all been sunk.  This function is appropriate for the Game module.


### PR DESCRIPTION
## Because
Improve wording in the project instructions the explicitly allow learner choice over how they instantiate their objects and stay consistent throughout the steps.


## This PR
- Reword calls for a factory function to `class/factory`
- Fix punctuation


## Issue
Closes #26126

## Additional Information
N/A


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
