### PR TITLE
ROR: The Asset Pipeline: Inconsistency of links in the 'Knowledge Check' section with the Assignment

### DIFF
--- a/ruby_on_rails/assets_and_navigation/asset_pipeline.md
+++ b/ruby_on_rails/assets_and_navigation/asset_pipeline.md
@@ -137,7 +137,7 @@ Remember the preprocessors we talked about in the previous lesson on Views?  Fil
 Some necessary and straightforward reading on the Asset Pipeline:
 
 <div class="lesson-content__panel" markdown="1">
-  1. Read [Rails Guides on the Asset Pipeline](http://guides.rubyonrails.org/asset_pipeline.html) sections 1 to 3.
+  1. Read [Rails Guides on the Asset Pipeline](http://guides.rubyonrails.org/asset_pipeline.html) sections 1 to 4.
 </div>
 
 ### Conclusion


### PR DESCRIPTION
## Because
The assignment link does not covers the questions asked in Knowledge Check section of Asset Pipeline lesson of Ruby on Rails.


## This PR
- updated the sections that needs to be read


## Issue
Closes #26786 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
