### PR TITLE
commit-messages.md: Updated the codeblock delimeters from '~' to '`' 

### DIFF
--- a/git/foundations_git/commit_messages.md
+++ b/git/foundations_git/commit_messages.md
@@ -24,9 +24,9 @@ Yes! Let me give you a quick list of reasons why:
 
 When it comes to writing commits, it is crucial to know how to write them effectively. Here's an example of a bad commit message:
 
-~~~
+```
 fix a bug
-~~~
+```
 
 Even though it describes what you did, the message is too vague, which leaves the other developers on your team confused. A good commit message will explain the **why** behind your changes. In other words, a commit message describes what problem your changes solve and how it solves them.
 
@@ -35,9 +35,9 @@ Effective commits consist of two separate parts: a subject, and a body:
 #### Subject
 A brief summary of the change you made to the project. 
 
-~~~
+```
 This is the change I made to the codebase.
-~~~
+```
 
 <div class="lesson-note lesson-note--tip" markdown=1>
 GitHub has a 72-character limit so we recommend keeping your commits' subject to within this amount.
@@ -46,18 +46,18 @@ GitHub has a 72-character limit so we recommend keeping your commits' subject to
 #### Body
 A concise yet clear description of what you did.
 
-~~~
+```
 Describe the problem your commit solves and how.
-~~~
+```
 
 
 Now that we learned the secret to creating a good commit message, let's try and fix the commit message from earlier:
 
-~~~git
+```git
 Add missing link and alt text to the company's logo
 
 Screen readers won't read the images to users with disabilities without this information
-~~~
+```
 
 Ahh, that's better! :) Now, developers can gain a better understanding of this commit message because it does the following:
 


### PR DESCRIPTION


## Because

- Updated the codeblock delimeters from '~' to '`' on the commit messages page to better align with the style guide.


## This PR
Updated the codeblock delimeters from '~' to '`' on the commit messages page


## Issue

Related to #26695

## Additional Information

n/a

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
