### PR TITLE
Testing: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,7 +8,7 @@ jobs:
         name: Check for spelling errors
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
         - uses: codespell-project/actions-codespell@master
           with:
             check_filenames: true


### PR DESCRIPTION
## Because
- Github has officially started the deprecation process for Node 16 [[1]](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/). The version of actions/checkout we currently use runs on Node16 by default, while `v4` runs on Node20 instead


## This PR
- Raises the major version of actions/checkout


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR