### PR TITLE
Computer Science Hashes: Clarify existence of non-probabilistic collisions

### DIFF
--- a/javascript/computer_science/hash_map_data_structure.md
+++ b/javascript/computer_science/hash_map_data_structure.md
@@ -155,7 +155,7 @@ How are we going to insert into those buckets when our hash function generates b
 For example, if we are to find the bucket where the value `"Manon"` will land, then we do the following:
 ![hashing using hash code and modular operation example](https://cdn.statically.io/gh/TheOdinProject/curriculum/7ea463cfb7c05c330d72f5977cc5fe3b0c640b86/javascript/computer_science/hash_map_data_structure/imgs/01.png)
 
-If we keep adding nodes into our buckets then the buckets will start filling up, but what is more important is we know for a fact that if almost all buckets have items in them, then collisions are guaranteed, it is mathematically impossible not to.
+As we continue to add nodes into our buckets, collisions get more and more likely. Eventually however, there will be more nodes than there are buckets, which guarantees a collision (check the additional resources section for an explanation of this fact if you're curious).
 
 Remember we don't want collisions. In a perfect world each bucket will either have 0 or 1 Node only, so we grow our buckets to have more chance that our Nodes will spread and not stack up in the same buckets. To grow our buckets, we create a new buckets list that is double the size of the old buckets list, then we copy all nodes over to the new buckets.
 
@@ -202,3 +202,4 @@ This section contains questions for you to check your understanding of this less
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
 - [This discussion goes through the usages of prime number](https://stackoverflow.com/questions/299304/why-does-javas-hashcode-in-string-use-31-as-a-multiplier/299748)
+- The [pigeonhole principle](https://en.wikipedia.org/wiki/Pigeonhole_principle) mathematically guarantees collisions when there are more nodes than boxes.

--- a/ruby/computer_science/hash_map_data_structure.md
+++ b/ruby/computer_science/hash_map_data_structure.md
@@ -150,7 +150,7 @@ How are we going to insert into those buckets when our hash method generates big
 For example, if we are to find the bucket where the value `"Manon"` will land, then we do the following:
 ![hashing using hash code and modular operation example](https://cdn.statically.io/gh/TheOdinProject/curriculum/7ea463cfb7c05c330d72f5977cc5fe3b0c640b86/javascript/computer_science/hash_map_data_structure/imgs/01.png)
 
-If we keep adding nodes into our buckets then the buckets will start filling up, but what is more important is we know for a fact that if almost all buckets have items in them, then collisions are guaranteed, it is mathematically impossible not to.
+As we continue to add nodes into our buckets, collisions get more and more likely. Eventually however, there will be more nodes than there are buckets, which guarantees a collision (check the additional resources section for an explanation of this fact if you're curious).
 
 Remember we don't want collisions. In a perfect world each bucket will either have 0 or 1 Node only, so we grow our buckets to have more chance that our Nodes will spread and not stack up in the same buckets. To grow our buckets, we create a new buckets list that is double the size of the old buckets list, then we copy all nodes over to the new buckets.
 
@@ -197,3 +197,4 @@ This section contains questions for you to check your understanding of this less
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
 - [This discussion goes through the usages of prime number](https://stackoverflow.com/questions/299304/why-does-javas-hashcode-in-string-use-31-as-a-multiplier/299748)
+- The [pigeonhole principle](https://en.wikipedia.org/wiki/Pigeonhole_principle) mathematically guarantees collisions when there are more nodes than boxes.


### PR DESCRIPTION
## Because
The lesson states "we know for a fact that if almost all buckets have items in them, then collisions are guaranteed, it is mathematically impossible not to." This is true, but implicitly invokes the [Pigeonhole Principle](https://en.wikipedia.org/wiki/Pigeonhole_principle) such that when there are more items than buckets, there must be a collision.

The current wording allows for a misinterpretation that this is a probabilistic argument, something like "if we have lots, there surely has to be a collision!" when it is not the case that it is probabilistic, as it is deterministic.


## This PR
Rewords the paragraph in question to clarify, with a corresponding link in additional resources for the curious reader


## Issue
Closes #27081

## Pull Request Requirements

-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
