### PR TITLE
React Components: Emphasise component capitalisation requirement

### DIFF
--- a/react/getting_started_with_react/react_components.md
+++ b/react/getting_started_with_react/react_components.md
@@ -37,7 +37,7 @@ function Greeting() {
 
 This might look mostly familiar to you - it's a simple JavaScript function, which returns JSX. Open up the project you were working on, create a new file named `Greeting.jsx`, and in that file write your own handmade functional component. Name it whatever you wish, and have it return whatever JSX you wish. 
 
-Are you done? Check the naming of your function! Is it capitalized? Keep this key difference in mind. **React components must be capitalized** or they will not function as expected. This is so that when JSX (more on that later) is parsed, React can tell the difference between a normal HTML tag and an instance of a React component and is why we capitalized `Greeting()`.
+Are you done? Check the naming of your function! Is it capitalized? Keep this key difference in mind. **React components must be capitalized** or they will not function as expected, which is why we capitalized `Greeting()`.
 
 <div class="lesson-note">
   
@@ -79,7 +79,9 @@ ReactDOM.createRoot(document.getElementById('root')).render(
 )
 ~~~
 
-Remember that `<Greeting />` should be capitalized! Try using lower case for the import, function name and component and see what happens. Otherwise, just like that, you've successfully imported and used your first custom-made component, congratulations!
+Remember that `<Greeting />` should be capitalized! Try using lower case for the import, function name and component and see what happens! When the JSX is parsed, React uses the capitalization to tell the difference between an HTML tag and an instance of a React component - `<greeting />` is not a valid HTML tag!
+
+Otherwise, just like that, you've successfully imported and used your first custom-made component, congratulations!
 
 ### Assignment
 

--- a/react/getting_started_with_react/react_components.md
+++ b/react/getting_started_with_react/react_components.md
@@ -37,7 +37,7 @@ function Greeting() {
 
 This might look mostly familiar to you - it's a simple JavaScript function, which returns JSX. Open up the project you were working on, create a new file named `Greeting.jsx`, and in that file write your own handmade functional component. Name it whatever you wish, and have it return whatever JSX you wish. 
 
-Are you done? Check the naming of your function! Is it capitalized? Keep this key difference in mind. **React components must be capitalized** or they will not function as expected. This is so that when JSX (more on that later) is parsed, React can tell the difference between a normal HTML tag and an instance of a React component. This is why we capitalized `Greeting()`.
+Are you done? Check the naming of your function! Is it capitalized? Keep this key difference in mind. **React components must be capitalized** or they will not function as expected. This is so that when JSX (more on that later) is parsed, React can tell the difference between a normal HTML tag and an instance of a React component and is why we capitalized `Greeting()`.
 
 <div class="lesson-note">
   

--- a/react/getting_started_with_react/react_components.md
+++ b/react/getting_started_with_react/react_components.md
@@ -37,7 +37,7 @@ function Greeting() {
 
 This might look mostly familiar to you - it's a simple JavaScript function, which returns JSX. Open up the project you were working on, create a new file named `Greeting.jsx`, and in that file write your own handmade functional component. Name it whatever you wish, and have it return whatever JSX you wish. 
 
-Are you done? Check the naming of your function! Is it capitalized? Keep this key difference in mind, components that aren't capitalized might not run as expected - which is why we capitalized `Greeting()`.
+Are you done? Check the naming of your function! Is it capitalized? Keep this key difference in mind. **React components must be capitalized** or they may not function as expected, which is why we capitalized `Greeting()`.
 
 <div class="lesson-note">
   
@@ -79,7 +79,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
 )
 ~~~
 
-And just like that, you've successfully imported and used your first custom-made component, congratulations!
+Remember that `<Greeting />` should be capitalized! Try using lower case for the import, function name and component and see what happens. Otherwise, just like that, you've successfully imported and used your first custom-made component, congratulations!
 
 ### Assignment
 

--- a/react/getting_started_with_react/react_components.md
+++ b/react/getting_started_with_react/react_components.md
@@ -37,7 +37,7 @@ function Greeting() {
 
 This might look mostly familiar to you - it's a simple JavaScript function, which returns JSX. Open up the project you were working on, create a new file named `Greeting.jsx`, and in that file write your own handmade functional component. Name it whatever you wish, and have it return whatever JSX you wish. 
 
-Are you done? Check the naming of your function! Is it capitalized? Keep this key difference in mind. **React components must be capitalized** or they may not function as expected, which is why we capitalized `Greeting()`.
+Are you done? Check the naming of your function! Is it capitalized? Keep this key difference in mind. **React components must be capitalized** or they will not function as expected. This is so that when JSX (more on that later) is parsed, React can tell the difference between a normal HTML tag and an instance of a React component. This is why we capitalized `Greeting()`.
 
 <div class="lesson-note">
   

--- a/react/getting_started_with_react/react_components.md
+++ b/react/getting_started_with_react/react_components.md
@@ -6,9 +6,9 @@ In this lesson we'll be going over the basics of React components - what they do
 
 This section contains a general overview of topics that you will learn in this lesson.
 
-*   What are components?
-*   How are components created?
-*   Where do components live?
+- What are components?
+- How are components created?
+- Where do components live?
 
 ### What are components?
 
@@ -86,19 +86,19 @@ Remember that `<Greeting />` should be capitalized! Try using lower case for the
 <div class="lesson-content__panel" markdown="1">
 
 1.  It's time to create some new components! Use the same project, but play around with it, try displaying something like your favorite food.
-    *   While components normally get exported as defaults, try using some named exports instead of default exports. If you're unsure how to do this, consult your best friend: [the MDN documentation about export statements](https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/export#description)
+    - While components normally get exported as defaults, try using some named exports instead of default exports. If you're unsure how to do this, consult your best friend: [the MDN documentation about export statements](https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/export#description)
 </div>
 
 ### Knowledge check
 
 This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
 
-*   <a class="knowledge-check-link" href="#what-are-components">What does a React element look like?</a>
-*   <a class="knowledge-check-link" href="#how-to-create-components">How would you create a functional component?</a>
-*   <a class="knowledge-check-link" href="#where-do-components-live">How do you export and then import a component?</a>
+- <a class="knowledge-check-link" href="#what-are-components">What does a React element look like?</a>
+- <a class="knowledge-check-link" href="#how-to-create-components">How would you create a functional component?</a>
+- <a class="knowledge-check-link" href="#where-do-components-live">How do you export and then import a component?</a>
 
 ### Additional resources
 
 This section contains helpful links to related content. It isn’t required, so consider it supplemental.
 
-*   Geeks for Geeks has a quick [ReactJS Functional Components tutorial](https://www.geeksforgeeks.org/reactjs-functional-components/). It introduces some new ways of calling functional components you can play around with if you feel a burning desire to do so. For the time being don't worry too much about Class components, which the resource also goes into. 
+- Geeks for Geeks has a quick [ReactJS Functional Components tutorial](https://www.geeksforgeeks.org/reactjs-functional-components/). It introduces some new ways of calling functional components you can play around with if you feel a burning desire to do so. For the time being don't worry too much about Class components, which the resource also goes into. 


### PR DESCRIPTION
## Because
React components **must** be capitalised to actually work as components. The current wording I felt was quite easy to miss/gloss over so it has been reworded to bring more attention to its necessity.


## This PR
- Reworded/added some short sentences to emphasise this point to the reader
- Fixed inconsistent list styling to follow the style guide

## Issue

## Additional Information
N/A


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
