### PR TITLE
Installing Node.js: Update codeblock delimiters per layout style guide

### DIFF
--- a/foundations/javascript_basics/installing_nodejs.md
+++ b/foundations/javascript_basics/installing_nodejs.md
@@ -10,34 +10,35 @@ Node is also very easy to install using nvm, so this should go quickly :)
 
 This section contains a general overview of topics that you will learn in this lesson.
 
--   Learn how to Install Node Version Manager and Node Package Manager
--   Learn how to run Node console
+- Learn how to Install Node Version Manager and Node Package Manager
+- Learn how to run Node console
 
 ### Installing NVM
 
 <details markdown="block">
   <summary class="dropDown-header">Installation on Linux</summary>
 
-#### Step 0: Prerequisites 
+#### Step 0: Prerequisites
+
 To install nvm properly, you'll need `curl`. Simply run the command below:
 
-~~~bash
+```bash
 sudo apt install curl
-~~~ 
-  
+```
+
 Note: You may need to update the Ubuntu package lists to the latest version for the Curl installation to complete. If so, run the command below:
 
-~~~bash
+```bash
 sudo apt update && sudo apt upgrade
-~~~ 
-  
+```
+
 #### Step 1: Downloading and installing NVM
 
 Simply run this command:
 
-~~~bash
+```bash
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
-~~~
+```
 
 This will install `nvm`
 
@@ -45,16 +46,16 @@ This will install `nvm`
 
 In the terminal there should be some directions on how to initialize `nvm`. If not, (or if you don't feel like copying from the terminal), run these commands:
 
-~~~bash
+```bash
 export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
-~~~
+```
 
 You can verify `nvm` is installed by running the command:
 
-~~~bash
+```bash
 command -v nvm
-~~~
+```
 
 if this returns `nvm: command not found`, close the terminal and re-open it.
 
@@ -67,27 +68,27 @@ On macOS 10.15 and above, the default shell is now zsh. During installation, nvm
 
 To create the `.zshrc` file and start the nvm installation, run the following commands:
 
-~~~bash
+```bash
 touch ~/.zshrc
-~~~
+```
 
-~~~bash
+```bash
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
-~~~
+```
 
-Restart your terminal, or copy and paste the following into your terminal and press <kbd>Enter</kbd>: 
+Restart your terminal, or copy and paste the following into your terminal and press <kbd>Enter</kbd>:
 
-~~~bash
+```bash
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" # This loads nvm bash_completion
-~~~
+```
 
 Test your nvm installation by running:
 
-~~~bash
+```bash
 nvm --version
-~~~
+```
 
 For more information, view [NVM's github documentation](https://github.com/nvm-sh/nvm#installation-and-update).
 
@@ -101,15 +102,15 @@ Now that we have `nvm` installed, we can install Node.
 
 Run:
 
-~~~bash
+```bash
 nvm install --lts
-~~~
+```
 
 This will install the most recent stable version of Node in 'long-term support' (LTS), and you’ll see a lot of output in the terminal. If everything worked, you should see something similar to this somewhere in the lines of output (with the X's replaced with actual numbers):
 
-~~~bash
+```bash
 Downloading and installing Node vXX.xx.x...
-~~~
+```
 
 If not, close the terminal, re-open it and run `nvm install --lts` again.
 
@@ -117,19 +118,19 @@ If not, close the terminal, re-open it and run `nvm install --lts` again.
 
 We need to tell `nvm` which version of Node to use when we run the `node` command. It's easy; just run the following command:
 
-~~~bash
+```bash
 nvm use --lts
-~~~
+```
 
 We have told `nvm` to use the most recent LTS version of Node installed on our computer. You **must** use the LTS version of Node to avoid incompatibilities with packages we will be installing in future lessons. The LTS version of Node is simply a version that is guaranteed support for thirty months after its initial release. It is more stable and compatible with a variety of packages than a non-LTS version of Node.
 
-Now when you run `node -v`, you should see `vXX.xx.x` or something similar (with the X's replaced with actual numbers). 
+Now when you run `node -v`, you should see `vXX.xx.x` or something similar (with the X's replaced with actual numbers).
 
 If you see that, you have successfully installed Node!
 
-### Using Node console  
+### Using Node console
 
-For convenience, Node provides an interactive console which lets you run and edit your javascript code right in your terminal, similar to IRB for ruby. This is quite helpful to debug or test small snippets of your code quickly without opening the browser every time.  
+For convenience, Node provides an interactive console which lets you run and edit your javascript code right in your terminal, similar to IRB for ruby. This is quite helpful to debug or test small snippets of your code quickly without opening the browser every time.
 
 To run the Node console, open up your terminal and type `node`. Type `.exit` to quit the console.
 
@@ -137,4 +138,4 @@ To run the Node console, open up your terminal and type `node`. Type `.exit` to 
 
 This section contains helpful links to related content. It isn’t required, so consider it supplemental.
 
-*   It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.
+- It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.


### PR DESCRIPTION
## Because
Codeblocks should be updated to align with new changes in our [layout style guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)


## This PR
Changes all tildes ~ to backticks ` in the following lesson: [Installing Node.js](https://www.theodinproject.com/lessons/foundations-installing-node-js)


## Issue
Related to #26794

## Additional Information


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
