### PR TITLE
Custom Properties Lesson: Update codeblocks delimiters per layout style guide

### DIFF
--- a/intermediate_html_css/intermediate_css_concepts/custom_properties.md
+++ b/intermediate_html_css/intermediate_css_concepts/custom_properties.md
@@ -13,7 +13,7 @@ We can even redefine custom properties under different contexts, which is incred
 
 The syntax for declaring and accessing a custom property is really simple and not too different from how we write normal rule declarations:
 
-~~~css
+```css
 .error-modal {
   --color-error-text: red;
   --modal-border: 1px solid black;
@@ -23,7 +23,7 @@ The syntax for declaring and accessing a custom property is really simple and no
   border: var(--modal-border);
   font-size: var(--modal-font-size);
 }
-~~~
+```
 
 That's it! First, we declare our custom property with a double hyphen followed by a case-sensitive, hyphen-separated property name (`color-error-text` wouldn't be the same as `Color-Error-Text`). The use of Kebab case (single hyphens to separate words) is very important here because spaces are not valid (`--color error text` would not work). Then we can store any valid CSS value in our newly declared custom property, whether it be a simple color value, shorthand values, or even a more complex function, just to give you a few examples.
 
@@ -33,14 +33,14 @@ When we want to access a custom property, we use the `var()` function as the val
 
 The `var()` function actually accepts two parameters. The first parameter we've already gone over, which is the custom property we want to assign. The second parameter is an optional fallback value. When a fallback value is provided in addition to a custom property, the fallback value will be used if the custom property is invalid or hasn't been declared yet. We can even pass in *another* custom property as a fallback, which can have *its own* fallback value as well!
 
-~~~css
+```css
 .fallback {
   --color-text: white;
 
   background-color: var(--undeclared-property, black);
   color: var(--undeclared-again, var(--color-text, yellow));
 }
-~~~
+```
 
 In the above example, our `background-color` property would have a value of `black` and our `color` property would have a value of `white`. If the `--color-text` custom property was invalid or didn't exist, the fallback to our fallback would take over and the `color` property would have a value of `yellow`.
 
@@ -50,14 +50,14 @@ In the first example above, you may have noticed that we declared and then acces
 
 In the example below, only the element with the `cool-paragraph` class would get styled with a red background since it's a descendant of the element where our custom property is declared.
 
-~~~html
+```html
 <div class='cool-div'>
   <p class='cool-paragraph'>Check out my cool, red background!</p>
 </div>
 
 <p class='boring-paragraph'>I'm not in scope so I'm not cool.</p>
-~~~
-~~~css
+```
+```css
 .cool-div {
   --main-bg: red;
 }
@@ -69,7 +69,7 @@ In the example below, only the element with the `cool-paragraph` class would get
 .boring-paragraph {
   background-color: var(--main-bg);
 }
-~~~
+```
 
 #### The :root selector
 
@@ -77,12 +77,12 @@ While there may be times where you will want to limit the scope of a custom prop
 
 A better solution is declaring those custom properties on the `:root` selector, which is essentially the same thing as the `html` selector except it has a higher specificity.
 
-~~~html
+```html
 <p class='cool-paragraph'>Lorem ipsum dolor sit amet.</p>
 
 <p class='exciting-paragraph'>Lorem ipsum dolor sit amet.</p>
-~~~
-~~~css
+```
+```css
 :root {
   --main-color: red;
 }
@@ -94,7 +94,7 @@ A better solution is declaring those custom properties on the `:root` selector, 
 .exciting-paragraph {
   background-color: var(--main-color);
 }
-~~~
+```
 
 By declaring our custom property on the `:root` selector in the example above, we can access it on *any* other valid selector within our CSS file, since any other selector would be considered a descendant of the `:root` selector.
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Codeblocks should be updated to align with new changes in our [layout style guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Replaces all tildes characters with backticks characters in the Custom Properties Lesson

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Related to #26842

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
