### PR TITLE
Node pathway/Linting: Add section on template repos

### DIFF
--- a/javascript/javascript_in_the_real_world/linting.md
+++ b/javascript/javascript_in_the_real_world/linting.md
@@ -51,7 +51,7 @@ Another way to address the conflict is to use `eslint-plugin-prettier`. It lets 
 
 ### Template repositories
 
-With the last few projects, you have felt that setting up Webpack involved a fair few files and configuration, and that you may have had to look at what you configured before to copy and paste the configuration you want to reuse. You may also have noticed that whenever you create a new repository on Github, there is an option near the top for a `Repository template`.
+With the last few projects, you might have felt that setting up Webpack involved a fair few files and configuration, and that you may have had to look at what you configured before to copy and paste the configuration you want to reuse. You may also have noticed that whenever you create a new repository on Github, there is an option near the top for a `Repository template`.
 
 This is where template repositories can come very much in handy. Any of your existing repositories can be converted to a template in its settings (right under where you can rename the repository, there is a checkbox for whether the repository is a template or not). If you check this box, congratulations, that's all you need to do! Now when you go to create a new repository, the `Repository template` dropdown will have any templates listed for you to select. Selecting one will mean your new repository will be a copy of the chosen template, not an empty one!
 

--- a/javascript/javascript_in_the_real_world/linting.md
+++ b/javascript/javascript_in_the_real_world/linting.md
@@ -1,10 +1,10 @@
 ### Introduction
 
-Before we dive all the way into the Code, we are going to take a moment to improve your editor setup. Doing this now will make things much easier for you going forward. This lesson will give you some information about code style, and then give you some tools to help you maintain consistent code-style throughout your projects.  In some cases it can even help adjust things like indentation for you!
+Before we dive all the way into the Code, we are going to take a moment to improve your editor setup and overall productivity. Doing this now will make things much easier for you going forward. This lesson will give you some information about code style, and then give you some tools to help you maintain consistent code-style throughout your projects.  In some cases it can even help adjust things like indentation for you! We will also introduce repository templates which can save you time setting up projects that share a lot of configuration with other projects.
 
 ### Style guides
 
-Code style is important! Having a consistent set of style rules for things such as indentation or preferred quote style makes your code more maintainable and easier to read. There are several popular JavaScript style guides on the net that set standards for these types of things, and a little time spent reading them _will_ make you a better developer. 
+Code style is important! Having a consistent set of style rules for things such as indentation or preferred quote style makes your code more maintainable and easier to read. There are several popular JavaScript style guides on the net that set standards for these types of things, and a little time spent reading them _will_ make you a better developer.
 
 1. The [Airbnb Style Guide](https://github.com/airbnb/javascript) is one of the most popular. It is also very well formatted and easy to read.
 2. Google also has their own [style guide](https://google.github.io/styleguide/jsguide.html) for JavaScript.
@@ -15,6 +15,7 @@ Code style is important! Having a consistent set of style rules for things such 
 This section contains a general overview of topics that you will learn in this lesson.
 
 - Set up a linter and prettier to make your code better.
+- Learn what repository templates are and how to set one up.
 
 ### Linting
 
@@ -48,6 +49,14 @@ We **highly** recommend that you install ESlint and Prettier and use them for al
 However, using ESLint and Prettier together causes conflicts. To fix that follow the instructions to install [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier#installation). It turns off all ESLint rules that are unnecessary or might conflict with Prettier. Doing just this is enough to resolve the conflict and get them both working smoothly with one another.
 Another way to address the conflict is to use `eslint-plugin-prettier`. It lets you run Prettier as if it were a rule in ESLint. However, doing this is **not recommended**. You can learn more about it [here](https://prettier.io/docs/en/integrating-with-linters.html#notes).
 
+### Repository templates
+
+With the last few projects, you have felt that setting up Webpack involved a fair few files and configuration, and that you may have had to look at what you configured before to copy and paste the configuration you want to reuse. You may also have noticed that whenever you create a new repository on Github, there is an option near the top for a `Repository template`.
+
+This is where repository templates can come very much in handy. Any of your existing repositories can be converted to a template in its settings (right under where you can rename the repository, there is a checkbox for whether the repository is a template or not). If you check this box, congratulations, that's all you need to do! Now when you go to create a new repository, the `Repository template` dropdown will have any templates listed for you to select. Selecting one will mean your new repository will be a copy of the chosen template, not an empty one!
+
+If you find yourself reusing a lot of setup code for multiple projects, you can simply make a new repository with all of the setup code you need then mark it as a template. Now any new project repositories can use that template to save time getting set up so you can dive into working on the project itself sooner!
+
 ### Knowledge check
 
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
@@ -55,3 +64,4 @@ This section contains questions for you to check your understanding of this less
 - [What is linting?](https://mikecavaliere.com/javascript-linting-what-developers-need-to-know/)
 - [Which problems can linting prevent?](https://mikecavaliere.com/javascript-linting-what-developers-need-to-know/)
 - [Why should you use Prettier?](https://www.youtube.com/watch?v=hkfBvpEfWdA)
+- [What is a repository template?](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-template-repository)

--- a/javascript/javascript_in_the_real_world/linting.md
+++ b/javascript/javascript_in_the_real_world/linting.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-Before we dive all the way into the Code, we are going to take a moment to improve your editor setup and overall productivity. Doing this now will make things much easier for you going forward. This lesson will give you some information about code style, and then give you some tools to help you maintain consistent code-style throughout your projects.  In some cases it can even help adjust things like indentation for you! We will also introduce repository templates which can save you time setting up projects that share a lot of configuration with other projects.
+Before we dive all the way into the Code, we are going to take a moment to improve your editor setup and overall productivity. Doing this now will make things much easier for you going forward. This lesson will give you some information about code style, and then give you some tools to help you maintain consistent code-style throughout your projects.  In some cases it can even help adjust things like indentation for you! We will also introduce template repositories which can save you time setting up projects that share a lot of configuration with other projects.
 
 ### Style guides
 
@@ -15,7 +15,7 @@ Code style is important! Having a consistent set of style rules for things such 
 This section contains a general overview of topics that you will learn in this lesson.
 
 - Set up a linter and prettier to make your code better.
-- Learn what repository templates are and how to set one up.
+- Learn what template repositories are and how to set one up.
 
 ### Linting
 
@@ -49,13 +49,13 @@ We **highly** recommend that you install ESlint and Prettier and use them for al
 However, using ESLint and Prettier together causes conflicts. To fix that follow the instructions to install [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier#installation). It turns off all ESLint rules that are unnecessary or might conflict with Prettier. Doing just this is enough to resolve the conflict and get them both working smoothly with one another.
 Another way to address the conflict is to use `eslint-plugin-prettier`. It lets you run Prettier as if it were a rule in ESLint. However, doing this is **not recommended**. You can learn more about it [here](https://prettier.io/docs/en/integrating-with-linters.html#notes).
 
-### Repository templates
+### Template repositories
 
 With the last few projects, you have felt that setting up Webpack involved a fair few files and configuration, and that you may have had to look at what you configured before to copy and paste the configuration you want to reuse. You may also have noticed that whenever you create a new repository on Github, there is an option near the top for a `Repository template`.
 
-This is where repository templates can come very much in handy. Any of your existing repositories can be converted to a template in its settings (right under where you can rename the repository, there is a checkbox for whether the repository is a template or not). If you check this box, congratulations, that's all you need to do! Now when you go to create a new repository, the `Repository template` dropdown will have any templates listed for you to select. Selecting one will mean your new repository will be a copy of the chosen template, not an empty one!
+This is where template repositories can come very much in handy. Any of your existing repositories can be converted to a template in its settings (right under where you can rename the repository, there is a checkbox for whether the repository is a template or not). If you check this box, congratulations, that's all you need to do! Now when you go to create a new repository, the `Repository template` dropdown will have any templates listed for you to select. Selecting one will mean your new repository will be a copy of the chosen template, not an empty one!
 
-If you find yourself reusing a lot of setup code for multiple projects, you can simply make a new repository with all of the setup code you need then mark it as a template. Now any new project repositories can use that template to save time getting set up so you can dive into working on the project itself sooner!
+If you find yourself reusing a lot of setup code for multiple projects, you can simply make a new repository with all of the setup code you need then mark it as a template. Now you can select that template when creating a new project repository to save time getting set up, letting you dive into working on the project itself sooner!
 
 ### Knowledge check
 
@@ -64,4 +64,4 @@ This section contains questions for you to check your understanding of this less
 - [What is linting?](https://mikecavaliere.com/javascript-linting-what-developers-need-to-know/)
 - [Which problems can linting prevent?](https://mikecavaliere.com/javascript-linting-what-developers-need-to-know/)
 - [Why should you use Prettier?](https://www.youtube.com/watch?v=hkfBvpEfWdA)
-- [What is a repository template?](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-template-repository)
+- [What is a template repository?](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-template-repository)


### PR DESCRIPTION
## Because
Template repos are simple and very handy, and are commonly suggested when learners ask about easier ways to manage things like reusing Webpack config for new projects.
A brief mention of what they are and how to set/use one has been added to the end of the Linting lesson, as part of the lesson's "productivity" theme, whilst also giving the learner an opportunity to get a better feel for Webpack across Restaurant Page/To-do list first.

## This PR
- Adds content on template repos
- Rephrase intro text to account for new content
- Add knowledge check and doc link for template repos


## Issue
Closes #26515

## Additional Information


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
