### PR TITLE
Javascript: Factory Functions and the Module Pattern

### DIFF
--- a/javascript/organizing_your_javascript_code/factory_functions_and_module_pattern.md
+++ b/javascript/organizing_your_javascript_code/factory_functions_and_module_pattern.md
@@ -75,7 +75,7 @@ console.log(add5(2)) // logs 7
 
 A lot going on, so let's break it down:
 
-1. The `makeAdding` function takes an argument, `first`, and returns another **function** (which we have named as `add5` while using).
+1. The `makeAdding` function takes an argument, `firstNumber`, declares a constant `first` with the value of `firstNumber` and returns another **function** (which we have named as `add5` while using).
 1. When an argument is passed to the returned function (in our case, `add5`), it returns the result of adding up the number passed earlier to the number passed now (`first` to `second`).
 
 Now, while it may sound good at first glance, you can already be raising your eyebrows at the second statement. As we've learned, the `first` variable is scoped within the `makeAdding` function. When we declare and use `add5`, however, we're **outside** the `makeAdding` function. How does the `first` variable still exist, ready to be added when we pass an argument to the `add5` function? This is where we encounter the concept of closures.


### PR DESCRIPTION
## Because
In the makeAdding example, the paragraph following the code block states that the makeAdding function has the argument `first`, when the argument in the code block is actually `firstNumber`

Semantically, they are the same number. But for clarity among the eagle-eyed readers who may get tripped up, we should be precise in our language. an argument (or parameter) is a well-defined term.


## This PR
* defines `firstNumber` as the argument, and `first` as the function variable
* Increases clarity by being specific and atomic in its change
* Decreases ambiguity in the text

## Issue

## Additional Information


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
