### PR TITLE
Fix typo in turbo.md

### DIFF
--- a/ruby_on_rails/rails_sprinkles/turbo.md
+++ b/ruby_on_rails/rails_sprinkles/turbo.md
@@ -84,7 +84,7 @@ The above example will generate a turbo frame for every article. Each frame will
 
 #### Connecting to other frames
 
-Now that we have our first frame, we can replace its content with a link that request new frame content. All we have to do is put a link inside of the Turbo Frame, where the requested view *also* includes a Turbo frame with the **same ID**.
+Now that we have our first frame, we can replace its content with a link that requests new frame content. All we have to do is put a link inside of the Turbo Frame, where the requested view *also* includes a Turbo frame with the **same ID**.
 
 Let us replace the `/show` view with the `/edit` view on an article:
 


### PR DESCRIPTION
Fix typo in first sentence of the '####Connecting to other frames 'section.