### PR TITLE
Fix: have Knowledge Section's question 3 link target the correct section of the webpage.

### DIFF
--- a/javascript/organizing_your_javascript_code/factory_functions_and_module_pattern.md
+++ b/javascript/organizing_your_javascript_code/factory_functions_and_module_pattern.md
@@ -277,7 +277,7 @@ This section contains questions for you to check your understanding of this less
 
 - [Explain how scope works in JavaScript.](https://wesbos.com/javascript-scoping)
 - [Explain what closures are and how they help in creating private variables.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures#closure)
-- [Describe the common issues that you can face when working with constructors.](#why-not-constructors)
+- [Describe the common issues that you can face when working with constructors.](#so-whats-wrong-with-constructors)
 - [Describe private variables in factory functions and how they can be useful.](#private-variables-and-functions)
 - [Describe how we can implement prototypal inheritance with factory functions.](#prototypal-inheritance-with-factories)
 - [Explain how the module pattern works.](https://dev.to/tomekbuszewski/module-pattern-in-javascript-56jm)


### PR DESCRIPTION
## Because
The third question of the Knowledge Check session links to the wrong part of the webpage - the very top -, which does not address the question. It should be targeting the "So, what’s wrong with constructors?" seection (correctly linked in the code below), which addresses the question made.

## This PR
- Adjusts it so the webpage's link so it correctly targets the section that answer the question made.

## Issue
None.

## Additional Information
This is a very simple fix.



## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
