### PR TITLE
React Testing-Mocking Callbacks And Components Lesson: Added a note to use vi.mock()

### DIFF
--- a/react/react_testing/mocking_callbacks_and_components.md
+++ b/react/react_testing/mocking_callbacks_and_components.md
@@ -127,6 +127,14 @@ jest.mock('../submission', () => ({ submission, isDashboardView }) => (
 
 We only render the bare minimum to realize the validity of the component we're testing. Next, we set up our props with fake data and mocked functions.
 
+<div class="lesson-note" markdown="1">
+
+#### Note
+
+The test here used `jest.mock()`. If you followed along and set up your test using vitest, you may use `vi.mock()` instead. See [vi.mock() API](https://vitest.dev/api/vi.html#vi-mock) 
+
+</div>
+
 Let's move toward our first assertion. Don't worry too much about the `ProjectSubmissionContext.Provider`. In the context of this test, its purpose is to act as a route to pass in the `allSubmissionsPath` prop. We've already identified the three points of interest that we want to test. We divide them into three test suites for readability purposes using `describe`.
 
 In the first suite, we make some assertions if the user has a submission and then some assertions if the user does not. The other suites follow a similar pattern.

--- a/react/react_testing/mocking_callbacks_and_components.md
+++ b/react/react_testing/mocking_callbacks_and_components.md
@@ -129,9 +129,9 @@ We only render the bare minimum to realize the validity of the component we're t
 
 <div class="lesson-note" markdown="1">
 
-#### Note
+#### Note - Vitest mocks
 
-The test here used `jest.mock()`. If you followed along and set up your test using vitest, you may use `vi.mock()` instead. See [vi.mock() API](https://vitest.dev/api/vi.html#vi-mock) 
+The test here used `jest.mock()`. If you followed along and set up your test using Vitest, you may use `vi.mock()` instead. See [`vi.mock()` API](https://vitest.dev/api/vi.html#vi-mock).
 
 </div>
 


### PR DESCRIPTION

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
I added a note to use vi.mock() instead of jest.mock() if people set up test using vitest.

I had some trouble using jest.mock() to mock a child component, but vi.mock() worked. I don't know 
how to make jest.mock() work here, but since we already set up test using vitest with this lesson, we can use vi.mock()
instead.

## This PR
* Added a note below the code that illustrates jest.mock().


## Issue
None

## Additional Information
None

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
