### PR TITLE
Clean Code lesson in Foundations: Fix typo

### DIFF
--- a/foundations/javascript_basics/clean_code.md
+++ b/foundations/javascript_basics/clean_code.md
@@ -76,7 +76,7 @@ In our first example we already touched on the importance of naming things _mean
 
 In our good example we have a variable `sum`, to which each new `number` from the array is added. The function is named `sumArray` and the function does what the name suggests (if you're thinking "what even is an array", don't worry - you'll learn about them soon). Nice, clean and understandable.
 
-Now, try picturing a conversation with someone about the bad example. The function is named `x` with variables like `z`, `w` and `q`. Uuf, not nice.
+Now, try picturing a conversation with someone about the bad example. The function is named `x` with variables like `z`, `w` and `q`. Oof, not nice.
 
 #### Use a consistent vocabulary
 


### PR DESCRIPTION
## Because
Just a simple typo I found in the "Clean Code" lesson on the Foundations path. Uuf is not technically a word - I assume this was meant to be oof, so it's been fixed. Very minor, but I thought I'd point it out

## This PR

- Typo fixed in "Clean Code" on Foundations

## Issue

## Additional Information
Also this is my first pull request on GitHub so, happy days!

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
