### PR TITLE
Sessions Cookies and Authentication. Fix wrong information regarding callback.

### DIFF
--- a/ruby_on_rails/forms_and_authentication/sessions_cookies_authentication.md
+++ b/ruby_on_rails/forms_and_authentication/sessions_cookies_authentication.md
@@ -98,15 +98,24 @@ Before we talk about authentication, we need to cover controller filters.  The i
 ~~~ruby
   # app/controllers/users_controller
   before_action :require_login
+  before_action :do_something_cool
   ...
   private
 
   def require_login
-    # do stuff to check if user is logged in
+    if current_user.logged_in?
+    # allow the user to perform the action they wanted
+    else
+      redirect_to login_path
+    end
+  end
+
+  def do_something_cool
+    # do stuff here
   end
 ~~~
 
-The `before_action` method takes the symbol of the method to run before anything else gets run in the controller.  If it returns `false` or `nil`, the request will not succeed.
+The `before_action` method takes the symbol of the method to run before anything else gets run in the controller. In the case that this callback renders or redirects, the request, as well as any callbacks that are scheduled to run after that callback, are also cancelled. So in the case above, if the user was redirected to the login page, the `before_action :do_something_cool` callback wouldn't have been executed either.
 
 You can specify to only apply the filter for specific actions by specifying the `only` option, e.g. `before_action :require_login, only: [:edit, :update]`.  The opposite applies by using the `:except` option... it will run for all actions except those specified.
 


### PR DESCRIPTION
## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
Correct and add clarifying information about the `before_action` callback.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #26801 


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [ ] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
