### PR TITLE
Node Odinbook: Remove omniauth mention

### DIFF
--- a/nodeJS/final_project/project_odin_book.md
+++ b/nodeJS/final_project/project_odin_book.md
@@ -36,7 +36,7 @@ The following requirements are a very global list of features your app should ha
 1. Users can comment on posts.
 1. Posts should always display the post content, author, comments, and likes.
 1. There should be an index page for posts, which shows all the recent posts from the current user and users they are following.
-1. Users can create a profile with a profile picture. You may be able to get the profile picture when users sign in using Omniauth. If this isn't the case you can use [Gravatar](https://www.gravatar.com/) to generate them
+1. Users can create a profile with a profile picture. Depending on how you handle authentication, for example via `passport-github2`, you may be able to use their account's existing profile picture. If this isn't the case you can use [Gravatar](https://www.gravatar.com/) to generate them.
 1. A user's profile page should contain their profile information, profile photo, and posts.
 1. There should be an index page for users, which shows all users and buttons for sending follow requests to users the user is not already following or have a pending request.
 1. Deploy your app to a hosting provider of your choice!
@@ -44,8 +44,8 @@ The following requirements are a very global list of features your app should ha
 #### Extra credit
 
 1. Make posts also allow images (either just via a URL or by uploading one.)
-2. Allow users to upload and update their profile photo.
-3. Create a guest sign-in functionality that allows visitors to bypass the login screen without creating an account or supplying credentials. This is especially useful if you are planning on putting this project on your résumé - most recruiters, hiring managers, etc. will not take the time to create an account. This feature will allow them to look at your hard work without going through a tedious sign-up process.
-4. Make it pretty!
+1. Allow users to update their profile photo.
+1. Create a guest sign-in functionality that allows visitors to bypass the login screen without creating an account or supplying credentials. This is especially useful if you are planning on putting this project on your résumé - most recruiters, hiring managers, etc. will not take the time to create an account. This feature will allow them to look at your hard work without going through a tedious sign-up process.
+1. Make it pretty!
 
 </div>

--- a/ruby_on_rails/mailers_advanced_topics/project_final.md
+++ b/ruby_on_rails/mailers_advanced_topics/project_final.md
@@ -39,9 +39,9 @@ Keep the following requirements in mind. We'll cover specific steps to get start
 #### Extra credit
 
 1. Make posts also allow images (either just via a URL or, more complicated, by uploading one).
-2. Use [Active Storage](https://guides.rubyonrails.org/active_storage_overview.html) to allow users to upload a photo to their profile.
-3. Make your post able to be either a text OR a photo by using a polymorphic association (so users can still like or comment on it while being none-the-wiser).
-4. Style it up nicely! We'll dive into HTML/CSS in the next course.
+1. Use [Active Storage](https://guides.rubyonrails.org/active_storage_overview.html) to allow users to upload a photo to their profile.
+1. Make your post able to be either a text OR a photo by using a polymorphic association (so users can still like or comment on it while being none-the-wiser).
+1. Style it up nicely! We'll dive into HTML/CSS in the next course.
 
 #### Getting started
 


### PR DESCRIPTION
## Because
A mention of Ruby's Omniauth was accidentally left in the Node version of Odinbook.


## This PR
- Removed omniauth mention for Node Odinbook only
- Fixed punctuation
- Fixed lazy list numbering as per style guide in both pathways' odinbooks (probably should have done this step in a separate PR to not mix the Rails project with this PR title)


## Issue
N/A


## Additional Information


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
