### PR TITLE
Remove redundant <> and </> tags, format <svg> tags

### DIFF
--- a/react/getting_started_with_react/what_is_jsx.md
+++ b/react/getting_started_with_react/what_is_jsx.md
@@ -99,13 +99,11 @@ If you were to take some valid HTML and copy it straight into your React compone
    ~~~jsx
    function App() {
      return (
-       <>
-         <div className="container">
-           <svg>
-             <circle cx="25" cy="75" r="20" stroke="green" strokeWidth="2" />
-           </svg>
-         </div>
-       </>
+      <div className="container">
+        <svg>
+          <circle cx="25" cy="75" r="20" stroke="green" strokeWidth="2" />
+        </svg>
+      </div>
      );
    }
    ~~~
@@ -115,13 +113,11 @@ If you were to take some valid HTML and copy it straight into your React compone
    ~~~jsx
    function App() {
      return (
-       <>
-         <div class="container">
-           <svg>
-             <circle cx="25" cy="75" r="20" stroke="green" stroke-width="2" />
-           </svg>
-         </div>
-       </>
+      <div class="container">
+        <svg>
+          <circle cx="25" cy="75" r="20" stroke="green" stroke-width="2" />
+        </svg>
+      </div>
      );
    }
    ~~~
@@ -137,7 +133,7 @@ Now that we've covered the Rules of JSX, we'll go through the conversion of a ch
   <li>List item 2
   <li>List item 3
 </ol>
-<svg >
+<svg>
    <circle cx="25" cy="75" r="20" stroke="green" stroke-width="2" />
 </svg>
 <form><input type="text"></form>
@@ -157,7 +153,7 @@ The first issue we get is that this would not return a single root element, so l
     <li>List item 2
     <li>List item 3
   </ol>
-  <svg >
+  <svg>
      <circle cx="25" cy="75" r="20" stroke="green" stroke-width="2" />
   </svg>
   <form><input type="text"></form>


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->

In the 3rd bullet point in the [What Is JSX? lesson](https://www.theodinproject.com/lessons/node-path-react-new-what-is-jsx#rules-of-jsx) - camelCase Most things - code samples provide redundant <> tags </>. It can be misleading for learners, whether should they put the tags everywhere or not. Therefore, I suggest it be removed.

The other change is, some of the <svg > tags have blank space just after the 'svg' and before '>' - it also can be misleading, and seems to be a little typo.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->

* Removes redundant `<>` and `</>` tags
* Removes blank space in `<svg >`


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
