### PR TITLE
Update semantic_html.md

### DIFF
--- a/advanced_html_css/accessibility/semantic_html.md
+++ b/advanced_html_css/accessibility/semantic_html.md
@@ -44,7 +44,7 @@ Because the `<button>` element has a semantic meaning and provides context, a sc
 
 When it comes to using semantic HTML correctly, you want to think about what your intent for users is and what context you want (or need) to provide to them. This can vary depending on the situation, but there are some things you should absolutely be checking for moving forward:
 
-* If a user is meant to click something, whether it's an actual button or not, you will usually want to use a `<button>` element. This will let the user know that they can interact with the element by clicking on it.
+* If a user is meant to click something, whether or not it's an actual button or if it's a clickable link, choose the appropriate HTML tag. For actions triggered by clicking, use the `<button>` element. For navigational links, use the `<a>` (anchor) element. This will let the user know that they can interact with the element by clicking on it.
 * If you want to provide some sort of tabular data to a user, use a `<table>` element along with the elements related to it. This will allow a user to more easily navigate and understand the data being presented.
 * When you use an input element, you should always create a relationship between it and a `<label>` element. A `<label>` provides context for what an input actually means to assistive technologies, announcing the label contents each time the input is announced. Not only that, but a proper `<label>` increases the clickable area of the input itself, which is useful for users who have trouble clicking on smaller items. There are two ways you can create this relationship:
 


### PR DESCRIPTION
JS Path, Advanced HTML CSS: Clarify that not all click interactions are semantically buttons

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
The current subsection regarding clickable elements states that "If a user is meant to click something, whether it’s an actual button or not, you will usually want to use a <button> element". However this could be interpreted to include links. Even on the lesson page itself there are more `<a>`'s to be clicked then there are `<button>`'s. Hence I think an update to the wording could be beneficial to explicitly separate these cases.


## This PR
- Proposes an update to the wording with the aforementioned clarification.



## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
