### PR TITLE
Added Passport: The Hidden Manual as an additional resource to the Authentication Basics lesson in the NodeJS path

### DIFF
--- a/nodeJS/authentication/authentication_basics.md
+++ b/nodeJS/authentication/authentication_basics.md
@@ -349,6 +349,8 @@ This section contains helpful links to other content. It isn't required, so cons
 
 - [This video](https://www.youtube.com/watch?v=8ZtInClXe1Q) gives a broad overview of some of the different methods to store passwords in databases, and the risks of some of them.
 
+- In [Passport: The Hidden Manual](https://github.com/jwalton/passport-api-docs), you can explore comprehensive explanations of Passport's functions, gaining a deeper understanding of what each function accomplishes.
+
 
 ### Knowledge checks
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.


### PR DESCRIPTION
## Because
Passport's documentation does not explain what it's function does which can lead to confusion and frustration. [Passport: The Hidden Manual](https://github.com/jwalton/passport-api-docs) was written to provide the missing explanations. 


## This PR
- Adds a link to [Passport: The Hidden Manual](https://github.com/jwalton/passport-api-docs) as an additional resource to `NodeJS: Authentication Basics` lesson. 


## Issue
Closes #26601

## Additional Information



## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
