### PR TITLE
Rephrase additional resource text

### DIFF
--- a/git/foundations_git/commit_messages.md
+++ b/git/foundations_git/commit_messages.md
@@ -33,7 +33,7 @@ Even though it describes what you did, the message is too vague, which leaves th
 Effective commits consist of two separate parts: a subject, and a body:
 
 #### Subject
-A brief summary of the change you made to the project. 
+A brief summary of the change you made to the project.
 
 ```
 This is the change I made to the codebase.
@@ -106,4 +106,4 @@ This section contains questions for you to check your understanding of this less
 This section contains helpful links to related content. It isn’t required, so consider it supplemental.
 
 -   One way to formulate high-information commit messages is to follow a template. [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) is one of many commit message templates that you can explore.
--   Explore this amazing tutorial video on Conventional Commits ➔ [Full Video Link](https://www.youtube.com/watch?v=OJqUWvmf4gg). The video showcases best commit message practices, including Yarn (a package manager) and creating releases. While the Yarn and creating releases information might not be immediately necessary for Foundations, you don't need to worry about it for now. So, feel free to explore and enhance your commit messages and development workflow.
+-   Explore this amazing tutorial video on Conventional Commits ➔ [Full Video Link](https://www.youtube.com/watch?v=OJqUWvmf4gg). The video showcases the Conventional Commits template from the resource above. It also mentions creating releases and shows using something called "Yarn". These two parts are out of scope for this part of the course, so don't worry about them and instead focus on the commit template.


### PR DESCRIPTION
## Because
Conventional commits additional resource has some confusing wording. This PR rephrases it to be more explicit as to what parts to pay attention to and what to not worry about.


## This PR
- Rephrase additional resource text for clarity
- Single trailing white space removed

## Issue
Closes #26723

## Additional Information


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
