### PR TITLE
 Intermediate HTML and CSS course: Updated codeblock delimiters in the SVG lesson

### DIFF
--- a/intermediate_html_css/intermediate_html_concepts/svgs.md
+++ b/intermediate_html_css/intermediate_html_concepts/svgs.md
@@ -34,12 +34,12 @@ The fact that SVG source-code is XML has a few key benefits.
 
 First, it means that it is _human-readable_. If you were to open up a JPEG in a text editor, it would just look like gobbledygook. If you were to open up an SVG, however, it would look something like this:
 
-~~~xml
+```xml
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
     <rect x=0 y=0 width=100 height=50 />
     <circle class="svg-circle" cx="50" cy="50" r="10"/>
 </svg>
-~~~
+```
 
 It might still be confusing, but hey--those are words! Tags! Attributes! Compared to [binary file formats](https://en.wikipedia.org/wiki/Binary_file) like JPEG, we're definitely in familiar territory.
 


### PR DESCRIPTION
## Because
Codeblocks should be updated to align with new changes in the [layout style guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)


## This PR

- replaced all the tildes ~ with backticks `  in the [SVG lesson](https://www.theodinproject.com/lessons/node-path-intermediate-html-and-css-svg) in the Intermediate HTML and CSS course


## Issue
Related to https://github.com/TheOdinProject/curriculum/issues/26842

## Additional Information

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
