### PR TITLE
Layout Style Guide: Update to use backtick fenced codeblocks

### DIFF
--- a/LAYOUT_STYLE_GUIDE.md
+++ b/LAYOUT_STYLE_GUIDE.md
@@ -349,15 +349,15 @@ Create a new file named `styles.css` first.
 
 ### Codeblocks
 
-For code quotations longer than a single line, use a codeblock with 3 opening and closing tilde marks:
+For code quotations longer than a single line, use a codeblock with 3 opening and closing backticks:
 
 <pre>
-~~~javascript
+```javascript
 const obj = {
   name: "object",
   marker: "X"
 }
-~~~
+```
 </pre>
 
 #### Declare the language
@@ -384,12 +384,12 @@ If you need a codeblock within a list, you should follow the same indenting rule
 <pre>
 - Bullet.
 
-  ~~~javascript
+  ```javascript
   // We start indenting with 2 space for the codeblock
   function tester() {
     const yay = 'From here we can indent like we normally would'
   }
-  ~~~
+  ```
 
 - Next bullet.
 </pre>


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
[This PR](https://github.com/TheOdinProject/theodinproject/pull/4241) on the main app brings support for backtick fenced codeblocks to the curriculum markdown content. Given this is a more conventional format for codeblocks, it'd be a good idea to make this the new standard we go with.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Updates the LAYOUT_STYLE_GUIDE to specify that codeblocks should be wrapped in backticks

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
