### PR TITLE
Deployment: Reword Railway free plan description

### DIFF
--- a/nodeJS/express_and_mongoose/deployment.md
+++ b/nodeJS/express_and_mongoose/deployment.md
@@ -122,7 +122,7 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 **Free plan**
 
 - You get a free one-time grant of $5 on their free trial, and the applications are never put to sleep when inactive.
-- However, the longevity of your free allowance depends on how many resources you consume. Full usage of the resources available is only enough to host one app for about 30 days, and thus isn't recommended.
+- However, the longevity of your free allowance depends on how many resources you consume. More complex apps with more traffic may consume all free resources within a month, whereas simpler apps may last longer.
 
 **Links**
 

--- a/ruby_on_rails/rails_basics/deployment.md
+++ b/ruby_on_rails/rails_basics/deployment.md
@@ -109,7 +109,7 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 **Free plan**
 
 - You get a free one-time grant of 5$ on their free trial, and the applications are never put to sleep when inactive.
-- However, the longevity of your free allowance depends on how many resources you consume. Full usage of the resources available is only enough to host one app for about 30 days, and thus isn't recommended.
+- However, the longevity of your free allowance depends on how many resources you consume. More complex apps with more traffic may consume all free resources within a month, whereas simpler apps may last longer.
 
 **Links**
 


### PR DESCRIPTION
## Because
The current deployment lessons' Railway free plan descriptions have what feels a little out of place considering how everything else is worded with
> Full usage of the resources available is only enough to host one app for about 30 days, and thus isn’t recommended.

This feels a bit like "so why list it?", and is also odd considering not even the Heroku mention with no free tier has "not recommended" attached to it.
I feel a more appropriate and accurate wording for that part would be to simply say that the $5 credit grant will last anywhere from a month to a few months depending on the resources used by the app, as per the documentation's advice. Then the reader can decide for themselves which PaaS they'd prefer to use for whatever app (be that a course project or revisiting for info for a personal project).


## This PR
- Reword a line in the Railway.app free plan description.


## Issue
N/A

## Additional Information


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
