### PR TITLE
JavaScript Course: Update codeblock delimiters per layout style guide in Project: Binary Search Trees

### DIFF
--- a/javascript/computer_science/project_binary_search_trees.md
+++ b/javascript/computer_science/project_binary_search_trees.md
@@ -18,7 +18,7 @@ You'll build a balanced BST in this assignment. Do not use duplicate values beca
 
     **Tip:** If you would like to visualize your binary search tree, here is a `prettyPrint()` function that will `console.log` your tree in a structured format. This function will expect to receive the root of your tree as the value for the `node` parameter.
 
-    ~~~javascript
+    ```javascript
     const prettyPrint = (node, prefix = "", isLeft = true) => {
       if (node === null) {
         return;
@@ -31,7 +31,7 @@ You'll build a balanced BST in this assignment. Do not use duplicate values beca
         prettyPrint(node.left, `${prefix}${isLeft ? "    " : "│   "}`, true);
       }
     };
-    ~~~ 
+    ```
 
 1.  Write `insert` and `delete` functions that accepts a value to insert/delete. You'll have to deal with several cases for delete, such as when a node has children or not. If you need additional resources, check out these two articles on [inserting](https://www.geeksforgeeks.org/insertion-in-binary-search-tree/?ref=lbp) and [deleting](https://www.geeksforgeeks.org/binary-search-tree-set-2-delete/?ref=lbp), or [this video](https://youtu.be/wcIRPqTR3Kc) with several visual examples.
 


### PR DESCRIPTION
## Because
update the codeblock delimiters in javascript course


## This PR
- updated codeblock delimiters in 'Project: Binary Search Trees' as per layout style guide


## Issue
#26962 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
