### PR TITLE
React Side Effects lesson: Reword explanation of counter

### DIFF
--- a/react/states_and_effects/how_to_deal_with_side_effects.md
+++ b/react/states_and_effects/how_to_deal_with_side_effects.md
@@ -37,7 +37,9 @@ export default function Clock() {
 }
 ~~~
 
-Alas, we see our counter going berserk. The reason this occurs is that we try to **manipulate the state during render**. As we know, the component gets torn down and re-rendered every time the state updates, and we are updating the state every second, thus incrementing rapidly.
+Alas, we see our counter going berserk. This happens because the `setInterval` function is being called not once, but at every state render.
+
+When our component first renders, it calls our initial `setInterval` function. That interval updates the state every second, triggering the component to re-render. But every re-render calls `setInterval` again, which triggers more frequent state updates, which each spawn new intervals, and everything quickly spirals out of control.
 
 This is where the `useEffect` hook swoops in to save us. We can wrap this calculation inside a `useEffect` hook to move it outside the rendering calculation. It accepts a callback function with all the calculations.
 


### PR DESCRIPTION
## Because
The current wording of the counter going berserk doesn't explain it's due to calling `setInterval` multiple times.

## This PR
- Clarifies the explanation of the counter in the React lesson "How to Deal With Side Effects"

## Issue
Closes #27136

## Additional Information
N/A

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)