### PR TITLE
React: Fix consistency of spacing/indentation/semicolons

### DIFF
--- a/react/class_components/component_lifecycle_methods.md
+++ b/react/class_components/component_lifecycle_methods.md
@@ -12,7 +12,7 @@ This section contains a general overview of topics that you will learn in this l
 
 ### render()
 
-The render function is the most used lifecycle method, and one that you've come across in the last class components lesson. It is the only required lifecycle method in a class component. It runs on mount and update of a component. Render should be pure, meaning it doesn't modify component state, returns the same thing each time it's called (given the same inputs), and doesn't directly interact with the browser. 
+The render function is the most used lifecycle method, and one that you've come across in the last class components lesson. It is the only required lifecycle method in a class component. It runs on mount and update of a component. Render should be pure, meaning it doesn't modify component state, returns the same thing each time it's called (given the same inputs), and doesn't directly interact with the browser.
 
 ### componentDidMount()
 
@@ -40,10 +40,10 @@ Now that we've learnt about class lifecycle methods, it's useful to understand t
 For example:
 
 ~~~js
-    useEffect(() => {
-        placeholderFunction()
-        return () => cleanupFunction()
-    }, [])
+  useEffect(() => {
+    placeholderFunction();
+    return () => cleanupFunction();
+  }, [])
 ~~~
 
 In this snippet, the useEffect contains the functionality of `componentDidMount`, and `componentWillUnmount` via the return function. This example doesn't have the `componentDidUpdate` functionality because of an empty dependency array.
@@ -55,8 +55,8 @@ In this snippet, the useEffect contains the functionality of `componentDidMount`
 1.  Check out this [lifecycle diagram](https://projects.wojtekmaj.pl/react-lifecycle-methods-diagram/) to see a good visual representation of a components lifecycle methods.
 
 2. Read this [component lifecycle documentation](https://reactjs.org/docs/react-component.html#the-component-lifecycle) by the people who made react!
-    *   You only have to worry about the methods in bold, but you can read up on the others if you're curious - they're uncommon and you likely won't need them in 
-        most of your apps. 
+    *   You only have to worry about the methods in bold, but you can read up on the others if you're curious - they're uncommon and you likely won't need them in
+        most of your apps.
 </div>
 
 ### Knowledge check

--- a/react/getting_started_with_react/keys_in_react.md
+++ b/react/getting_started_with_react/keys_in_react.md
@@ -11,7 +11,7 @@ By the end of the lesson you should be able to answer the following:
 
 ### Why does React need keys?
 
-In the upcoming lessons as you learn more about the internal workings of React, more specifically the rerendering process, you will understand the importance of keys. For now, we will keep it simple. 
+In the upcoming lessons as you learn more about the internal workings of React, more specifically the rerendering process, you will understand the importance of keys. For now, we will keep it simple.
 
 In the previous lesson on rendering lists, we used the `.map()` method to iterate over an array of data and return a list of elements. Now imagine, if any of the items in the list were to change, how would React know which item to update?
 
@@ -29,7 +29,7 @@ As long as `keys` remain consistent and unique, React can handle the DOM effecti
 
 Keys are passed into the component or a DOM element as a prop. You should already be familiar with the syntax.
 
-~~~jsx  
+~~~jsx
 <Component key={keyValue} />
 //or
 <div key={keyValue} />
@@ -40,7 +40,7 @@ Keys are passed into the component or a DOM element as a prop. You should alread
 ~~~jsx
 // a list of todos, each todo object has a task and an id
 const todos = [
-  { task: "mow the yard", id: uuid() }, 
+  { task: "mow the yard", id: uuid() },
   { task: "Work on Odin Projects", id: uuid() },
   { task: "feed the cat", id: uuid() },
 ];
@@ -53,7 +53,7 @@ function TodoList() {
         <li key={todo.id}>{todo.task}</li>
       ))}
     </ul>
-  ) 
+  )
 }
 ~~~
 
@@ -62,7 +62,7 @@ function TodoList() {
 ~~~jsx
 const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
 
-function MonthList(){
+function MonthList() {
   return (
     <ul>
       {/* here we are using the index as key */}
@@ -76,20 +76,20 @@ function MonthList(){
 
 ~~~jsx
 const todos = [
-  { task: "mow the yard", id: uuid() }, 
+  { task: "mow the yard", id: uuid() },
   { task: "Work on Odin Projects", id: uuid() },
   { task: "feed the cat", id: uuid() },
 ];
 
 function TodoList() {
   return (
-      <ul>
-        {todos.map((todo) => (
-          // DON'T do the following i.e. generating keys during render    
-          <li key={uuid()}>{todo.task}</li>
-        ))}
-      </ul>
-  ) 
+    <ul>
+      {todos.map((todo) => (
+        // DON'T do the following i.e. generating keys during render
+        <li key={uuid()}>{todo.task}</li>
+      ))}
+    </ul>
+  )
 }
 ~~~
 

--- a/react/getting_started_with_react/keys_in_react.md
+++ b/react/getting_started_with_react/keys_in_react.md
@@ -53,7 +53,7 @@ function TodoList() {
         <li key={todo.id}>{todo.task}</li>
       ))}
     </ul>
-  )
+  );
 }
 ~~~
 
@@ -68,7 +68,7 @@ function MonthList() {
       {/* here we are using the index as key */}
       {months.map((month, index) => (<li key={index}>{month}</li>))}
     </ul>
-  )
+  );
 }
 ~~~
 
@@ -89,7 +89,7 @@ function TodoList() {
         <li key={uuid()}>{todo.task}</li>
       ))}
     </ul>
-  )
+  );
 }
 ~~~
 

--- a/react/getting_started_with_react/passing_data_between_components.md
+++ b/react/getting_started_with_react/passing_data_between_components.md
@@ -21,7 +21,7 @@ Now that we know *how* data transfers between components, let's explore *why* th
 function Button() {
   return (
     <button>Click Me!</button>
-  )
+  );
 }
 
 export default function App() {
@@ -31,7 +31,7 @@ export default function App() {
       <Button />
       <Button />
     </div>
-  )
+  );
 }
 ~~~
 So far so good right? We have a beautiful reusable button that we can use as many times as we like, there is just one small problem.
@@ -42,13 +42,13 @@ What if we wanted the text within our second button to be “Don’t Click Me!�
 function Button() {
   return (
     <button>Click Me!</button>
-  )
+  );
 }
 
 function Button2() {
   return (
     <button>Don't Click Me!</button>
-  )
+  );
 }
 
 export default function App() {
@@ -58,7 +58,7 @@ export default function App() {
       <Button2 />
       <Button />
     </div>
-  )
+  );
 }
 ~~~
 This may not seem like a huge deal right now, but what if we had 10 buttons, each one having different text, fonts, colors, sizes, and any other variation you can think of. Creating a new component for each of these button variations would very quickly lead to a LOT of code duplication.
@@ -72,7 +72,6 @@ You may notice squiggly lines under your props (for example under `color` and `f
 
 ~~~jsx
 function Button(props) {
-
   const buttonStyle = {
     color: props.color,
     fontSize: props.fontSize + 'px'
@@ -80,7 +79,7 @@ function Button(props) {
 
   return (
     <button style={buttonStyle}>{props.text}</button>
-  )
+  );
 }
 
 export default function App() {

--- a/react/getting_started_with_react/rendering_techniques.md
+++ b/react/getting_started_with_react/rendering_techniques.md
@@ -34,6 +34,7 @@ It is perfectly acceptable, but what if we want to render more than just four? I
 ~~~javascript
 function App() {
   const animals = ["Lion", "Cow", "Snake", "Lizard"];
+
   return (
     <div>
       <h1>Animals: </h1>
@@ -47,13 +48,13 @@ function App() {
 }
 ~~~
 
-We define an array called `animals`. Now inside our JSX, we use `map` to return a new array of `li` elements, adding `animal` as its text. It should now render the same as the previous snippet we wrote. This is because JSX has the ability to automatically render arrays. The following code is identical: 
+We define an array called `animals`. Now inside our JSX, we use `map` to return a new array of `li` elements, adding `animal` as its text. It should now render the same as the previous snippet we wrote. This is because JSX has the ability to automatically render arrays. The following code is identical:
 
 ~~~javascript
 function App() {
   const animals = ["Lion", "Cow", "Snake", "Lizard"];
   const animalsList = animals.map((animal) => <li key={animal}>{animal}</li>)
-  
+
   return (
     <div>
       <h1>Animals: </h1>
@@ -104,7 +105,7 @@ We have moved our `<ul>` element to a different component called `<List />`. It 
 
 This component accepts a `props` which is an object containing the `animals` that we defined as a property when we wrote `<List animals={animals} />`. Do note that you can name it anything, for example, `<List animalList={animals} />`. You will still need to pass the animals to the property, but now you will use `props.animalList` instead of `props.animals`.
 
-We have also created a different component for the `<li>` element called `<ListItem />`, which also accepts `props`, and uses `props.animal` to render the text. It should now render the same thing. 
+We have also created a different component for the `<li>` element called `<ListItem />`, which also accepts `props`, and uses `props.animal` to render the text. It should now render the same thing.
 
 ### Conditionally rendering UI
 

--- a/react/getting_started_with_react/what_is_jsx.md
+++ b/react/getting_started_with_react/what_is_jsx.md
@@ -52,8 +52,8 @@ If you were to take some valid HTML and copy it straight into your React compone
    ~~~jsx
    function App() {
      return (
-         <h1>Example h1</h1>
-         <h2>Example h2</h2>
+       <h1>Example h1</h1>
+       <h2>Example h2</h2>
      );
    }
    ~~~
@@ -82,10 +82,10 @@ If you were to take some valid HTML and copy it straight into your React compone
    ~~~jsx
    function App() {
      return (
-         <>
-          <input>
-          <li>
-         </>
+       <>
+         <input>
+         <li>
+       </>
      );
    }
    ~~~
@@ -143,7 +143,7 @@ Now that we've covered the Rules of JSX, we'll go through the conversion of a ch
 <form><input type="text"></form>
 ~~~
 
-If you try to return this from a React component, you would get many errors, so we are going to fix that! 
+If you try to return this from a React component, you would get many errors, so we are going to fix that!
 
  Make sure to follow along this example in your local environment. Alternatively, you can go to [react.new](https://react.new/) to have a quick React environment up and going in your web browser.
 

--- a/react/states_and_effects/how_to_deal_with_side_effects.md
+++ b/react/states_and_effects/how_to_deal_with_side_effects.md
@@ -63,7 +63,7 @@ But, it still keeps growing too fast! This is where another argument of the `use
 
 #### The dependency array
 
-By default, `useEffect` hook runs on every render. Since setting state tears the component down, we still get multiple setter calls on every render, which doesn't help us. 
+By default, `useEffect` hook runs on every render. Since setting state tears the component down, we still get multiple setter calls on every render, which doesn't help us.
 
 Fortunately, the second argument accepts an array of dependencies allowing the hook to re-render **only when those dependencies are changed**. So if you have a state variable and want to have some side-effect occur any time the state changes, you can use this hook and mention the state variable in the dependency array.
 
@@ -126,7 +126,7 @@ export default function Clock() {
 
     return () => {
       clearInterval(key);
-    }
+    };
   }, [])
 
   return (
@@ -190,7 +190,7 @@ Let us address a few cases where `useEffect` does not need to be used.
 
       const handleInput = (e) => {
         setInput(e.target.value);
-      }
+      };
 
       // You should avoid direct manipulation when not necessary
 
@@ -200,7 +200,7 @@ Let us address a few cases where `useEffect` does not need to be used.
       //     document.getElementById("name").removeEventListener("change", handleInput);
       //   }
       // });
-      
+
       return (
         <>
           {/* <input id="name" /> */}
@@ -208,7 +208,7 @@ Let us address a few cases where `useEffect` does not need to be used.
           <input onChange={handleInput} value={input} />
           <p>{ input }</p>
         </>
-      )
+      );
     }
     ~~~
 

--- a/react/states_and_effects/more_on_state.md
+++ b/react/states_and_effects/more_on_state.md
@@ -190,13 +190,13 @@ This pattern is extremely useful wherever you need user input i.e. typing in a t
 <div class="lesson-content__panel" markdown="1">
 
 1. Read the following articles from the React documentation:
-  - [State as a Snapshot](https://react.dev/learn/state-as-a-snapshot)
-  - [Choosing the State Structure](https://react.dev/learn/choosing-the-state-structure)
-  - [Sharing State Between Components](https://react.dev/learn/sharing-state-between-components)
+   - [State as a Snapshot](https://react.dev/learn/state-as-a-snapshot)
+   - [Choosing the State Structure](https://react.dev/learn/choosing-the-state-structure)
+   - [Sharing State Between Components](https://react.dev/learn/sharing-state-between-components)
 
 2. Update the `Person` component we've been using above.
-  - Add two separate input fields for first name and last name. The updated full name should be displayed on every keystroke on either of the two input fields.
-  - There are many ways you can do this. Keep in mind what you've learned in this lesson while coding it out.
+   - Add two separate input fields for first name and last name. The updated full name should be displayed on every keystroke on either of the two input fields.
+   - There are many ways you can do this. Keep in mind what you've learned in this lesson while coding it out.
 
 </div>
 

--- a/react/states_and_effects/more_on_state.md
+++ b/react/states_and_effects/more_on_state.md
@@ -12,9 +12,9 @@ This section contains a general overview of topics that you will learn in this l
 
 ### How to structure state
 
-Managing and structuring state effectively is by far one of the most crucial parts of building your application. If not done correctly it can become a source of bugs and headaches.   
+Managing and structuring state effectively is by far one of the most crucial parts of building your application. If not done correctly it can become a source of bugs and headaches.
 
-The assignment items go through the topic thoroughly, but as a general rule of thumb: don't put values in state that can be calculated using existing values, state, and/or props. 
+The assignment items go through the topic thoroughly, but as a general rule of thumb: don't put values in state that can be calculated using existing values, state, and/or props.
 
 #### State should not be mutated
 
@@ -23,30 +23,30 @@ In order for us to change state, we should always use the `setState` function. M
 
 ~~~jsx
 function Person() {
-   const [person, setPerson] = useState({ name: 'John', age: 100 });
+  const [person, setPerson] = useState({ name: 'John', age: 100 });
 
-   // BAD - Don't do this!
-   const handleIncreaseAge = () =>{
-      // mutating the current state object
-      person.age = person.age + 1;
-      setPerson(person);
-   }
+  // BAD - Don't do this!
+  const handleIncreaseAge = () =>{
+    // mutating the current state object
+    person.age = person.age + 1;
+    setPerson(person);
+  };
 
-   // GOOD - Do this!
-   const handleIncreaseAge = () =>{
-      // copy the existing person object into a new object 
-      // while updating the age property
-      const newPerson = { ...person, age: person.age + 1 };
-      setPerson(newPerson);
-   }
-   
-   return (
-      <>
-         <h1>{person.name}</h1>
-         <h2>{person.age}</h2>
-         <button onClick={handleIncreaseAge}>Increase age</button>
-      </>
-   )
+  // GOOD - Do this!
+  const handleIncreaseAge = () =>{
+    // copy the existing person object into a new object
+    // while updating the age property
+    const newPerson = { ...person, age: person.age + 1 };
+    setPerson(newPerson);
+  };
+
+  return (
+    <>
+      <h1>{person.name}</h1>
+      <h2>{person.age}</h2>
+      <button onClick={handleIncreaseAge}>Increase age</button>
+    </>
+  );
 }
 ~~~
 
@@ -70,27 +70,27 @@ Remember, state variables aren't reactive, the component is. This can be underst
 
 ~~~jsx
 function Person() {
-   const [person, setPerson] = useState({ name: 'John', age: 100 });
+  const [person, setPerson] = useState({ name: 'John', age: 100 });
 
-   const handleIncreaseAge = () =>{
-      console.log("in handleIncreaseAge (before setPerson call): ", person)
-      setPerson({ ...person, age: person.age + 1 });
-      // we've called setPerson, surely person has updated?
-      console.log("in handleIncreaseAge (after setPerson call): ", person);
-   }
+  const handleIncreaseAge = () =>{
+    console.log("in handleIncreaseAge (before setPerson call): ", person)
+    setPerson({ ...person, age: person.age + 1 });
+    // we've called setPerson, surely person has updated?
+    console.log("in handleIncreaseAge (after setPerson call): ", person);
+  };
 
-   // this console.log runs every time the component renders 
-   // what do you think this will print?
-   console.log("during render: ", person);
-   
-   return (
-      <>
-         <h1>{person.name}</h1>
-         <h2>{person.age}</h2>
-         <button onClick={handleIncreaseAge}>Increase age</button>
-      </>
-   )
-} 
+  // this console.log runs every time the component renders
+  // what do you think this will print?
+  console.log("during render: ", person);
+
+  return (
+    <>
+      <h1>{person.name}</h1>
+      <h2>{person.age}</h2>
+      <button onClick={handleIncreaseAge}>Increase age</button>
+    </>
+  );
+}
 ~~~
 
 These are the logs:
@@ -101,7 +101,7 @@ Uh oh, what is happening? Let's break it down (ignore the double `console.logs` 
 
 1. The component renders for the first time. The `person` state variable is initialized to `{ name: 'John', age: 100 }`. The "during render" `console.log` prints the state variable.
 1. The button is clicked invoking `handleIncreaseAge`. Interestingly, the `console.log` before and after the `setPerson` call prints the same value.
-1. The component re-renders. The `person` state variable is updated to `{ name: 'John', age: 101 }`. 
+1. The component re-renders. The `person` state variable is updated to `{ name: 'John', age: 101 }`.
 
 The `person` state stays the same throughout the current render of the component. This is what "state as a snapshot" refers to. The `setState` call triggers a component re-render and the `person` state is updated to the new value.
 
@@ -113,13 +113,13 @@ The following is an infinite loop, can you guess why? Drop by in our [Discord ch
 
 ~~~jsx
 function Time() {
-   const [time, setTime] = useState(new Date());
+  const [time, setTime] = useState(new Date());
 
-   setTime(new Date());
+  setTime(new Date());
 
-   return (
-      <h1>{time.toLocaleTimeString()}</h1>
-   )
+  return (
+    <h1>{time.toLocaleTimeString()}</h1>
+  );
 }
 ~~~
 
@@ -132,9 +132,9 @@ A trick question. Let's look at another implementation of `handleIncreaseAge`; w
 
 ~~~jsx
 const handleIncreaseAge = () => {
-   setPerson({ ...person, age: person.age + 1 });
-   setPerson({ ...person, age: person.age + 1 });
-}
+  setPerson({ ...person, age: person.age + 1 });
+  setPerson({ ...person, age: person.age + 1 });
+};
 ~~~
 
 Surely, it will increase the age by 2? Nope. The above code is saying to React:
@@ -145,12 +145,12 @@ Notice the word "replace". When you pass in the value to the `setState` function
 
 ~~~jsx
 const handleIncreaseAge = () => {
-   setPerson((prevPerson) => ({ ...prevPerson, age: prevPerson.age + 1 }));
-   setPerson((prevPerson) => ({ ...prevPerson, age: prevPerson.age + 1 }));
-}
+  setPerson((prevPerson) => ({ ...prevPerson, age: prevPerson.age + 1 }));
+  setPerson((prevPerson) => ({ ...prevPerson, age: prevPerson.age + 1 }));
+};
 ~~~
 
-When a callback is passed to the `setState` function, it ensures that the latest state is passed in as an argument to the callback. 
+When a callback is passed to the `setState` function, it ensures that the latest state is passed in as an argument to the callback.
 
 Using an updater is not always necessary. If you want to change the state using your previous state, and you prefer consistency over verbosity then you might consider using an updater.
 
@@ -169,19 +169,19 @@ There are native HTML elements that maintain their own internal state. The `inpu
 
 ~~~jsx
 function CustomInput() {
-   const [value, setValue] = useState('');
-   
-   return (
-      <input
-         type="text"
-         value={value}
-         onChange={(event) => setValue(event.target.value)}
-      />
-   );
+  const [value, setValue] = useState('');
+
+  return (
+    <input
+        type="text"
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+    />
+  );
 }
 ~~~
 
-Instead of letting the `input` maintain its own state, we define our own state using the `useState` hook. We then set the `value` prop of the `input` to the state variable and update the state variable on every `onChange` event. Now, every time the user types something in the input, React will ensure you have the latest comment/review/post (whatever the user was typing) in `value`. 
+Instead of letting the `input` maintain its own state, we define our own state using the `useState` hook. We then set the `value` prop of the `input` to the state variable and update the state variable on every `onChange` event. Now, every time the user types something in the input, React will ensure you have the latest comment/review/post (whatever the user was typing) in `value`.
 
 This pattern is extremely useful wherever you need user input i.e. typing in a textbox, toggling a checkbox etc. Contrarily, yes, the `input` element can be left uncontrolled and access its value through some other method. You don't need to worry about it yet as it is covered later on in the course. For now, control your components!
 
@@ -189,14 +189,14 @@ This pattern is extremely useful wherever you need user input i.e. typing in a t
 
 <div class="lesson-content__panel" markdown="1">
 
-1. Read the following articles from the React documentation: 
-   - [State as a Snapshot](https://react.dev/learn/state-as-a-snapshot)
-   - [Choosing the State Structure](https://react.dev/learn/choosing-the-state-structure)
-   - [Sharing State Between Components](https://react.dev/learn/sharing-state-between-components)
+1. Read the following articles from the React documentation:
+  - [State as a Snapshot](https://react.dev/learn/state-as-a-snapshot)
+  - [Choosing the State Structure](https://react.dev/learn/choosing-the-state-structure)
+  - [Sharing State Between Components](https://react.dev/learn/sharing-state-between-components)
 
 2. Update the `Person` component we've been using above.
-   - Add two separate input fields for first name and last name. The updated full name should be displayed on every keystroke on either of the two input fields. 
-   - There are many ways you can do this. Keep in mind what you've learned in this lesson while coding it out.
+  - Add two separate input fields for first name and last name. The updated full name should be displayed on every keystroke on either of the two input fields.
+  - There are many ways you can do this. Keep in mind what you've learned in this lesson while coding it out.
 
 </div>
 

--- a/react/the_react_ecosystem/fetching_data_in_react.md
+++ b/react/the_react_ecosystem/fetching_data_in_react.md
@@ -74,17 +74,16 @@ To simulate a network error, scroll up to the previous code snippet and change t
 To fix this, we need to check for _something_ before Image component returns JSX. We'll call it: `error`.
 
 ~~~jsx
-  if (error) return <p>A network error was encountered</p>
+if (error) return <p>A network error was encountered</p>
 
-  return (
-    imageURL && (
-      <>
-        <h1>An image</h1>
-        <img src={imageURL} alt={"placeholder text"} />
-      </>
-    )
-  );
-};
+return (
+  imageURL && (
+    <>
+      <h1>An image</h1>
+      <img src={imageURL} alt={"placeholder text"} />
+    </>
+  )
+);
 ~~~
 
 To set this `error`, we'll add it to the component's state.


### PR DESCRIPTION
## Because
Noticed inconsistency across some of the React lessons with spacing/indentation/semicolon usage. Many of these have been fixed so semicolons are used where they can be put, and indentation is kept to 2 spaces as with the other lessons.


## This PR
- Fixes indentation consistency to 2-spaces
- Fixes missing space after function params parens
- Adds in semicolons to keep usage consistent across lessons
- Trailing white space automatically removed


## Issue
N/A

## Additional Information


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
