### PR TITLE
what_is_nodeJS.md: Temporarily replace Broken Link

### DIFF
--- a/nodeJS/introduction_to_nodeJS/introduction_what_is_nodeJS.md
+++ b/nodeJS/introduction_to_nodeJS/introduction_what_is_nodeJS.md
@@ -72,7 +72,7 @@ While you may have learned React (or any other frontend framework) before, eithe
 1. [This short module](https://developer.mozilla.org/en-US/docs/Learn/Server-side/First_steps) on "The Server Side" from MDN is a great source for the background knowledge you need. Read through at least the first two articles posted under the 'Guides' section: Introduction to the server side and Client-Server Overview. The other two are interesting and worth reviewing, but less relevant to our immediate concerns.
 2. To gain a little more insight into the nature of Node, and to unpack the rest of the above definition, read [this article](https://medium.freecodecamp.org/what-exactly-is-node-js-ae36e97449f5).
 3. What is the Node Event Loop? Check out this long, but _really_ [fantastic video](https://www.youtube.com/watch?v=8aGhZQkoFbQ)... don't skip it!
-4. Take a few minutes to go through the "Getting Started" section of the new official [Node.js website](https://nodejs.dev/en/learn/introduction-to-nodejs/). Read up until, but not including, the TypeScript module.
+4. Take a few minutes to go through the "Getting Started" section of the new official [Node.js website](https://web.archive.org/web/20230610075505/https://nodejs.dev/en/learn/introduction-to-nodejs/). Read up until, but not including, the TypeScript module. <br>**Note:** The above link temporarily redirects to an archived copy of the original page because at the time the official link is broken. The above link will be replaced once a new link is available on the official source. Meanwhile, the archived copy will fare well. 
 5. [This short video](https://www.youtube.com/watch?v=uVwtVBpw7RQ) is a great introduction as well!
 
 </div>


### PR DESCRIPTION
# Because
The link to NodeJS Getting Started Section is broken. The broken link: https://nodejs.dev/en/learn/introduction-to-nodejs/)

# This PR
Fixes the link and points to the new URL of the getting started section: https://web.archive.org/web/20230610075505/https://nodejs.dev/en/learn/introduction-to-nodejs/

# Pull Request Requirements
 I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
 The title of this PR follows the location of change: brief description of change format, e.g. Intro to HTML and CSS lesson: Fix link text
 The Because section summarizes the reason for this PR
 The This PR section has a bullet point list describing the changes in this PR
 If this PR addresses an open issue, it is linked in the Issue section
 If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
 If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)