### PR TITLE
Websockets and Actioncable lesson: update info about boilerplate

### DIFF
--- a/ruby_on_rails/mailers_advanced_topics/websockets_and_actioncable.md
+++ b/ruby_on_rails/mailers_advanced_topics/websockets_and_actioncable.md
@@ -104,11 +104,11 @@ Each channel you create can be subscribed to by one or more clients. Messages ca
 
 #### Connections
 
-Consumers of subscriptions require an instance of the connection on the client side also. This is so when the server broadcasts a message it can be picked up and handled by the browser. Rails generates this boilerplate for you by default and the files live in `app/javascript/channels`.
+Consumers of subscriptions require an instance of the connection on the client side also. This is so when the server broadcasts a message it can be picked up and handled by the browser. Rails generates this boilerplate for you when you create a channel and the files live in `app/javascript/channels`.
 
 #### Connect consumer
 
-This lives in `app/javascript/channels/consumer.js`
+This will be in `app/javascript/channels/consumer.js` when you create a channel
 
 ~~~javascript
 import { createConsumer } from "@rails/actioncable"


### PR DESCRIPTION
Rails doesn't generate this file by default anymore. It's created only when a channel is created, for example when using the 'rails generate channel' command.

## Because
It updates information that is currently wrong on the lesson.

## This PR
- Corrects information about the consumer.js file being created by default. It's not by default anymore. It's only created when the 'rails generate channel' is called.

## Issue

## Additional Information
- The Issue was already mentioned by other user on the The Odin Project's Discord: https://discord.com/channels/505093832157691914/690591236922409012/1021624587382964224


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
