### PR TITLE
Foundations: Intro to CSS - Rephrasing Sentence about css ancestors

### DIFF
--- a/foundations/html_css/css-foundations/intro-to-css.md
+++ b/foundations/html_css/css-foundations/intro-to-css.md
@@ -191,7 +191,7 @@ In general, you can't chain more than one type selector since an element can’t
 
 Combinators allow us to combine multiple selectors differently than either grouping or chaining them, as they show a relationship between the selectors. There are four types of combinators in total, but for right now we're going to only show you the **descendant combinator**, which is represented in CSS by a single space between selectors. <span id="descendant-combinator-description">A descendant combinator will only cause elements that match the last selector to be selected if they also have an ancestor (parent, grandparent, etc) that matches the previous selector.</span>
 
-So something like `.ancestor .child` would select an element with the class `child` if it has an ancestor with the class `ancestor`. Another way to think of it is `child` will only be selected if it is nested inside of `ancestor`, no matter how deep. Take a quick look at the example below and see if you can tell which elements would be selected based on the CSS rule provided:
+So something like `.ancestor .child` would select an element with the class `child` if it has an ancestor with the class `ancestor`. Another way to think of it is that `child` will only be selected if it is nested inside `ancestor`, regardless of how deep that nesting is. Take a quick look at the example below and see if you can tell which elements would be selected based on the CSS rule provided:
 
 ~~~html
 <!-- index.html -->


### PR DESCRIPTION
Fixed sentence to make the content understandable. 📖 

## Because

While reading this module, I stumbled across a little mistake in a sentence. I believe that this small fix would help polish the content 💅 

On the Module you have this sentence, which to me sounds a little fuzzy... ❗

> "Another way to think of it is `child` will only be selected if it is nested inside of `ancestor`, no matter how deep."

💡 I suggest the following fix to make it more understandable:

> "Another way to think of it is that `child` will only be selected if it is nested inside `ancestor`, regardless of how deep that nesting is."

## This PR
- Changed the phrase so that it is more understandable


## Issue
Closes #26421


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [X] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [X] The `Because` section summarizes the reason for this PR
-   [X] The `This PR` section has a bullet point list describing the changes in this PR
-   [X] If this PR addresses an open issue, it is linked in the `Issue` section
-   [X] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [X] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
