### PR TITLE
Links and Images: Adds new line stating that HTML assumes image size unit in pixels (px) when not explicitly defined.

### DIFF
--- a/foundations/html_css/html-foundations/links-and-images.md
+++ b/foundations/html_css/html-foundations/links-and-images.md
@@ -243,6 +243,8 @@ Here is our Odin Project logo example with height and width tags included:
 </p>
 <script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
 
+Here, the measurement units for the "height" and "width" attributes are not explicitly defined. When you specify dimensions in HTML without a unit, the values are assumed to be in pixels (px) by default.
+
 Go ahead and update the `odin-links-and-images` project with width and height tags on the dog image.
 
 ### Assignment


### PR DESCRIPTION
Added a little bit of information that when measurement units for the "height" and "width" attributes are not explicitly defined the values are assumed to be in pixels (px) by default in HTML. There isn't anything mentioned about this in the lesson. So it could have been confusing for beginners.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
In links-and-images lesson on Image Size Attributes, on codepen there is this code: 
```html
<img src="https://www.theodinproject.com/mstile-310x310.png" alt="The Odin Project Logo" height="310" width="310">
``` 
Here, it is told that its better to always define width and height for proper layout but here just 310 is mentioned without any unit and further clearation. This can confuse beginners. So I added a line stating "Here, the measurement units for the "height" and "width" attributes are not explicitly defined. When you specify dimensions in HTML without a unit, the values are assumed to be in pixels (px) by default.".
This can help the learners get more knowledge and clear the confusion they may have when just seeing the number.


## This PR

- A new line is added in Image size attributes: Here, the measurement units for the "height" and "width" attributes are not explicitly defined. When you specify dimensions in HTML without a unit, the values are assumed to be in pixels (px) by default.


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [ X] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [ X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [ x] The `Because` section summarizes the reason for this PR
-   [x ] The `This PR` section has a bullet point list describing the changes in this PR
-   [ x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
