### PR TITLE
Intermediate HTML and CSS: Update codeblock delimiters as per layout style guide in Form Basics Lesson

### DIFF
--- a/intermediate_html_css/forms/form_basics.md
+++ b/intermediate_html_css/forms/form_basics.md
@@ -29,11 +29,11 @@ POST is used when we want to change something on the server, for example, when a
 
 The markup for creating a form element looks like this:
 
-~~~html
+```html
 <form action="example.com/path" method="post">
 
 </form>
-~~~
+```
 
 ### Form controls
 
@@ -45,11 +45,11 @@ The input element is the most versatile of all the form control elements. It acc
 
 A text input looks like this:
 
-~~~html
+```html
 <form action="example.com/path" method="post">
   <input type="text">
 </form>
-~~~
+```
 
 Text inputs accept any text input. For example, you would use it to collect things like users' first and last names.
 
@@ -59,12 +59,12 @@ An input on its own isn't very useful since the user will not know what kind of 
 
 To create a label, we use the `<label>` element. The text we want displayed in the label will go between its opening and closing tags:
 
-~~~html
+```html
 <form action="example.com/path" method="post">
   <label for="first_name">First Name:</label>
   <input type="text" id="first_name">
 </form>
-~~~
+```
 
 Labels accept a `for` attribute, which associates it with a particular input. The input we want to associate with a label needs an `id` attribute with the same value as the label's `for` attribute.
 
@@ -76,10 +76,10 @@ To guide users on what to enter in form elements, we can include placeholder tex
 
 This is done by adding a `placeholder` attribute to an input. The value will be the *placeholder* text we want to display in the input:
 
-~~~html
+```html
 <label for="first_name">First Name:</label>
 <input type="text" id="first_name" placeholder="Bob...">
-~~~
+```
 
 Use placeholder text to demonstrate how text should be entered and formatted.
 
@@ -90,10 +90,10 @@ We need to use labels so that users understand what the data entered into an inp
 
 We do this by adding a `name` attribute to our inputs:
 
-~~~html
+```html
 <label for="first_name">First Name:</label>
 <input type="text" id="first_name" name="first_name">
-~~~
+```
 
 The `name` attribute serves as a reference to the data inputted into a form control after submitting it. You can think of it as a variable name for the input. Form input should always have a `name` attribute; otherwise, it will be ignored when the form is submitted.
 
@@ -108,13 +108,13 @@ To get a better understanding of what this looks like we can submit a form to [h
 
 The output we care about from the response is the "form" object. It should look something like this:
 
-~~~json
+```json
 "form": {
     "age": "33",
     "first_name": "John",
     "last_name": "Doe"
   },
-~~~
+```
 
 Try changing the `name` attributes of some of the input fields in the form and removing the attribute entirely, then submit the form again to see how the form data in the response changes.
 
@@ -141,37 +141,37 @@ They also validate that the user has entered a correctly formatted email address
 
 To create an email input, we use an input element with `type` attribute of "email":
 
-~~~html
+```html
 <label for="user_email">Email Address:</label>
 <input type="email" id="user_email" name="email" placeholder="you@example.com">
-~~~
+```
 
 `Password inputs` are another specialized text input. They differ from regular text inputs in that they mask the inputted data with another character – usually an asterisk (*) or bullet point (•) – to prevent anyone from seeing what has been entered.
 
 A password input can be created using an input element with a type of "password":
 
-~~~html
+```html
 <label for="user_password">Password:</label>
 <input type="password" id="user_password" name="password">
-~~~
+```
 
 The `number input` only accepts number values and ignores any other characters the user tries to enter.
 
 We create a number input using the input element with a `type` attribute of "number":
 
-~~~html
+```html
 <label for="amount">Amount:</label>
 <input type="number" id="amount" name="amount">
-~~~
+```
 
 To collect dates from a user, we can use a `date input`. This input is unique because it provides a better user experience for choosing dates by rendering a simple date picker calendar.
 
 To create a date input, we use the input element with a `type` attribute of "date":
 
-~~~html
+```html
 <label for="dob">Date of Birth:</label>
 <input type="date" id="dob" name="dob">
-~~~
+```
 
 **Text area**
 
@@ -179,21 +179,21 @@ While technically not an input element, the text area element provides an input 
 
 To create a text area, we use the `<textarea>` element:
 
-~~~html
+```html
 <textarea></textarea>
-~~~
+```
 
 Unlike input elements, Textarea elements do have a closing tag. This allows you to wrap some initial content you want the text area to display:
 
-~~~html
+```html
 <textarea>Some initial content</textarea>
-~~~
+```
 
 Text area elements accept a couple of unique attributes that other form controls do not. These are the `rows` and `cols` attributes. They allow you to control the initial height (rows) and width (cols) of the text area:
 
-~~~html
+```html
 <textarea rows="20" cols="60"></textarea>
-~~~
+```
 
 ### Selection elements
 
@@ -205,7 +205,7 @@ The select element renders a dropdown list where users can select an option. Syn
 
 To create a select dropdown, we use the `<select>` element. Any options we want to display within the select element are defined using `<option>` elements:
 
-~~~html
+```html
 <select name="Car">
   <option value="mercedes">Mercedes</option>
   <option value="tesla">Tesla</option>
@@ -214,13 +214,13 @@ To create a select dropdown, we use the `<select>` element. Any options we want 
   <option value="mini">Mini</option>
   <option value="ford">Ford</option>
 </select>
-~~~
+```
 
 All the option elements should have a `value` attribute (otherwise the text content inside is used). This value will be sent to the server when the form is submitted.
 
 We can set one of the options to be the default selected element when the browser first renders the form by giving one of the options the `selected` attribute:
 
-~~~html
+```html
 <select name="Car">
   <option value="mercedes">Mercedes</option>
   <option value="tesla">Tesla</option>
@@ -229,11 +229,11 @@ We can set one of the options to be the default selected element when the browse
   <option value="mini">Mini</option>
   <option value="ford">Ford</option>
 </select>
-~~~
+```
 
 We may also split the list of options into groups using the `<optgroup>` element. The optgroup element takes a `label` attribute which the browser uses as the label for each group:
 
-~~~html
+```html
 <select name="fashion">
   <optgroup label="Clothing">
     <option value="t_shirt">T-Shirts</option>
@@ -246,7 +246,7 @@ We may also split the list of options into groups using the `<optgroup>` element
     <option value="sandals">Sandals</option>
   </optgroup>
 </select>
-~~~
+```
 
 **Radio buttons**
 
@@ -254,7 +254,7 @@ Select dropdowns are great for saving space on the page when we have an extensiv
 
 In this case, we can use radio buttons. Radio buttons allow us to create multiple options that the user can choose one of. To create radio buttons, we use the ever adaptable input element again with a `type` attribute of "radio":
 
-~~~html
+```html
 <h1>Ticket Type</h1>
 <div>
   <input type="radio" id="child" name="ticket_type" value="child">
@@ -270,13 +270,13 @@ In this case, we can use radio buttons. Radio buttons allow us to create multipl
   <input type="radio" id="senior" name="ticket_type" value="senior">
   <label for="senior">Senior</label>
 </div>
-~~~
+```
 
 When we select one of the radio buttons and then select another, it will deselect the first one. Radio buttons know to do this because they have the same `name` attribute. This is how the browser knows these elements are part of the same group of options.
 
 We can set the default selected radio button by adding the `checked` attribute to it:
 
-~~~html
+```html
 <h1>Ticket Type</h1>
 <div>
   <input type="radio" id="child" name="ticket_type" value="child">
@@ -292,7 +292,7 @@ We can set the default selected radio button by adding the `checked` attribute t
   <input type="radio" id="senior" name="ticket_type" value="senior">
   <label for="senior">Senior</label>
 </div>
-~~~
+```
 
 **Checkboxes**
 
@@ -300,7 +300,7 @@ Checkboxes are similar to radio buttons in that they allow users to choose from 
 
 To create a checkbox, we use the input element with a `type` attribute of "checkbox":
 
-~~~html
+```html
 <h1>Pizza Toppings</h1>
 
 <div>
@@ -322,25 +322,25 @@ To create a checkbox, we use the input element with a `type` attribute of "check
   <input type="checkbox" id="mushrooms" name="topping" value="mushrooms">
   <label for="mushrooms">Mushrooms</label>
 </div>
-~~~
+```
 
 We can also have a single checkbox when we want users to toggle if they want something to be true or false. Like signing up to a newsletter when they create an account for example:
 
-~~~html
+```html
 <div>
   <input type="checkbox" id="newsletter" name="news_letter">
   <label for="newsletter">Send me the news letter</label>
 </div>
-~~~
+```
 
 We can set checkboxes to be checked by default on page load by giving them a `checked` attribute:
 
-~~~html
+```html
 <div>
   <input type="checkbox" id="newsletter" name="news_letter" checked>
   <label for="newsletter">Send me the news letter</label>
 </div>
-~~~
+```
 
 ### Buttons
 
@@ -348,9 +348,9 @@ The button element creates clickable buttons that the user can interact with to 
 
 To create a button, we use the `<button>` element. The content or text we want to have displayed inside the button will go within the opening and closing tags:
 
-~~~html
+```html
 <button>Click Me</button>
-~~~
+```
 
 The button element also accepts a `type` attribute that tells the browser which kind of button it is dealing with. There are three types of buttons available to us.
 
@@ -360,9 +360,9 @@ Once a user is finished filling in a form, they will need a way to submit it. Th
 
 To create a submit button, we use the button element with a `type` attribute of "submit":
 
-~~~html
+```html
 <button type="submit">Submit</button>
-~~~
+```
 
 **Reset button**
 
@@ -370,9 +370,9 @@ A reset button clears all the data the user has entered into the form and sets a
 
 To create a reset button, we use the button element with a `type` attribute of "reset":
 
-~~~html
+```html
 <button type="reset">Reset</button>
-~~~
+```
 
 **Generic button**
 
@@ -380,9 +380,9 @@ The third and final button type is simply a generic button that can be used for 
 
 To create a generic button, we use the button element with a `type` attribute of "button":
 
-~~~html
+```html
 <button type="button">Click to Toggle</button>
-~~~
+```
 
 <div class="lesson-note lesson-note--tip" markdown=1>
 It is important to remember that a button within a form with the `type` value of submit (which happens to be the default value) will always try to make a new request and submit data back to the server. Hence, for buttons that are used within a form for different purposes other than submitting the data, the `type` attribute should always be specified to avoid unwanted effects of submitting a form.
@@ -400,7 +400,7 @@ The fieldset element is a container element that allows us to group related form
 
 To create a fieldset, we use the `<fieldset>` element. Whatever form inputs we want to group together go within the opening and closing fieldset tags:
 
-~~~html
+```html
 <fieldset>
   <label for="first_name">First Name</label>
   <input type="text" id="first_name" name="first_name">
@@ -408,7 +408,7 @@ To create a fieldset, we use the `<fieldset>` element. Whatever form inputs we w
   <label for="last_name">Last Name</label>
   <input type="text" id="last_name" name="last_name">
 </fieldset>
-~~~
+```
 
 **Legend**
 
@@ -416,7 +416,7 @@ The legend element is used to give field sets a heading or caption so the user c
 
 To create a legend, we use the `<legend>` element with the text we want to display within its opening and closing tags. A legend should always come right after an opening fieldset tag:
 
-~~~html
+```html
 <fieldset>
   <legend>Contact Details</legend>
 
@@ -442,11 +442,11 @@ To create a legend, we use the `<legend>` element with the text we want to displ
   <label for="zip_code">Zip Code:</label>
   <input type="text" id="zip_code" name="zip_code">
 </fieldset>
-~~~
+```
 
 A common use-case for these elements is using a fieldset to group radio buttons and using a legend to communicate to the user what each of the options is ultimately for:
 
-~~~html
+```html
 <fieldset>
   <legend>What would you like to drink?</legend>
 
@@ -465,7 +465,7 @@ A common use-case for these elements is using a fieldset to group radio buttons 
     <label for="soda">Soda</label>
   </div>
 </fieldset>
-~~~
+```
 
 ### A note on styling forms
 


### PR DESCRIPTION
## Because
Codeblocks should be updated to align with new changes in the [layout style guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md#codeblocks)


## This PR
Replaces all tildes (~) with backticks (`) in the Form Basics Lesson to match the layout style


## Issue
Related to #26842

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
