### PR TITLE
Node deployment: Add Adaptable.io as PaaS option

### DIFF
--- a/nodeJS/express_and_mongoose/deployment.md
+++ b/nodeJS/express_and_mongoose/deployment.md
@@ -140,7 +140,7 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 **Free plan**
 
 - No limits on the number of apps you can deploy on the free plan.
-- App performance is limited but very similar to the other PaaS options and more than sufficient for our purposes.
+- Monthly performance allowance is more than sufficient for course/personal projects (approx. 25,000 API requests per month).
 - Idle server wake up duration is quicker than Render.
 - No credit card required.
 

--- a/nodeJS/express_and_mongoose/deployment.md
+++ b/nodeJS/express_and_mongoose/deployment.md
@@ -121,13 +121,34 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 
 **Free plan**
 
-- You get a free one-time grant of 5$ on their free trial, and the applications are never put to sleep when inactive.
+- You get a free one-time grant of $5 on their free trial, and the applications are never put to sleep when inactive.
 - However, the longevity of your free allowance depends on how many resources you consume. Full usage of the resources available is only enough to host one app for about 30 days, and thus isn't recommended.
 
 **Links**
 
 - [Homepage](https://railway.app/)
 - [Documentation](https://docs.railway.app/)
+
+---
+
+### Adaptable.io
+
+- Like Railway, has a simple deployment process. You simply link to your project's GitHub repo.
+- Free plan does not limit the number of apps you can deploy.
+- Also has fixed and usage-based payment plans.
+
+**Free plan**
+
+- No limits on the number of apps you can deploy on the free plan.
+- App performance is limited but very similar to the other PaaS options and more than sufficient for our purposes.
+- Idle server wake up duration is quicker than Render.
+- No credit card required.
+
+**Links**
+
+- [Homepage](https://adaptable.io/)
+- [Documentation](https://adaptable.io/docs/what-is-adaptable)
+- [Guide: Official getting started with deploying an Express app on Adaptable guide](https://adaptable.io/docs/app-guides/deploy-express-app)
 
 ---
 

--- a/nodeJS/express_and_mongoose/deployment.md
+++ b/nodeJS/express_and_mongoose/deployment.md
@@ -134,14 +134,14 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 ### Adaptable.io
 
 - Like Railway, has a simple deployment process. You simply link to your project's GitHub repo.
-- Free plan does not limit the number of apps you can deploy.
+- Free plan does not limit the number of applications you can deploy.
 - Also has fixed and usage-based payment plans.
 
 **Free plan**
 
-- No limits on the number of apps you can deploy on the free plan.
-- Monthly performance allowance is more than sufficient for course/personal projects (approx. 25,000 API requests per month).
-- Idle server wake up duration is quicker than Render.
+- No limits on the number of applications you can deploy on the free plan.
+- Monthly performance allowance is more than sufficient for course/personal projects (approximately 25,000 API requests per month).
+- Applications are put to sleep when inactive but wake up speed is quicker than Render.
 - No credit card required.
 
 **Links**


### PR DESCRIPTION
## Because
Adaptable is a great Heroku-like alternative deployment for Node apps that has (for now) a no-app-limit free tier and does not require a credit card. Deployment is simple like Railway and Render by simply linking a GH repo and a very similar configuration regarding environment variables.
In a nutshell, it's probably the simplest PaaS to use in terms of the course whilst also not having as many of the annoying limitations of the other options outside of the expected free-tier performance (which of course is not relevant at this point).


## This PR
- Adds Adaptable.io as a new PaaS option to the Node deployment lesson (may be compatible with Rails via Dockerfile but [likely out of the scope of the course](https://github.com/TheOdinProject/curriculum/issues/26731#issuecomment-1832401440))
- Fixes incorrect position of $ sign


## Issue
Closes #26731

## Additional Information


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
