### PR TITLE
JavaScript course factory functions: Reword private variable closure example

### DIFF
--- a/javascript/organizing_your_javascript_code/factory_functions_and_module_pattern.md
+++ b/javascript/organizing_your_javascript_code/factory_functions_and_module_pattern.md
@@ -194,11 +194,11 @@ console.log({
 // logs { discordName: "@josh", reputation: 2 }
 ~~~
 
-We've introduced a new metric for a new user, a reputation, and in our returned object, added two new functions to control this reputation count. Sounds about right? But notice that we did not return the reputation count, *itself*. Instead, we used the power of closure to let it remain hidden, as a detail of implementation, and offered a function to check its value at any time and another one to increase its value by one. This is what we call a "private" variable.
+We’ve introduced a new metric for a new user - a reputation. Notice that the object we return in the factory function does not contain the `reputation` variable itself, nor any copy of its value. Instead, the returned object contains two functions - one that reads the value of the `reputation` variable, and another that increases its value by one. The `reputation` variable is what we call a "private" variable, since we cannot access the variable directly in the object instance - it can only be accessed via the closures we defined.
 
 Concerning factory functions, a private variable or function uses closures to create smaller, dedicated variables and functions within a factory function itself - things that we do not *need* to return in the object itself. This way we can create neater code, without polluting the returned object with unnecessary variables that we create while creating the object itself. Often, you do not need every single function within a factory to be returned with the object, or expose an internal variable. You can use them privately since the property of closures allows you to do so.
 
-In this case, we did not need control of `reputation` itself. To avoid foot guns, like accidentally setting the reputation to `-18000`, we simply expose the necessary details in the form of `getReputation` and `giveReputation`.
+In this case, we did not need control of the `reputation` variable itself. To avoid foot guns, like accidentally setting the reputation to `-18000`, we simply expose the necessary details in the form of `getReputation` and `giveReputation`.
 
 ### Prototypal inheritance with factories
 


### PR DESCRIPTION

## Because
A learner came into the discord confused (see link below) that `reputation` had not been returned, while the getter did indeed return it. This seemed to have stemmed from a lack of clarity on which of the return statements was being referred to in the explanation - "notice that we did not return the reputation count, itself". From the factory, no. From the getter, yes. A discussion followed in which some changes were proposed to smooth out the wording, and I've done my best to combine them in this PR


## This PR
- Clarifies the explanation for the code example, with a reword
- Rewording tries to be as explicit as possible as to what is being referred to at any given moment


## Issue
Closes #XXXXX

## Additional Information
[The start of the conversation that spurred this PR](https://discord.com/channels/505093832157691914/505093832157691916/1173117241672351804)


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
