### PR TITLE
Fix testing_routes_and_controllers sections

### DIFF
--- a/nodeJS/testing_express/testing_routes_and_controllers.md
+++ b/nodeJS/testing_express/testing_routes_and_controllers.md
@@ -14,6 +14,7 @@ By the end of this lesson, you should be able to do or answer the following:
 - Explain and have a firm understanding of `.expect()` method's functionality.
 - Have familiarity with `supertest`'s documentation and methods.
 
+### Routes testing with supertest
 
 The most important, basic requirement for testing something in your code is that it must be in an exported module. This is true for both custom middleware and your routes/controllers, so the very first thing you need to do is separate those things into their own modules, if they aren't already.
 


### PR DESCRIPTION
I just added another section to separate the "Learning outcomes"  part from the actual lesson. It wasn't making sense to have the full lesson in this part + when you were scrolling you would still see that you're reading the lesson from "Learning outcomes part". 

I'm not quite sur about the title that I gave though ("Routes testing with supertest").

## Because
"Learning outcomes" should not contains the entire lesson.


## This PR
I just added a title to separate sections.


## Issue
|

## Additional Information
|


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
