### PR TITLE
React Props: Add lesson note about prop types ESLint warning

### DIFF
--- a/react/getting_started_with_react/passing_data_between_components.md
+++ b/react/getting_started_with_react/passing_data_between_components.md
@@ -65,6 +65,11 @@ This may not seem like a huge deal right now, but what if we had 10 buttons, eac
 
 Let's see how by using props, we can account for any number of variations with a *single* button component.
 
+<div class="lesson-note" markdown="1">
+<h4>"Missing in props validation"</h4>
+You may notice squiggly lines under your props (for example under `color` and `fontSize` inside the Button component below). Hovering over these will tell you they are `missing in props validation`. For now, this can safely be ignored as it is just a default ESLint rule warning about prop types, something that will be covered later in the course.
+</div>
+
 ~~~jsx
 function Button(props) {
 


### PR DESCRIPTION
## Because
Vite ESLint default rules include warnings about missing props validation. Since prop types are not covered until later in the course, learners will benefit from knowing they can ignore this warning for now (given that many times, people have come to the Discord server concerned/to ask about it).


## This PR
- Add a lesson note to the props lesson above the first props example regarding the props validation ESLint warning


## Issue
N/A


## Additional Information
N/A


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
