### PR TITLE
Javascript - webpack lesson: Update codeblock to follow style guide

### DIFF
--- a/javascript/organizing_your_javascript_code/webpack.md
+++ b/javascript/organizing_your_javascript_code/webpack.md
@@ -28,7 +28,7 @@ Similarly to how we will need loaders and rules for CSS and assets, we can use a
 
 By default, it will create this from a blank template, so the resulting HTML file will essentially be the usual boilerplate with our script and perhaps any other options we add in the configuration. If we had our own `dist/index.html` then it would be overwritten! In order to preserve our own HTML, we can tell it to use a template and provide a path to our own HTML file that is in `src`. You will see more examples of how to set up `html-webpack-plugin` appropriately in the assignment links below, but an example of how to set the template option within your webpack configuration file is as follows:
 
-~~~javascript
+```javascript
 // webpack.config.js
 
 const HtmlWebpackPlugin = require('html-webpack-plugin');
@@ -40,7 +40,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
         }),
     ],
 // ...
-~~~
+```
 
 ### Assignment
 


### PR DESCRIPTION
## Because
Codeblocks should be updated to align with new changes in the [layout style guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md#codeblocks)

## This PR
Replaces all tildes (~) with backticks (`) in the Javascript Webpacks Lesson to match the layout style

## Issue
Related to #26913 

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
