### PR TITLE
Block and Inline lesson: fix link description

### DIFF
--- a/foundations/html_css/css-foundations/block-and-inline.md
+++ b/foundations/html_css/css-foundations/block-and-inline.md
@@ -80,5 +80,5 @@ This section contains questions for you to check your understanding of this less
 This section contains helpful links to related content. It isn’t required, so consider it supplemental.
 
 - [This tutorial](https://learnlayout.com/no-layout.html) is a little dated at this point, but its examples are clear. The first 6 slides cover the material we've seen so far.
-- Watch ["this"](https://www.youtube.com/watch?v=nfXRw06FgK8) short video on What does the term "Normal Flow" Mean In CSS.
+- Watch [this](https://www.youtube.com/watch?v=nfXRw06FgK8) short video on what the term "Normal Flow" means in CSS.
 - For a more interactive explanation and example, try this [Scrim on block and inline display](https://scrimba.com/scrim/co5024997a7e46c232d9abe55).


### PR DESCRIPTION
Fixes grammar and extraneous use of quotation marks in the description of the "Normal Flow" additional resource.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
This PR fixes grammar and a typo in block-and-inline.md to improve readability.


## This PR
- Fixes grammar in the description of the Additional Resource regarding normal flow.
- Removes extraneous quotation marks around the word "this" in the description of the Additional Resource regarding normal flow.


## Issue
None

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
