### PR TITLE
DOM Manipulation & Events: Fixed display issue caused by missing class

### DIFF
--- a/foundations/javascript_basics/DOM_manipulation_and_events.md
+++ b/foundations/javascript_basics/DOM_manipulation_and_events.md
@@ -173,7 +173,7 @@ div.innerHTML = '<span>Hello World!</span>';
 // renders the HTML inside div
 ```
 
-<div class="lesson-note--tip" markdown="1">
+<div class="lesson-note lesson-note--tip" markdown="1">
 
 Note that textContent is preferable for adding text, and innerHTML should be used sparingly as it can create security risks if misused. Check out [this video](https://youtube.com/watch?v=ns1LX6mEvyM) if you want to see an example of how.
 
@@ -346,7 +346,7 @@ btn.addEventListener('click', function (e) {
 });
 ```
 
-<div class="lesson-note--tip" markdown="1">
+<div class="lesson-note lesson-note--tip" markdown="1">
 
 Note that `function (e)` is a callback from addEventListener. Further explanation of callbacks can be found [HERE](https://dev.to/i3uckwheat/understanding-callbacks-2o9e).
 


### PR DESCRIPTION
Added a missing lesson-note class that was required by some divs causing display issues.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
There were display issues caused by a missing class in a `div`. The missing class is `lesson-note` and it was required along with `lesson-note--tip` (according to the layout style guide) to properly show a note-styled section/paragraph. Only `lesson-note--tip` was there, but the other was missing. I just simply added `lesson-note` to the two `div` elements that had display issues and required the missing class.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Added `lesson-note` class to `div` elements that needed it.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #26969 

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
