### PR TITLE
React Router: change 'default Profile' to `DefaultProfile'

### DIFF
--- a/react/the_react_ecosystem/react_router.md
+++ b/react/the_react_ecosystem/react_router.md
@@ -236,7 +236,7 @@ Check out the `/profile`, `/profile/popeye` and `/profile/spinach` pages. The `<
 
 If you want to render something as a default component when no path is added to Profile, you can add an index route to the children! 
 
-Create a default Profile component:
+Create a DefaultProfile component:
 
 ~~~jsx
 const DefaultProfile = () => {


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
The student is prompted to create a default Profile component. I thought it was more appropriate to change 'default Profile' to 'DefaultProfile' as it is consistent with the React style. Also, earlier in the lesson, the student is prompted to create a Profile component. So this change may help reduce confusion.

## This PR
- "default Profile" changed to "DefaultProfile"

## Issue
Closes #26533

## Additional Information


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
