### PR TITLE
Elements and tags:Updated codeblock delimeters on Elements and tags page

### DIFF
--- a/foundations/html_css/html-foundations/elements-and-tags.md
+++ b/foundations/html_css/html-foundations/elements-and-tags.md
@@ -19,17 +19,15 @@ Closing tags tell the browser where an element ends. They are almost the same as
 
 A full paragraph element looks like this:
 
-~~~html
+```html
 <p>some text content</p>
-~~~
-
+```
 
 Let's break this down:
 
 - `<p>` is the opening tag.
-- `some text content` represents content wrapped within the opening and closing tags. 
+- `some text content` represents content wrapped within the opening and closing tags.
 - `</p>` is the closing tag.
-
 
 You can think of elements as containers for content. The opening and closing tags tell the browser what content the element contains. The browser can then use that information to determine how it should interpret and format the content.
 
@@ -43,8 +41,8 @@ Using the correct elements for content is called semantic HTML. We will explore 
 
 <div class="lesson-content__panel" markdown="1">
 
-  1. [Watch Kevin Powell's Introduction to HTML Video](https://www.youtube.com/watch?v=LGQuIIv2RVA&list=PL4-IK0AVhVjM0xE0K2uZRvsM7LkIhsPT-)
-  
+1. [Watch Kevin Powell's Introduction to HTML Video](https://www.youtube.com/watch?v=LGQuIIv2RVA&list=PL4-IK0AVhVjM0xE0K2uZRvsM7LkIhsPT-)
+
 </div>
 
 ### Knowledge check


### PR DESCRIPTION
Updated the codeblock delimeters from '~' to '`' on the elements and tags page to better align with the style guide.
Related to #26695 
location of change foundations/html_css/html-foundations/elements-and-tags.md
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Updated the code delimeters from tildes to back ticks for the Elements and tags page.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
replaced tildes with backticks.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
