### PR TITLE
Authentication_basics: Add note about passport.authenticate()

### DIFF
--- a/nodeJS/authentication/authentication_basics.md
+++ b/nodeJS/authentication/authentication_basics.md
@@ -223,7 +223,18 @@ app.post(
 );
 ```
 
-As you can see, all we have to do is call `passport.authenticate()`. This middleware performs numerous functions behind the scenes. Among other things, it looks at the request body for parameters named `username` and `password` then runs the `LocalStrategy` function that we defined earlier to see if the username and password are in the database. It then creates a session cookie that gets stored in the user's browser, and that we can access in all future requests to see whether or not that user is logged in.  It can also redirect you to different routes based on whether the login is a success or a failure.  If we had a separate login page we might want to go back to that if the login failed, or we might want to take the user to their user dashboard if the login is successful.  Since we're keeping everything in the index we want to go back to "/" no matter what.
+As you can see, all we have to do is call `passport.authenticate()`. This middleware performs numerous functions behind the scenes. Among other things, it looks at the request body for parameters named `username` and `password` then runs the `LocalStrategy` function that we defined earlier to see if the username and password are in the database. It then creates a session cookie that gets stored in the user's browser, and that we can access in all future requests to see whether or not that user is logged in.  It can also redirect you to different routes based on whether the login is a success or a failure.  If we had a separate login page we might want to go back to that if the login failed, or we might want to take the user to their user dashboard if the login is successful.  Since we're keeping everything in the index we want to go back to "/" no matter what. 
+
+For future projects combining the frontend with the backend, please note that for routes and callbacks utilising `passport.authenticate()`, this middleware does NOT send a successful response on successful authentication, if redirect options are omitted where the redirected routes end the request-response cycle. Thus it is necessary to create and add a following middleware to end the request-response cycle:
+
+```javascript
+app.post(
+'/log-in',
+  passport.authenticate('local'),
+  function(req, res) {
+    res.json({});
+  });
+```   
 
 If you fill out and submit the form now, everything should technically work, but you won't actually SEE anything different on the page... let's fix that.
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->

How passport.authenticate() middleware works in a fullstack project context (eg. the Messaging-App project) is not made abundantly clear. It is not clear that this middleware does not send a successful response upon successful authentication. 
Given that learners are likely to encounter this issue when they try and implement PassportJS in a fullstack project, it may be helpful to include the note proposed. 
I understand that this lesson is an introduction to Authentication with a primary focus on the backend (Express), so this note may seem out of place or not relevant for the requirement of the lesson. However I feel that the note could significantly improve the understanding of how to use PassportJS in a full stack context. That being said, I understand if this note needs to be rewritten to better suit the requirements of the lesson. Additionally this note may be better suited in a different section of the lesson; I chose to put it under the first implementation of passport.authenticate() in the lesson. 

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->

- Added a paragraph mentioning that passport.authenticate() does not send a successful response upon succesful authentication. Thus in a full stack context, a middleware that ends the request-response cycle following passport.authenticate() in the middleware chain is required.

- Added a brief code snippet to accompany this paragraph.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
