### PR TITLE
Typo: Fix "ES6 Modules"'s Lesson Overview section bullet line

### DIFF
--- a/javascript/organizing_your_javascript_code/es6_modules.md
+++ b/javascript/organizing_your_javascript_code/es6_modules.md
@@ -12,7 +12,7 @@ This section contains a general overview of topics that you will learn in this l
 - Describe what `npm init` does and what `package.json` is.
 - Know how to install packages using npm.
 - Describe what a JavaScript module bundler like webpack is.
-- Explain what the concepts "entry" and "output" mean as relates to webpack.
+- Explain what the concepts "entry" and "output" mean in relation to webpack.
 - Briefly explain what a development dependency is.
 - Explain what "transpiling code" means and how it relates to front-end development.
 - Briefly describe what a task runner is and how it's used in front-end development.


### PR DESCRIPTION
## Because
The current line as it is is confusing to read, especially for non-native English speakers, and does not convey the message in the clearest way possible.


## This PR

- Provides a minor grammar fix to the 5th bullet line within the **Lesson Overview** section.


## Issue

## Additional Information
This is a simple fix.

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
