### PR TITLE
Refs and Memoization: Fix redundant text and typo

### DIFF
--- a/react/more_react_concepts/refs_and_memoization.md
+++ b/react/more_react_concepts/refs_and_memoization.md
@@ -234,7 +234,7 @@ const ButtonComponent = memo(({ children, onClick }) => {
 });
 ~~~
 
-Wrapping the component with a `memo` pretty much prevents the downward update that is triggered above the component. So, this component will only re-render when its `props` changes or if its own `state` changes *if any*.
+Wrapping the component with a `memo` prevents the downward update that is triggered above the component. So, this component will only re-render when its `props` change or if its own `state` changes.
 
 With all that said and done, test and break things in our interactive example:
 


### PR DESCRIPTION
## Because
There was some redundant text, a typo and incorrect grammar in one of the paragraphs in `refs_and_memoization.md`.


## This PR
* Removes "pretty much" from sentence describing what memo does
* Replaces "props changes" with "props change"
* Removes "if any" from end of paragraph


## Issue
Closes #XXXXX

## Additional Information

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
