### PR TITLE
JavaScript Developer Tools lesson: Add warning to debug assignment

### DIFF
--- a/foundations/javascript_basics/javascript_developer_tools.md
+++ b/foundations/javascript_basics/javascript_developer_tools.md
@@ -41,7 +41,7 @@ Google has updated some of the required sections in the below tutorials and some
     -  Mobile Simulation
         1.  [Simulate mobile devices with Device Mode](https://developer.chrome.com/docs/devtools/device-mode/)
     -  JavaScript
-        1.  [Debug JavaScript](https://developer.chrome.com/docs/devtools/javascript/) - Warning: In point 4 of step 3 of the tutorial, devtools will pause on the second line rather than at the declaration of the function. Don’t worry this is expected.
+        1.  [Debug JavaScript](https://developer.chrome.com/docs/devtools/javascript/) - Warning: In point 4 of step 3 of the tutorial, devtools will pause on the second line (`if (inputsAreEmpty()) {`) rather than at the declaration of the function. Don’t worry this is expected.
         2.  [Pause your code with breakpoints](https://developer.chrome.com/docs/devtools/javascript/breakpoints/)
         
 2. Then, watch [the console overview video and read through the page](https://developer.chrome.com/docs/devtools/console/) to familiarize yourself with the console and its usage.

--- a/foundations/javascript_basics/javascript_developer_tools.md
+++ b/foundations/javascript_basics/javascript_developer_tools.md
@@ -41,7 +41,7 @@ Google has updated some of the required sections in the below tutorials and some
     -  Mobile Simulation
         1.  [Simulate mobile devices with Device Mode](https://developer.chrome.com/docs/devtools/device-mode/)
     -  JavaScript
-        1.  [Debug JavaScript](https://developer.chrome.com/docs/devtools/javascript/)
+        1.  [Debug JavaScript](https://developer.chrome.com/docs/devtools/javascript/) - Warning: In point 4 of step 3 of the tutorial, devtools will pause on the second line rather than at the declaration of the function. Don’t worry this is expected.
         2.  [Pause your code with breakpoints](https://developer.chrome.com/docs/devtools/javascript/breakpoints/)
         
 2. Then, watch [the console overview video and read through the page](https://developer.chrome.com/docs/devtools/console/) to familiarize yourself with the console and its usage.


### PR DESCRIPTION
## Because
Adds a warning text for the readers who plan on opening the Chrome Debugger Tutorial link. This prevents further unnecessary confusion since one of the steps in the tutorial states to have an expected outcome that is not necessarily the case. Specifically, it states, 

> "DevTools should be paused on this line of code: `function onClick() {`
> If you're paused on a different line of code, press Resume Script Execution until you're paused on the correct line."

when it should actually end at the second line of the function.


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
* Adds "Warning: In point 4 of step 3 of the tutorial, devtools will pause on the second line rather than at the declaration of the function. Don’t worry this is expected." to the Assignment segment of the Javascript Developer Tools Lesson right after the link to the Chrome Debugger Tutorial is placed.


## Issue
Not part of an open issue

## Additional Information

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
