### PR TITLE
Getting Started Lesson (Node Course): replace old article links

### DIFF
--- a/nodeJS/introduction_to_nodeJS/getting_started.md
+++ b/nodeJS/introduction_to_nodeJS/getting_started.md
@@ -1,4 +1,5 @@
 ### Introduction
+
 Like we learned in the introduction lesson, Node.js is really just JavaScript. So a basic understanding of JavaScript is necessary in order to understand Node. For this reason, it is highly recommended that you take our prerequisite [JavaScript course](https://www.theodinproject.com/paths/full-stack-javascript/courses/javascript) before continuing with this course.
 
 This lesson will take you through a tutorial that will teach you the basic modules and functions that you need to get up and running with Node.js. The project that comes at the end of this section will ask you to use Node to create a basic website that will include an `Index`, `About` and `Contact Me` page. So while learning the topics in this lesson, be on the lookout for things that might help you complete the project.
@@ -6,20 +7,22 @@ This lesson will take you through a tutorial that will teach you the basic modul
 <div class="lesson-note" markdown="1">
 
 ### Important notice
+
 Recently the NodeJS.dev team removed a large amount of content from their website. Several of those removed pages were linked to in this lesson. Until we find a replacement for that content we will be linking directly to the markdown files on their GitHub repository. The formatting may look a bit odd, but the content should still be just as good.
 
 </div>
 
 ### Learning outcomes
+
 By the end of this lesson, you should be able to do the following:
 
- - Explain some things that Node.js is commonly used for.
- - Create and use modules in Node.js (both built-in and user created). 
- - Set up a basic webserver with Node.js using the HTTP module.
- - Read, create, update, and delete files from Node.js.
- - Use the URL module to parse a url address and split it into readable parts.
- - Understand how to use NPM.
- - Create, fire and listen for your own events.
+- Explain some things that Node.js is commonly used for.
+- Create and use modules in Node.js (both built-in and user created).
+- Set up a basic webserver with Node.js using the HTTP module.
+- Read, create, update, and delete files from Node.js.
+- Use the URL module to parse a url address and split it into readable parts.
+- Understand how to use NPM.
+- Create, fire and listen for your own events.
 
 ### Assignment
 
@@ -27,26 +30,25 @@ By the end of this lesson, you should be able to do the following:
 
 - Let's dive in and start looking at Node server-side code! We will be hopping around lessons in the [NodeJS.dev](https://nodejs.dev/en/learn) docs which you should follow along.
   - Get Started
-    - Learn how to run Node.js scripts from the terminal in [this](https://github.com/nodejs/nodejs.dev/blob/aa4239e87a5adc992fdb709c20aebb5f6da77f86/content/learn/command-line/node-run-cli.en.md) lesson.
-    - Learn quickly about .env files and how we use them [here](https://github.com/nodejs/nodejs.dev/blob/aa4239e87a5adc992fdb709c20aebb5f6da77f86/content/learn/command-line/node-environment-variables.en.md)! This will become very important in the future when working with databases and other sensitive credentials!
+    - Learn how to run Node.js scripts from the terminal in [this](https://nodejs.dev/en/learn/run-nodejs-scripts-from-the-command-line/) lesson.
+    - Learn quickly about .env files and how we use them [here](https://nodejs.dev/en/learn/how-to-read-environment-variables-from-nodejs/)! This will become very important in the future when working with databases and other sensitive credentials!
   - HTTP Module
     - Learn [how to make HTTP requests with Node](https://github.com/nodejs/nodejs.dev/blob/aa4239e87a5adc992fdb709c20aebb5f6da77f86/content/learn/node-js-web-server/node-make-http-requests.en.md).
   - File System
     - First, take a look at the [fs module](https://github.com/nodejs/nodejs.dev/blob/aa4239e87a5adc992fdb709c20aebb5f6da77f86/content/learn/node-js-modules/node-module-fs.en.md) that we use heavily for working with files in Node.
-    - Then, let's start [writing files](https://github.com/nodejs/nodejs.dev/blob/aa4239e87a5adc992fdb709c20aebb5f6da77f86/content/learn/manipulating-files/node-writing-files.en.md) in Node.
-    - Finally, we'll learn how to [read files](https://github.com/nodejs/nodejs.dev/blob/aa4239e87a5adc992fdb709c20aebb5f6da77f86/content/learn/manipulating-files/node-reading-files.en.md).
+    - Then, let's start [writing files](https://nodejs.dev/en/learn/writing-files-with-nodejs/) in Node.
+    - Finally, we'll learn how to [read files](https://nodejs.dev/en/learn/reading-files-with-nodejs/).
   - The URL Class
     - Check out this [documentation](https://nodejs.org/api/url.html#url_the_whatwg_url_api) on the URL class. Play with the code samples to see how it works!
   - NPM
-    - Let's get an [introduction](https://github.com/nodejs/nodejs.dev/blob/aa4239e87a5adc992fdb709c20aebb5f6da77f86/content/learn/node-js-package-manager/npm.en.md) to NPM.
+    - Let's get an [introduction](https://nodejs.dev/en/learn/an-introduction-to-the-npm-package-manager/) to NPM.
     - After that, it's time to quickly get introduced to the [package.json file](https://github.com/nodejs/nodejs.dev/blob/aa4239e87a5adc992fdb709c20aebb5f6da77f86/content/learn/node-js-package-manager/package-json.en.md).
     - And the differences between [NPM global and local packages](https://github.com/nodejs/nodejs.dev/blob/aa4239e87a5adc992fdb709c20aebb5f6da77f86/content/learn/node-js-package-manager/npm-packages-local-global.en.md).
   - Events
-    - Follow along the [Event Emitter](https://github.com/nodejs/nodejs.dev/blob/aa4239e87a5adc992fdb709c20aebb5f6da77f86/content/learn/asynchronous-work/node-event-emitter.en.md) section.
+    - Follow along the [Event Emitter](https://nodejs.dev/en/learn/the-nodejs-event-emitter/) section.
     - Look into [this](https://github.com/nodejs/nodejs.dev/blob/aa4239e87a5adc992fdb709c20aebb5f6da77f86/content/learn/node-js-modules/node-module-events.en.md) section to see the `events` module.
-    
 - Optional Extra Credit!
-  - Although a bit outdated, the W3 Schools introduction to Node.js is super useful!  Go to the [W3 Schools node tutorial](https://www.w3schools.com/nodejs/default.asp) and code along with the following lessons (which should be listed on the sidebar of their site). Specifically, work from the **Node.js Intro** through to **Node.js Events**. You can look at the **File Uploads** and **Email** sections if you're feeling particularly ambitious! **NOTE**: The URL module is very outdated. Refer to the earlier link if you run into issues in the Node.js URL Module from W3.
+  - Although a bit outdated, the W3 Schools introduction to Node.js is super useful! Go to the [W3 Schools node tutorial](https://www.w3schools.com/nodejs/default.asp) and code along with the following lessons (which should be listed on the sidebar of their site). Specifically, work from the **Node.js Intro** through to **Node.js Events**. You can look at the **File Uploads** and **Email** sections if you're feeling particularly ambitious! **NOTE**: The URL module is very outdated. Refer to the earlier link if you run into issues in the Node.js URL Module from W3.
 
 </div>
 
@@ -54,14 +56,13 @@ By the end of this lesson, you should be able to do the following:
 
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
-
 - <a class="knowledge-check-link" href="https://github.com/nodejs/nodejs.dev/blob/aa4239e87a5adc992fdb709c20aebb5f6da77f86/content/learn/node-js-modules/node-module-fs.en.md">What is a File System Module? How and why would you use it?</a>
 - <a class="knowledge-check-link" href="https://github.com/nodejs/nodejs.dev/blob/aa4239e87a5adc992fdb709c20aebb5f6da77f86/content/learn/node-js-package-manager/npm-packages-local-global.en.md">What is the command for installing a package locally in with npm?</a>
 - <a class="knowledge-check-link" href="https://github.com/nodejs/nodejs.dev/blob/aa4239e87a5adc992fdb709c20aebb5f6da77f86/content/learn/node-js-package-manager/npm-packages-local-global.en.md">What is the command for installing a package globally in with npm?</a>
 - <a class="knowledge-check-link" href="https://github.com/nodejs/nodejs.dev/blob/aa4239e87a5adc992fdb709c20aebb5f6da77f86/content/learn/node-js-package-manager/npm-packages-local-global.en.md">What is the difference between a global and local package install with npm?</a>
 
-
 ### Additional resources
+
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
 - This [crash course video](https://www.youtube.com/watch?v=fBNz5xF-Kx4) from TraversyMedia is a great code-along for getting into Node.js. It may seem repetitive after completing the assignment, but practice is repetition!


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
In the "Getting Started" lesson in the Node course, it says that the links to the articles take you to the node repository on GitHub and that it's meant to be a temporary measure. Since some of the articles are back online, I thought it would be helpful to change the links back to the official docs.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- "Learn how to run Node.js scripts" article link replaced
- "Learn quickly about .env files" article link replaced
- "Then, let's start writing files" article link replaced
- "Finally, we'll learn how to read files" article link replaced
- "Let's get an introduction to NPM" article link replaced
- "Following along with the Event Emitter section" article link replaced

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes https://github.com/TheOdinProject/curriculum/issues/26345

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
1. Some of the articles aren't back online from what I could see, so they still link to the node docs repository.
2. The new "writing files with node" article that is now live on the docs has a slight difference with the article on their repository - it doesn't mention anything about using streams (it's basically just missing a sentence at the bottom). Besides that, the two articles are identical.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
