### PR TITLE
React Intro: Clarify component capitalisation explanation

### DIFF
--- a/react/getting_started_with_react/react_components.md
+++ b/react/getting_started_with_react/react_components.md
@@ -37,7 +37,7 @@ function Greeting() {
 
 This might look mostly familiar to you - it's a simple JavaScript function, which returns JSX. Open up the project you were working on, create a new file named `Greeting.jsx`, and in that file write your own handmade functional component. Name it whatever you wish, and have it return whatever JSX you wish.
 
-Are you done? Check the naming of your function! Is it capitalized? Keep this key difference in mind. **React components must be capitalized** or they will not function as expected, which is why we capitalized `Greeting()`.
+Are you done? Check the naming of your function! Is it capitalized? Keep this key difference in mind. **React components must be capitalized** or they will not function as expected, which is why we capitalized `Greeting()`. More about that later.
 
 <div class="lesson-note">
 
@@ -79,7 +79,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
 )
 ~~~
 
-Remember that `<Greeting />` should be capitalized! Try using lower case for the import, function name and component and see what happens! When the JSX is parsed, React uses the capitalization to tell the difference between an HTML tag and an instance of a React component - `<greeting />` is not a valid HTML tag!
+Remember that `<Greeting />` should be capitalized! Try using lower case for the import, function name and component and see what happens! When the JSX is parsed, React uses the capitalization to tell the difference between an HTML tag and an instance of a React component. `<greeting />` would be interpreted as a normal HTML element with no special meaning, instead of your shiny new React component.
 
 Otherwise, just like that, you've successfully imported and used your first custom-made component, congratulations!
 


### PR DESCRIPTION


## Because
The explanation of why components must be capitalised is much further down the lesson than when it is stated, with nothing to tell the reader an explanation will be coming soon.

The wording currently states that `<greeting />` is not a valid HTML tag, when really it is, but will be interpreted as normal HTML rather than a component


## This PR
- A short sentence at the introduction of capitalisation to say that the reasoning will be covered later on
- Clarify the point about valid html tags vs how they are interpreted



## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
