### PR TITLE
Typo: fix lesson "ES6 Module" 's Knowledge Check section bullet

### DIFF
--- a/javascript/organizing_your_javascript_code/es6_modules.md
+++ b/javascript/organizing_your_javascript_code/es6_modules.md
@@ -168,7 +168,7 @@ This section contains questions for you to check your understanding of this less
 - [Describe what `npm init` does and what `package.json` is.](https://docs.npmjs.com/creating-a-package-json-file)
 - [Know how to install packages using npm.](https://docs.npmjs.com/downloading-and-installing-packages-locally)
 - [Describe what a JavaScript module bundler like webpack is.](https://peterxjang.com/blog/modern-javascript-explained-for-dinosaurs.html)
-- [Explain what the concepts "entry" and "output" mean as relates to webpack.](#webpack-knowledge-check)
+- [Explain what the concepts "entry" and "output" mean in relation to webpack.](#webpack-knowledge-check)
 - [Briefly explain what a development dependency is.](https://dev.to/moimikey/demystifying-devdependencies-and-dependencies-5ege)
 - [Explain what "transpiling code" means and how it relates to frontend development.](https://peterxjang.com/blog/modern-javascript-explained-for-dinosaurs.html)
 - [Briefly describe what a task runner is and how it's used in frontend development.](https://peterxjang.com/blog/modern-javascript-explained-for-dinosaurs.html)


### PR DESCRIPTION
## Because
The grammar as it is is incorrect, and may make it more difficult for reading, especially for non-native English speakers.


## This PR
- Fixes grammar for one of the bullet points of the Knowledge Section session, essential to ingraining knowledge acquired in the lesson.


## Issue

## Additional Information
This is a minor fix.


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
