### PR TITLE
JS HashMap project: Make the assignment's methods follow the default format

### DIFF
--- a/javascript/computer_science/project_hash_map.md
+++ b/javascript/computer_science/project_hash_map.md
@@ -8,11 +8,11 @@ You already know the magic behind hash maps, now it's time to write your own imp
 
   Use the following snippet whenever you access a bucket through an index. We want to throw an error if we try to access an out of bound index:
 
-      ```javascript
-      if (index < 0 || index >= buckets.length) {
-        throw new Error("Trying to access index out of bound");
-      }
-      ```
+```javascript
+if (index < 0 || index >= buckets.length) {
+  throw new Error("Trying to access index out of bound");
+}
+```
 
 ### Assignment
 

--- a/javascript/computer_science/project_hash_map.md
+++ b/javascript/computer_science/project_hash_map.md
@@ -4,9 +4,9 @@ You already know the magic behind hash maps, now it's time to write your own imp
 
 #### Limitation
 
-  Before we get started, we need to lay down some ground rules. JavaScript's dynamic nature of array allow us to insert and retrieve indexes that are outside our array size range. Example: if we create an array of size `16` to be our buckets size, nothing stopping us from storing items at index `500`. This defeats the purpose we are trying to demonstrate, so we need to put some self restriction to work around this.
+  Before we get started, we need to lay down some ground rules. JavaScript's dynamic nature of array allows us to insert and retrieve indexes that are outside our array size range. Example: if we create an array of size `16` to be our buckets size, nothing stopping us from storing items at index `500`. This defeats the purpose we are trying to demonstrate, so we need to put some self restriction to work around this.
 
-  1. Use the following snippet whenever you access a bucket through an index. We want to throw an error if we try to access an out of bound index:
+  Use the following snippet whenever you access a bucket through an index. We want to throw an error if we try to access an out of bound index:
 
       ```javascript
       if (index < 0 || index >= buckets.length) {
@@ -20,31 +20,31 @@ You already know the magic behind hash maps, now it's time to write your own imp
 
   1. Start by creating a `HashMap` class or factory function. It's up to you which you want to use. Then proceed to create the following methods:
 
-  1. `hash` takes a value and produces a hash code with it. We did implement a fairly good `hash` function in the previous lesson. You are free to use that, or if you wish, you can conduct your own research. Beware, this is a deep deep rabbit hole.
+  2. `hash(key)` takes a key and produces a hash code with it. We did implement a fairly good `hash` function in the previous lesson. You are free to use that, or if you wish, you can conduct your own research. Beware, this is a deep deep rabbit hole.
 
       <div class="lesson-note lesson-note--tip" markdown="1">
         Hash maps could accommodate various data types for keys like numbers, strings, objects. But for this project, only handle keys of type strings.
       </div>
 
-  1. `set` takes two arguments, the first is a key and the second is a value that is assigned to this key. If a key already exists, then the old value is overwritten.
+  3. `set(key, value)` takes two arguments, the first is a key and the second is a value that is assigned to this key. If a key already exists, then the old value is overwritten.
 
      - Remember to grow your buckets size when it needs to, by calculating if your bucket has reached the `load factor`.
 
-  1. `get` takes one argument as a key and returns the value that is assigned to this key. If key is not found, return `null`.
+  4. `get(key)` takes one argument as a key and returns the value that is assigned to this key. If a key is not found, return `null`.
 
-  1. `has` takes a key as an argument and returns `true` or `false` based on whether or not the key is in the hash map.
+  5. `has(key)` takes a key as an argument and returns `true` or `false` based on whether or not the key is in the hash map.
 
-  1. `remove` takes a key as an argument. If the given key is in the hash map, it should remove the entry with that key and return `true`. If the key isn't in the hash map, it should return `false`.
+  6. `remove(key)` takes a key as an argument. If the given key is in the hash map, it should remove the entry with that key and return `true`. If the key isn't in the hash map, it should return `false`.
 
-  1. `length` returns the number of stored keys in the hash map.
+  7. `length()` returns the number of stored keys in the hash map.
 
-  1. `clear` removes all entries in the hash map.
+  8. `clear()` removes all entries in the hash map.
 
-  1. `keys` returns an array containing all the keys inside the hash map.
+  9. `keys()` returns an array containing all the keys inside the hash map.
 
-  1. `values` returns an array containing all the values.
+  10. `values()` returns an array containing all the values.
 
-  1. `entries` returns an array that contains each `key, value` pair. Example: `[[firstKey, firstValue], [secondKey, secondValue]]`
+  11. `entries()` returns an array that contains each `key, value` pair. Example: `[[firstKey, firstValue], [secondKey, secondValue]]`
 
   Remember that a hash map does not preserve insertion order when you are retrieving your hash map's data. It is normal and expected for keys and values to appear out of the order you inserted them in.
 

--- a/javascript/computer_science/project_hash_map.md
+++ b/javascript/computer_science/project_hash_map.md
@@ -20,31 +20,31 @@ if (index < 0 || index >= buckets.length) {
 
   1. Start by creating a `HashMap` class or factory function. It's up to you which you want to use. Then proceed to create the following methods:
 
-  2. `hash(key)` takes a key and produces a hash code with it. We did implement a fairly good `hash` function in the previous lesson. You are free to use that, or if you wish, you can conduct your own research. Beware, this is a deep deep rabbit hole.
+  1. `hash(key)` takes a key and produces a hash code with it. We did implement a fairly good `hash` function in the previous lesson. You are free to use that, or if you wish, you can conduct your own research. Beware, this is a deep deep rabbit hole.
 
       <div class="lesson-note lesson-note--tip" markdown="1">
         Hash maps could accommodate various data types for keys like numbers, strings, objects. But for this project, only handle keys of type strings.
       </div>
 
-  3. `set(key, value)` takes two arguments, the first is a key and the second is a value that is assigned to this key. If a key already exists, then the old value is overwritten.
+  1. `set(key, value)` takes two arguments, the first is a key and the second is a value that is assigned to this key. If a key already exists, then the old value is overwritten.
 
      - Remember to grow your buckets size when it needs to, by calculating if your bucket has reached the `load factor`.
 
-  4. `get(key)` takes one argument as a key and returns the value that is assigned to this key. If a key is not found, return `null`.
+  1. `get(key)` takes one argument as a key and returns the value that is assigned to this key. If a key is not found, return `null`.
 
-  5. `has(key)` takes a key as an argument and returns `true` or `false` based on whether or not the key is in the hash map.
+  1. `has(key)` takes a key as an argument and returns `true` or `false` based on whether or not the key is in the hash map.
 
-  6. `remove(key)` takes a key as an argument. If the given key is in the hash map, it should remove the entry with that key and return `true`. If the key isn't in the hash map, it should return `false`.
+  1. `remove(key)` takes a key as an argument. If the given key is in the hash map, it should remove the entry with that key and return `true`. If the key isn't in the hash map, it should return `false`.
 
-  7. `length()` returns the number of stored keys in the hash map.
+  1. `length()` returns the number of stored keys in the hash map.
 
-  8. `clear()` removes all entries in the hash map.
+  1. `clear()` removes all entries in the hash map.
 
-  9. `keys()` returns an array containing all the keys inside the hash map.
+  1. `keys()` returns an array containing all the keys inside the hash map.
 
-  10. `values()` returns an array containing all the values.
+  1. `values()` returns an array containing all the values.
 
-  11. `entries()` returns an array that contains each `key, value` pair. Example: `[[firstKey, firstValue], [secondKey, secondValue]]`
+  1. `entries()` returns an array that contains each `key, value` pair. Example: `[[firstKey, firstValue], [secondKey, secondValue]]`
 
   Remember that a hash map does not preserve insertion order when you are retrieving your hash map's data. It is normal and expected for keys and values to appear out of the order you inserted them in.
 

--- a/javascript/computer_science/project_hash_map.md
+++ b/javascript/computer_science/project_hash_map.md
@@ -50,6 +50,6 @@ if (index < 0 || index >= buckets.length) {
 
 #### Extra Credit
 
-  - Create a class `HashSet` that behaves the same as a `HashMap` but only contains `keys` with no `values`.
+- Create a class `HashSet` that behaves the same as a `HashMap` but only contains `keys` with no `values`.
 
 </div>


### PR DESCRIPTION
## Because
Previous projects in the CS section specify their methods with arguments included. It is a small change but it helps learners to recreate the same initial point and potentially avoid unnecessary confusion.

## This PR
`set` -> `set(key, value)` 

## Issue
Closes #XXXXX

## Additional Information
—

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)