### PR TITLE
NodeJS: Use uniform wording when referring to the Express tutorial

### DIFF
--- a/nodeJS/express_and_mongoose/express_101.md
+++ b/nodeJS/express_and_mongoose/express_101.md
@@ -1,14 +1,16 @@
 ### Introduction
+
 In the last lesson, we set the stage by explaining quite a bit of the background information you'll need to really understand what's going on as we start to dive into Express. This lesson will actually start you on the project that you'll be completing as you follow the tutorial.
 
 ### Learning outcomes
+
 By the end of this lesson, you should be able to do the following:
 
- - Use `express-generator` to generate a basic express site.
- - Understand the basic parts of an express project.
- - Understand what a Templating Language is and be able to list a couple of popular ones.
- - Understand what Middleware is.
- - Understand `req`, `res` and `next` in the context of middleware.
+- Use `express-generator` to generate a basic express site.
+- Understand the basic parts of an express project.
+- Understand what a Templating Language is and be able to list a couple of popular ones.
+- Understand what Middleware is.
+- Understand `req`, `res` and `next` in the context of middleware.
 
 ### Templating engines
 
@@ -38,11 +40,11 @@ When someone visits your site, their web-browser sends a request to your server.
 
  <span id='req'>`req`</span> or `request` is an object that has data about the incoming request such as the exact URL that was visited, any parameters in the URL, the `body` of the request (useful if the user is submitting a form with some data in it) and many other things.
 
- - You can see everything it includes in the [express docs](https://expressjs.com/en/4x/api.html#req).
+- You can see everything it includes in the [express docs](https://expressjs.com/en/4x/api.html#req).
 
  <span id='res'>`res`</span> or `response` is an object that represents the response that Express is going to send back to the user. Typically, you use the information in the `req` to determine what you're going to do with the `res` by calling `res.send()` or another method on the object.
 
- - Check out the documentation for the response object [here!](https://expressjs.com/en/4x/api.html#res)
+- Check out the documentation for the response object [here!](https://expressjs.com/en/4x/api.html#res)
 
 <span id='next'>`next`</span> is a function that you see a little less often, but is _very_ important to the functioning of your app. If you are writing or using some middleware that does not send a response back to the user's client then you _must_ call the `next` function at the end of your middleware function.  The next function simply tells express to move to the next middleware in the stack, but if you forget to call it then your app will pause and nothing will happen!
 
@@ -74,12 +76,14 @@ As you work through this tutorial, make sure to put the `node_modules` folder in
 
 <div class="lesson-content__panel" markdown="1">
 
-1. Read this [intro article](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/Tutorial_local_library_website) on MDN.
+1. Read the [intro article of the MDN Express tutorial](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/Tutorial_local_library_website) on MDN.
 2. Begin the project by following [this lesson](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/skeleton_website).  Be sure to read everything carefully! There's quite a bit of important information in this article. You only have to do part 2 for now. We will continue where we leave off later.
 3. For a little more detail on the nature of middleware read the official documentation [here](http://expressjs.com/en/guide/using-middleware.html).
+
 </div>
 
 ### Knowledge check
+
 This section contains questions for you to check your understanding of this lesson. If you're having trouble answering the questions below on your own, review the material above to find the answer.
 
 - [What is middleware?](#middleware)
@@ -92,4 +96,4 @@ This section contains questions for you to check your understanding of this less
 
 This section contains helpful links to related content. It isn't required, so consider it supplemental.
 
--   It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.
+- It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.

--- a/nodeJS/express_and_mongoose/express_102_crud_and_mvc.md
+++ b/nodeJS/express_and_mongoose/express_102_crud_and_mvc.md
@@ -1,7 +1,9 @@
 ### Introduction
+
 After setting up the skeleton for your project it's time to set up the database.  As usual, there's quite a bit of background information that you will find useful as you progress.
 
 ### Learning outcomes
+
 By the end of this lesson, you should be able to do the following:
 
 - Explain CRUD and how it correlates to HTTP methods in Express.
@@ -11,7 +13,7 @@ By the end of this lesson, you should be able to do the following:
 - Declare object schema and models.
 - Describe the main field types and basic validation.
 - List a few ways to access model data.
-- Test models by creating a number of instances (using a standalone script). 
+- Test models by creating a number of instances (using a standalone script).
 
 ### CRUD
 
@@ -50,15 +52,15 @@ If this is a little confusing at this point, don't worry about it too much.  You
 
 One final note before diving back into the tutorial.  Express does not care about which database you use.  The lesson lists a few options but ultimately uses MongoDB. In this case, the actual DB you use matters little.  If you later decide that you would rather use SQL or something else, you should be able to pick it up fairly easily by reading the documentation. At this point, Mongo is probably the most popular choice to use with Express so we recommend just sticking with that for now.
 
-
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">
 
-1. Continue where we left off with the [MDN library tutorial (Part 3)!](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/mongoose)
+1. Complete part 3 of [the MDN Express tutorial](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/mongoose).
+
 </div>
 
-### Knowledge checks 
+### Knowledge checks
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
 - [What does CRUD stand for?](#crud)

--- a/nodeJS/express_and_mongoose/express_103_routes_and_controllers.md
+++ b/nodeJS/express_and_mongoose/express_103_routes_and_controllers.md
@@ -1,4 +1,5 @@
 ### Introduction
+
 The next step in the MDN express tutorial sets up all the routes and controllers you're going to need when creating the Library project. This project is designed using the MVC (Model, View, Controller) architecture. In a previous step you set up all the Models (or Database Objects) and in the _next_ step you'll be setting up several different views.
 
 If you remember from our earlier lessons, the controller is the code that sits between the models and the views. It determines which view is going to be shown, as well as which information is going to populate that view. In this lesson, you will copy and paste quite a bit of repetitive code to get the controllers and routes set up, but be sure to read everything in between them! There is a _lot_ of useful information therein.
@@ -17,10 +18,12 @@ By the end of this lesson, you should be able to do the following:
 
 <div class="lesson-content__panel" markdown="1">
 
-1. Continue where we left off with part 4 of the [Express tutorial](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/routes).
+1. Complete part 4 of [the MDN Express tutorial](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/routes).
+
 </div>
 
 ### Knowledge check
+
 This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, review the material above to find the answer.
 
 - [How do you define a route function in Express?](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/routes#defining_and_using_separate_route_modules)
@@ -28,9 +31,8 @@ This section contains questions for you to check your understanding of this less
 - [What is a route parameter, and what syntax is used to define one in a route handler?](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/routes#route_parameters)
 - [What is a route-handler callback function commonly called?](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/routes#create_the_route-handler_callback_functions)
 
-
 ### Additional resources
 
 This section contains helpful links to related content. It isn't required, so consider it supplemental.
 
--   It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.
+- It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.

--- a/nodeJS/express_and_mongoose/express_104_view_templates.md
+++ b/nodeJS/express_and_mongoose/express_104_view_templates.md
@@ -22,7 +22,7 @@ By the end of this lesson, you should be able to do the following:
 
 <div class="lesson-content__panel" markdown="1">
 
-1. Let's get back to [Express tutorial on MDN](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data).
+1. Complete part 5 of [the MDN Express tutorial](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data).
 
 </div>
 
@@ -30,4 +30,4 @@ By the end of this lesson, you should be able to do the following:
 
 This section contains helpful links to related content. It isn't required, so consider it supplemental.
 
--   It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.
+- It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.

--- a/nodeJS/express_and_mongoose/project_express_105_forms_and_deployment.md
+++ b/nodeJS/express_and_mongoose/project_express_105_forms_and_deployment.md
@@ -23,8 +23,8 @@ By the end of this lesson, you should be able to do the following:
 
 <div class="lesson-content__panel" markdown="1">
 
-1. Let's get back to [the tutorial](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/forms).
-2. Read about deploying your app in the [last article](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/deployment) in this tutorial.
+1. Complete part 6 of [the MDN Express tutorial](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/forms).
+2. Read about deploying your app in the [final article of the MDN Express tutorial](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/deployment).
 
 Reminder: Make sure to hide your MongoDB connection URL! Once you've hosted your app on Railway you'll be creating a new database with them and can use the instructions in the MDN tutorial to manage environment variables through the Railway dashboard.
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
- Currently, some of the wording related to which parts need to be completed is confusing, and each lesson uses its own bespoke way of referring to it


## This PR
- Clarifies the wording and uses the same sentence for each lesson


## Issue
Closes #26921 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
