### PR TITLE
Style guide: Match example to linter requirements

### DIFF
--- a/LAYOUT_STYLE_GUIDE.md
+++ b/LAYOUT_STYLE_GUIDE.md
@@ -413,7 +413,7 @@ Note boxes can be added by wrapping the content in a `div` with the class `lesso
 
 For nested markdown inside note boxes to be displayed properly additional `markdown="1" attribute` is needed.
 
-A heading can be added to a note by using an `h4` element. When adding a heading, be sure to provide text that helps describe the note rather than "A note" or "Warning".
+A heading can be added to a note by using a `####` heading. When adding a heading, be sure to provide text that helps describe the note rather than "A note" or "Warning".
 
 ### Variations
 

--- a/LAYOUT_STYLE_GUIDE.md
+++ b/LAYOUT_STYLE_GUIDE.md
@@ -424,13 +424,17 @@ Note boxes come in two variations, which can be set by adding an extra class tog
 ### Example
 ~~~markdown
 <div class="lesson-note" markdown="1">
-<h4>An optional title</h4>
+
+#### An optional title
+
 A sample note box.
 </div>
 ~~~
 ~~~markdown
 <div class="lesson-note lesson-note--tip" markdown="1">
-<h4>An optional title</h4>
+
+#### An optional title
+
 A sample note box, variation: tip.
 </div>
 ~~~


### PR DESCRIPTION
## Because
The style guide provides examples for note boxes using `<h4>` tags, which the markdown linter throws errors about, in favour of headings generated by markdown `#` characters


## This PR
Brings the style guide in-line with the linter

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
