### PR TITLE
Fix typo in opening sentence of lesson for Project: Knights Travails. Closes #27285.

### DIFF
--- a/javascript/computer_science/project_knights_travails.md
+++ b/javascript/computer_science/project_knights_travails.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-Now you're pro with DFS and BFS. Let's try using our search algorithms on a real problem.
+Now you're a pro with DFS and BFS. Let's try using our search algorithms on a real problem.
 
 For this project, you'll need to use a data structure that's similar (but not identical) to a binary tree. For a summary of a few different examples, reference [this article](https://www.khanacademy.org/computing/computer-science/algorithms/graph-representation/a/describing-graphs).
 


### PR DESCRIPTION
Fixed a typo error reported in issue TheOdinProject/curriculum#27285.

## Because
Fixes a typo in the lesson opening sentence ('Now you're pro...' to 'Now you're a pro...').

## This PR
Addresses a typographical error in the opening sentence of the lesson. It currently reads 'Now you're pro...' and should read 'Now you're a pro...' as reported in issue TheOdinProject/curriculum#27285. This PR aims to enhance the clarity and correctness of the lesson content.

## Issue
Closes TheOdinProject/curriculum#27285.

## Additional Information

## Pull Request Requirements
- [x] I have thoroughly read and understand The Odin Project Contributing Guide.
- [x] The title of this PR follows the `curriculum/javascript/computer_science/project_knights_travails.md: Javascript course: fix the typo` format.
- [x] The Because section summarizes the reason for this PR.
- [x] The This PR section has a bullet point list describing the changes in this PR.
- [x] If this PR addresses an open issue, it is linked in the Issue section.
- [x] If any lesson files are included in this PR, they have been previewed with the Markdown preview tool to ensure they are formatted correctly.
- [x] If any lesson files are included in this PR, they follow the Layout Style Guide.
