### PR TITLE
Javascript - space complexity lesson: Update codeblock to follow style guide

### DIFF
--- a/javascript/computer_science/space_complexity.md
+++ b/javascript/computer_science/space_complexity.md
@@ -53,11 +53,11 @@ Let's work through some examples. We won't go through every possible complexity 
 
 Consider this example
 
-~~~js
+```js
 function multiply(num1, num2) {
   return num1 * num2;
 }
-~~~
+```
 
 Here it should hopefully be clear that no matter the arguments we enter when we call the function, only two variables are created. It doesn't change. Therefore, we can consider the space this takes is always O(1).
 
@@ -65,7 +65,7 @@ Here it should hopefully be clear that no matter the arguments we enter when we 
 
 Most data structures you come across will have a space complexity of O(N). That makes sense - when you increase the number of items in your data structure, it increases the space that data structure occupies in a linear way.
 
-~~~js
+```js
 function sumArr(arr) {
   const copyArr = arr.slice();
   let sum = 0;
@@ -74,7 +74,7 @@ function sumArr(arr) {
   });
   return sum;
 }
-~~~
+```
 
 We wrote this in a slightly more verbose way than you'd normally write it in JavaScript to make it a little clearer. Here we have a method which accepts an array. Within, we have two variables. One called `sum` and the other `copyArr` which holds a copy of the array passed in. We then have a `forEach` loop that iterates over the array. The amount of space that this algorithm takes depends on the array that is passed to it. It could be 3 elements in the array or 300. When we don't know the length of the array, we refer to it as N, so we have N + 1 variable called `sum`. We know that we drop constants with Big O, so we are left with N, or O(N) for its Big O notation.
 
@@ -82,7 +82,7 @@ Why did we make a copy of the array? That will be discussed in a later section.
 
 The complexity is replicated no matter the data structure:
 
-~~~js
+```js
 function sumObjectValues(obj) {
   const copyObject = { ...obj };
   let sum = 0;
@@ -91,7 +91,7 @@ function sumObjectValues(obj) {
   });
   return sum;
 }
-~~~
+```
 
 Here as the object size increases, the space it uses grows in a linear way.
 
@@ -109,7 +109,7 @@ That's why we won't be diving into examples for other Big O notations with space
 
 One of the common areas that causes confusion when considering space complexity is what constitutes using space in the context of an algorithm. In an earlier example we wrote methods that duplicated an array and object argument. We did that to be explicit. But what if we'd written the method as:
 
-~~~js
+```js
 function sumArr(arr) {
   let sum = 0;
   arr.forEach((number) => {
@@ -117,7 +117,7 @@ function sumArr(arr) {
   });
   return sum;
 }
-~~~
+```
 
 When a data structure is passed in as the argument, especially for languages that pass arrays by reference rather than value, it can be a bit unclear if that method considers the space used by that data structure when calculating its space complexity. If we didn't count it, then it would be easy for all our methods to have great space usage on paper because we put the onus on the caller to allocate that space. If we did count it, but the data structure was created for use by many different methods, then the space complexity for all those methods is O(N) when they aren't utilizing additional space. Then consider that if your method receives an array as an input and loops it, an index must be created for the loop which uses additional space.
 


### PR DESCRIPTION
## Because
Codeblocks should be updated to align with new changes in the [layout style guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md#codeblocks)

## This PR
Replaces all tildes (~) with backticks (`) in the Javascript Space Complexity Lesson to match the layout style

## Issue
Related to #26962 

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
