### PR TITLE
Etch-a-Sketch: Be more explicit with instruction to use flexbox

### DIFF
--- a/foundations/javascript_basics/project_etch_a_sketch.md
+++ b/foundations/javascript_basics/project_etch_a_sketch.md
@@ -15,7 +15,7 @@ Don't forget to commit early & often! You can [reference the Commit Message less
 2.  Create a webpage with a 16x16 grid of square divs.
     *   Create the divs using JavaScript. Don't try making them by hand with copy and pasting in your HTML file!
     *   It's best to put your grid squares inside another "container" div \(which can go directly in your HTML\).
-    *   Use flexbox to make the divs appear as a grid \(versus just one on each line\). Despite the name, do not be tempted to research/use CSS Grid for this as Grid will be taught later after foundations. This is an opportunity specifically to get more practice in for flexbox! You will get opportunities to practice CSS Grid when the time is right.
+    *   Use flexbox to make the divs appear as a grid \(versus just one on each line\). Despite the name, do not be tempted to research/use CSS Grid for this as Grid will be taught later after the foundations course. This is an opportunity specifically to get more practice in for flexbox!
     *   Be careful with borders and margins, as they can adjust the size of the squares!
     *   "OMG, why isn't my grid being created???"
         *   Did you link your CSS stylesheet?

--- a/foundations/javascript_basics/project_etch_a_sketch.md
+++ b/foundations/javascript_basics/project_etch_a_sketch.md
@@ -15,7 +15,7 @@ Don't forget to commit early & often! You can [reference the Commit Message less
 2.  Create a webpage with a 16x16 grid of square divs.
     *   Create the divs using JavaScript. Don't try making them by hand with copy and pasting in your HTML file!
     *   It's best to put your grid squares inside another "container" div \(which can go directly in your HTML\).
-    *   You need to make the divs appear as a grid \(versus just one on each line\). This is a perfect opportunity to apply what you have learned about flexbox.
+    *   Use flexbox to make the divs appear as a grid \(versus just one on each line\). Despite the name, do not be tempted to research/use CSS Grid for this as Grid will be taught later after foundations. This is an opportunity specifically to get more practice in for flexbox! You will get opportunities to practice CSS Grid when the time is right.
     *   Be careful with borders and margins, as they can adjust the size of the squares!
     *   "OMG, why isn't my grid being created???"
         *   Did you link your CSS stylesheet?
@@ -35,9 +35,9 @@ Don't forget to commit early & often! You can [reference the Commit Message less
 5.  Push your project to GitHub!
 
 #### Extra credit
-Transform the behavior of a square when interacting with the mouse by introducing a series of modifications. 
+Transform the behavior of a square when interacting with the mouse by introducing a series of modifications.
 
-1. Rather than a simple color change from black to white, each interaction should randomize the square's RGB value entirely. 
+1. Rather than a simple color change from black to white, each interaction should randomize the square's RGB value entirely.
 2. Additionally, implement a progressive darkening effect where each interaction adds 10% more black or color to the square. The objective is to achieve a completely black square only after ten interactions.
 
 You can choose to do either one or both of these challenges, it's up to you.


### PR DESCRIPTION
## Because
Despite previous rewording to remove openendedness of approach for the grid cells to suggest practising flexbox, some people still seem to think to reach for or suggest using CSS Grid. The wording of this flexbox mention has now been reworded as an explicit instruction to use flexbox *and* not to use CSS Grid.


## This PR
- Reword instruction to use flexbox for etch-a-sketch grid cells
- Trailing whitespace removed


## Issue
Closes #26732

## Additional Information
N/A


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
