### PR TITLE
Fix #26579: Corrected inaccuracies in HTML Encoding Reference article

### DIFF
--- a/foundations/html_css/html-foundations/html-boilerplate.md
+++ b/foundations/html_css/html-foundations/html-boilerplate.md
@@ -177,8 +177,6 @@ This section contains questions for you to check your understanding of this less
 
 This section contains helpful links to related content. It isn’t required, so consider it supplemental.
 
-*   Read through this article about what [charsets you should use with your HTML pages](https://www.positioniseverything.net/html-encoding/).
-
 *   Another option for opening your HTML pages in the browser is using the [live server extension](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer) with VSCode. This will open your HTML document and automatically refresh it every time you save the document. However, we recommend not using this extension and instead doing it the old-fashioned way, by opening the page and refreshing the page manually in the browser for your first few HTML projects. This way, you can get used to that process and won't become reliant on extensions right away. One reason is that there may be subtle differences when using extensions. For example, live server will always use UTF-8 character encoding and not the value defined in your `meta-charset` attribute. This could potentially hide some characters on your site as they will not be encoded the way you expect.
 
 *   If you wish, you can add the `lang` attribute to individual elements throughout the webpage. Read through [this doc](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang) for a better understanding of the `lang` attribute.


### PR DESCRIPTION
Title:
Fixed HTML Encoding Additional resources Article

Description:
This pull request addresses issue #26579 by correcting inaccuracies in the HTML Encoding Additional resources article. I removed the link to the article about charsets (https://www.positioniseverything.net/html-encoding/) from the Additional Resources section, as it contained misleading information. The removed line of code was:

* Read through this article about what [charsets you should use with your HTML pages](https://www.positioniseverything.net/html-encoding/).

The changes ensure that the information provided to users is accurate and reliable. Please review the modifications, and feel free to reach out if further adjustments are needed.

Thank you for your attention to this contribution.

Best regards,
Sahil Shityalkar.



before,
![Screenshot 2023-10-30 231041](https://github.com/TheOdinProject/curriculum/assets/116258053/f26a206a-0ecb-4e0a-9c10-82a6426fec00)

