### PR TITLE
Getting Hired Professional Networking: Adding link for first ruby friend

### DIFF
--- a/getting_hired/preparing_for_job_search/professional_networking.md
+++ b/getting_hired/preparing_for_job_search/professional_networking.md
@@ -91,3 +91,4 @@ This section contains helpful links to other content. It isn't required, so cons
 
 * [How to use LinkedIn as a developer to get a job in tech](https://www.youtube.com/watch?v=SG5Sb5WTV_g)
 * [How to Network: a Guide for Remote Software Developers & Engineers](https://arc.dev/developer-blog/how-to-network-as-remote-developer/)
+* [First ruby friend](https://firstrubyfriend.org): people on the ruby path can find free mentorship from friendly volunteers here.


### PR DESCRIPTION
## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->

This adds an amazing resource for Rubyists to the Getting Hired section.
FirstRubyFriend.org offers free mentoring for early career devs from mentors in the ruby community.
According to last information from the organizer of the program there is actually an oversupply of Ruby mentors over the demand.
I will inform the organizer Andi Croll about the potential addition of this link, so we can remove it, should there be too many requests for mentorships.


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- adds a link to https://firstrubyfriend.org

## Issue

There is no issue, I just belive this to be a worthwhile addition.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
