### PR TITLE
DOM Manipulation and Events: updated codeblock delimiters per layout style guide

### DIFF
--- a/foundations/javascript_basics/DOM_manipulation_and_events.md
+++ b/foundations/javascript_basics/DOM_manipulation_and_events.md
@@ -19,12 +19,12 @@ This section contains a general overview of topics that you will learn in this l
 The DOM (or Document Object Model) is a tree-like representation of the contents of a webpage - a tree of "nodes" with different relationships depending on how they're arranged in the HTML document.
 
 
-~~~html
+```html
 <div id="container">
   <div class="display"></div>
   <div class="controls"></div>
 </div>
-~~~
+```
 
 
 In the above example, the `<div class="display"></div>` is a "child" of `<div id="container"></div>` and a sibling to `<div class="controls"></div>`. Think of it like a family tree. `<div id="container"></div>`  is a **parent**, with its **children** on the next level, each on their own "branch".
@@ -40,7 +40,7 @@ When working with the DOM, you use "selectors" to target the nodes you want to w
 
 You can also use relational selectors (i.e. `firstElementChild` or `lastElementChild` etc.) with special properties owned by the nodes.
 
-~~~javascript
+```javascript
 const container = document.querySelector('#container');
 // selects the #container div (don't worry about the syntax, we'll get there)
 
@@ -52,7 +52,7 @@ const controls = document.querySelector('.controls');
 
 console.dir(controls.previousElementSibling);                  
 // selects the prior sibling => .display
-~~~
+```
 
 So you're identifying a certain node based on its relationships to the nodes around it.
 
@@ -77,9 +77,9 @@ It's important to note that when using querySelectorAll, the return value is **n
 
 - `document.createElement(tagName, [options])` - creates a new element of tag type tagName. `[options]` in this case means you can add some optional parameters to the function.  Don't worry about these at this point.
 
-~~~javascript
+```javascript
 const div = document.createElement('div');
-~~~
+```
 
 This function does NOT put your new element into the DOM - it simply creates it in memory.  This is so that you can manipulate the element (by adding styles, classes, ids, text, etc.) before placing it on the page. You can place the element into the DOM with one of the following methods.
 
@@ -96,14 +96,14 @@ This function does NOT put your new element into the DOM - it simply creates it 
 
 When you have a reference to an element, you can use that reference to alter the element's own properties. This allows you to do many useful alterations, like adding/removing and altering attributes, changing classes, adding inline style information and more.
 
-~~~javascript
+```javascript
 const div = document.createElement('div');                     
 // creates a new div referenced in the variable 'div'
-~~~
+```
 
 #### Adding inline style
 
-~~~javascript
+```javascript
 div.style.color = 'blue';                                      
 // adds the indicated style rule
 
@@ -112,22 +112,22 @@ div.style.cssText = 'color: blue; background: white;';
 
 div.setAttribute('style', 'color: blue; background: white;');    
 // adds several style rules
-~~~
+```
 
 See DOM Enlightenment's [section on CSS Style rules](https://domenlightenment.com/#6.2) for more info on inline styles.
 
 Note that if you're accessing a kebab-cased CSS rule from JS, you'll either need to use camelCase or you'll need to use bracket notation instead of dash notation.
 
-~~~javascript
+```javascript
 div.style.background-color // doesn't work - attempts to subtract color from div.style.background
 div.style.backgroundColor // accesses the div's background-color style
 div.style['background-color'] // also works
 div.style.cssText = "background-color: white;" // sets the div's background-color by assigning a CSS string
-~~~
+```
 
 #### Editing attributes
 
-~~~javascript
+```javascript
 div.setAttribute('id', 'theDiv');                              
 // if id exists, update it to 'theDiv', else create an id
 // with value "theDiv"
@@ -138,13 +138,13 @@ div.getAttribute('id');
 
 div.removeAttribute('id');                                     
 // removes specified attribute
-~~~
+```
 
 See MDN's section on [HTML Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes) for more info on available attributes.
 
 #### Working with classes
 
-~~~javascript
+```javascript
 div.classList.add('new');                                      
 // adds class "new" to your new div
 
@@ -154,24 +154,24 @@ div.classList.remove('new');
 div.classList.toggle('active');                                
 // if div doesn't have class "active" then add it, or if
 // it does, then remove it
-~~~
+```
 
 It is often standard (and cleaner) to toggle a CSS style rather than adding and removing inline CSS.
 
 #### Adding text content
 
-~~~javascript
+```javascript
 div.textContent = 'Hello World!'                               
 // creates a text node containing "Hello World!" and
 // inserts it in div
-~~~
+```
 
 #### Adding HTML content
 
-~~~javascript
+```javascript
 div.innerHTML = '<span>Hello World!</span>';                   
 // renders the HTML inside div
-~~~
+```
 
 <div class="lesson-note--tip" markdown="1">
 
@@ -181,7 +181,7 @@ Note that textContent is preferable for adding text, and innerHTML should be use
 
 Let's take a minute to review what we've covered and give you a chance to practice this stuff before moving on.  Check out this example of creating and appending a DOM element to a webpage.
 
-~~~html
+```html
 <!-- your HTML file: -->
 <body>
   <h1>
@@ -189,9 +189,9 @@ Let's take a minute to review what we've covered and give you a chance to practi
   </h1>
   <div id="container"></div>
 </body>
-~~~
+```
 
-~~~javascript
+```javascript
 // your JavaScript file
 const container = document.querySelector('#container');
 
@@ -200,11 +200,11 @@ content.classList.add('content');
 content.textContent = 'This is the glorious text-content!';
 
 container.appendChild(content);
-~~~
+```
 
 In the JavaScript file, first we get a reference to the `container` div that already exists in our HTML.  Then we create a new div and store it in the variable `content`.  We add a class and some text to the `content` div and finally append that div to `container`.   All in all it's a simple process.  After the JavaScript code is run, our DOM tree will look like this:
 
-~~~html
+```html
 <!-- The DOM -->
 <body>
   <h1>
@@ -216,7 +216,7 @@ In the JavaScript file, first we get a reference to the `container` div that alr
     </div>
   </div>
 </body>
-~~~
+```
 
 Keep in mind that the JavaScript does *not* alter your HTML, but the DOM - your HTML file will look the same, but the JavaScript changes what the browser renders.
 
@@ -226,11 +226,11 @@ Your JavaScript, for the most part, is run whenever the JS file is run, or when 
 
 Alternatively, you can link the JavaScript file in the `<head>` of your HTML document. Use the `<script>` tag with the `src` attribute containing the path to the JS file, and include the `defer` keyword to load the file *after* the HTML is parsed, as such:
 
-~~~html
+```html
 <head>
   <script src="js-file.js" defer></script>
 </head>
-~~~
+```
 
 Read the second bullet point (under the Applying CSS and JavaScript to HTML section) in [this MDN article](https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML#applying_css_and_javascript_to_html) for more information, which also includes a link to additional script loading strategies.
 
@@ -259,24 +259,24 @@ We're going to create 3 buttons that all alert "Hello World" when clicked.  Try 
 
 #### Method 1
 
-~~~html
+```html
 <button onclick="alert('Hello World')">Click Me</button>
-~~~
+```
 
 This solution is less than ideal because we're cluttering our HTML with JavaScript. Also, we can only set one "onclick" property per DOM element, so we're unable to run multiple separate functions in response to a click event using this method.
 
 #### Method 2
 
-~~~html
+```html
 <!-- the HTML file -->
 <button id="btn">Click Me</button>
-~~~
+```
 
-~~~javascript
+```javascript
 // the JavaScript file
 const btn = document.querySelector('#btn');
 btn.onclick = () => alert("Hello World");
-~~~
+```
 
 **(Need to review [arrow functions](http://javascript.info/arrow-functions-basics)?)**
 
@@ -284,30 +284,30 @@ This is a little better. We've moved the JS out of the HTML and into a JS file, 
 
 #### Method 3
 
-~~~html
+```html
 <!-- the HTML file -->
 <button id="btn">Click Me Too</button>
-~~~
+```
 
-~~~javascript
+```javascript
 // the JavaScript file
 const btn = document.querySelector('#btn');
 btn.addEventListener('click', () => {
   alert("Hello World");
 });
-~~~
+```
 
 Now, we maintain separation of concerns, and we also allow multiple event listeners if the need arises. Method 3 is much more flexible and powerful, though it is a bit more complex to set up.
 
 Note that all 3 of these methods can be used with named functions like so:
 
-~~~html
+```html
 <!-- the HTML file -->
 <!-- METHOD 1 -->
 <button onclick="alertFunction()">CLICK ME BABY</button>
-~~~
+```
 
-~~~javascript
+```javascript
 // the JavaScript file
 function alertFunction() {
   alert("YAY! YOU DID IT!");
@@ -318,17 +318,17 @@ btn.onclick = alertFunction;
 
 // METHOD 3
 btn.addEventListener('click', alertFunction);
-~~~
+```
 
 Using named functions can clean up your code considerably, and is a *really* good idea if the function is something that you are going to want to do in multiple places.
 
 With all three methods we can access more information about the event by passing a parameter to the function that we are calling.  Try this out on your own machine:
 
-~~~javascript
+```javascript
 btn.addEventListener('click', function (e) {
   console.log(e);
 });
-~~~
+```
 
 <div class="lesson-note--tip" markdown="1">
 
@@ -340,19 +340,19 @@ The `e` in that function is an object that references the **event** itself.  Wit
 
 Try this:
 
-~~~javascript
+```javascript
 btn.addEventListener('click', function (e) {
   console.log(e.target);
 });
-~~~
+```
 
 and now this:
 
-~~~javascript
+```javascript
 btn.addEventListener('click', function (e) {
   e.target.style.background = 'blue';
 });
-~~~
+```
 
 Pretty cool, eh?
 
@@ -360,15 +360,15 @@ Pretty cool, eh?
 
 This might seem like a lot of code if you're attaching lots of similar event listeners to many elements. There are a few ways to go about doing that more efficiently.  We learned above that we can get a nodelist of all of the items matching a specific selector with `querySelectorAll('selector')`.  In order to add a listener to each of them we simply need to iterate through the whole list like so:
 
-~~~HTML
+```HTML
 <div id="container">
     <button id="1">Click Me</button>
     <button id="2">Click Me</button>
     <button id="3">Click Me</button>
 </div>
-~~~
+```
 
-~~~javascript
+```javascript
 // buttons is a node list. It looks and acts much like an array.
 const buttons = document.querySelectorAll('button');
 
@@ -380,7 +380,7 @@ buttons.forEach((button) => {
     alert(button.id);
   });
 });
-~~~
+```
 
 This is just the tip of the iceberg when it comes to DOM manipulation and event handling, but it's enough to get you started with some exercises.  In our examples so far we have been using the 'click' event exclusively, but there are *many* more available to you.  
 


### PR DESCRIPTION
## Because
Codeblocks should be updated to align with new changes in the [layout style guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

## This PR
- Changes all tildes ~ to backticks ` in the lesson [DOM Manipulation and Events](https://www.theodinproject.com/lessons/foundations-dom-manipulation-and-events)

## Issue
Related to #26794 

## Additional Information

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
