### PR TITLE
Node Path Object Constructors: Correct unintended code example behaviour

### DIFF
--- a/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
+++ b/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
@@ -121,7 +121,7 @@ function Player(name, marker) {
   this.name = name;
   this.marker = marker;
   this.sayName = function() {
-    console.log(name)
+    console.log(this.name)
   };
 }
 


### PR DESCRIPTION
## Because
In one of the code [examples](https://www.theodinproject.com/lessons/node-path-javascript-objects-and-object-constructors#object-constructors) on this lesson:
The constructor has a method `sayName` that logs `name` instead of `this.name`. 
While this is syntactically valid, it returns the argument the constructor was called with via closure, instead of the intended instance's name property. This goes unnoticed until one changes the name property of the instance, and then observes the disparity.


## This PR
- Corrects the behaviour to the expected `this.name`


## Issue
Closes #26737


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
