### PR TITLE
Fix a typo in commit_messages.md

### DIFF
--- a/git/foundations_git/commit_messages.md
+++ b/git/foundations_git/commit_messages.md
@@ -92,7 +92,7 @@ There will come a time when you are working on a project and you FINALLY get som
 - Using VSCode as your text editor (you should have set this up in the Git Basics section) will allow you to easily make multi-line commit messages, easily see the character length of each line, and will allow you to use [VSCode spell check extensions](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) to make sure your spelling is correct
 - Use an active voice: "Fix card generator".
 - Avoid using vague commit messages such as "saved" or "updated".
-- Commit early and often!.
+- Commit early and often!
 
 ### Knowledge check
 


### PR DESCRIPTION
## Because
This PR is to correct a spelling mistake in a lesson.


## This PR
- Fixes a typo in a lesson file `curriculum/git/foundations_git/commit_messages.md`: it removes a period after the exclamation mark.


## Issue

Closes none.

## Additional Information

None


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
