### PR TITLE
Ruby-on-Rails: Fix various linting errors in the Turbo and Stimulus JS lessons

### DIFF
--- a/ruby_on_rails/rails_sprinkles/stimulus_js.md
+++ b/ruby_on_rails/rails_sprinkles/stimulus_js.md
@@ -281,7 +281,7 @@ we will use the new Rails standard of using import maps.
 haven't already. Don't worry if not everything sticks, but you should know where to look up what you need.
 </div>
 
-### Exercises
+#### Exercises
 
 To practice you need to create a new standard Rails application. Stimulus will be installed by default with Rails 7.0.
 
@@ -296,47 +296,18 @@ button.
 count (imagine a user writing a tweet which has a maximum length of 280 characters)
 - **Project**:
 Go back to you **Flight Booker** project and improve it:
-  - Add a controller that allows the user to add another passenger by clicking on an "Add passenger" button, which adds another set of fields to enter the passenger details (hint: have a look at the [\<template\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template)) tag)
+  - Add a controller that allows the user to add another passenger by clicking on an "Add passenger" button, which adds another set of fields to enter the passenger details (hint: have a look at the [\<template\>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template) tag)
   - Allow to remove existing passengers by clicking a "Remove" button, which removes the one set of passenger fields (make sure submissions to the server still works as expected)
   - Prevent removing the last set of passenger details.
 
 ### Knowledge check
 
-*This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering
-the questions below on your own, clicking the small arrow to the left of the question will reveal the answers.*
+The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
 
-<details markdown="block">
-  <summary>When do you use Stimulus?</summary>
-
-- When you want functionality, where a roundtrip to a server would not make sense
-
-</details>
-
-<details markdown="block">
-  <summary>How do you select a DOM element?</summary>
-
-- There are three aspects to it:
-  - add a `data-my-thing-target` to the HTML element
-  - declare it with `static targets = ["myThing"]` in your controller
-  - use it in the controller with `this.myThingTarget` or `this.myThingTargets`
-
-</details>
-
-<details markdown="block">
-  <summary>How do you make your Stimulus controllers reusable?</summary>
-
-- By using abstract controllers, like `toggle`, rather than one specific to the view, like `reveal-comments`
-- By making them configurable with `values` and `classes`
-
-</details>
-
-<details markdown="block">
-  <summary>How do you trigger actions on an event?</summary>
-
-- By using `data-action="click->some-controller#someAction"` on a HTML element
-- Or by using `data-action="resize@window->gallery#layout"` for window events
-
-</details>
+- <a class='knowledge-check-link' href='#introduction'>When do you use Stimulus?</a>
+- <a class='knowledge-check-link' href='#selecting-targeting-elements'>How do you select a DOM element?</a>
+- <a class='knowledge-check-link' href='#use-class-attributes-to-make-your-controllers-more-configurable'>How do you make your Stimulus controllers reusable?</a>
+- <a class='knowledge-check-link' href='#triggering-an-action'>How do you trigger actions on an event?</a>
 
 ### Additional resources
 

--- a/ruby_on_rails/rails_sprinkles/turbo.md
+++ b/ruby_on_rails/rails_sprinkles/turbo.md
@@ -22,28 +22,28 @@ implementation for web applications that loads only a single web document. Rathe
 
 #### Creating a Single-page application in Rails
 
-There are various Javascript frameworks to help developers implement SPA functionality. You have possibly heard of some of them, such as AngularJS or ReactJS. However, Rails has its own solution to creating the experience of a SPA without writing Javascript. This solution is a collection of libraries that are under the umbrella of Hotwire.
+There are various JavaScript frameworks to help developers implement SPA functionality. You have possibly heard of some of them, such as AngularJS or ReactJS. However, Rails has its own solution to creating the experience of a SPA without writing JavaScript. This solution is a collection of libraries that are under the umbrella of Hotwire.
 
 #### Hotwire
 
 In Rails 7, all new applications include Hotwire by default. Hotwire is actually an umbrella term for three different frameworks. These frameworks are:
 
-1.  Turbo
-2.  Stimulus
-3.  Strada
+1. Turbo
+1. Stimulus
+1. Strada
 
 The lesson you are reading now is all about Turbo. We will cover Stimulus in another lesson. Strada is a currently unreleased framework that aims to work alongside Turbo to deliver responsive mobile applications. You don't need to worry about Strada for the scope of this course, just be familiar with the name as you will see it mentioned from time-to-time.
 
 ### Turbo
 
-Turbo is the heart of the Hotwire umbrella. The goal of Turbo is to use four different techniques to create the experience of a speedy SPA without having to write any Javascript.
+Turbo is the heart of the Hotwire umbrella. The goal of Turbo is to use four different techniques to create the experience of a speedy SPA without having to write any JavaScript.
 
 Here is a quick summary of the four Turbo techniques together. As you continue to read this lesson, we will look at each piece more in-depth
 
-1.  **Turbo Drive**: We already covered this in an earlier lesson.
-2.  **Turbo Frames**: Turbo Frames, like Turbo Drive, also help with fast navigation, but for predefined portions of a page. Rather than requesting an entire page, you can define a region of your HTML as a Turbo Frame and replace only the content inside of that region.
-3.  **Turbo Streams**: Turbo Stream delivers web page changes to instantly insert, update, or remove a region of the webpage. An example of this could be a user creating a new post and that post immediately inserts itself at the top of the post index feed without any refresh or redirection.
-4.  **Turbo Native**: Turbo Native is a technique that allows developers to achieve the same Turbo style transitions on a mobile app for iOS or Android.
+1. **Turbo Drive**: We already covered this in an earlier lesson.
+1. **Turbo Frames**: Turbo Frames, like Turbo Drive, also help with fast navigation, but for predefined portions of a page. Rather than requesting an entire page, you can define a region of your HTML as a Turbo Frame and replace only the content inside of that region.
+1. **Turbo Streams**: Turbo Stream delivers web page changes to instantly insert, update, or remove a region of the webpage. An example of this could be a user creating a new post and that post immediately inserts itself at the top of the post index feed without any refresh or redirection.
+1. **Turbo Native**: Turbo Native is a technique that allows developers to achieve the same Turbo style transitions on a mobile app for iOS or Android.
 
 ### Turbo Frames
 
@@ -55,32 +55,32 @@ A frame is designated by wrapping a region inside of a `<turbo-frame>` element. 
 
 A basic Turbo Frame, using Rails helpers, may look like so:
 
-~~~erb
+```erb
 <%= turbo_frame_tag "article" do %>
   Some content
 <% end %>
-~~~
+```
 
 which will generate:
 
-~~~html
+```html
 <turbo-frame id="article">
   Some content
 </turbo-frame>
-~~~
+```
 
 Note that the frames have an ID. The ID is how Turbo is able to identify a frame to find out which one is which.
 With the Turbo Frame helper, you can substitute the ID for a variable. For instance:
 
-~~~erb
+```erb
 <% @articles.each do |article| %>
   <%= turbo_frame_tag article do %>
     <%= article.title %>
   <% end %>
 <% end %>
-~~~
+```
 
-The above example will generate a turbo frame for every article. Each frame will have a unique id like `article_1` or `article_2` and all we had to include was our article variable. 
+The above example will generate a turbo frame for every article. Each frame will have a unique id like `article_1` or `article_2` and all we had to include was our article variable.
 
 #### Connecting to other frames
 
@@ -88,7 +88,7 @@ Now that we have our first frame, we can replace its content with a link that re
 
 Let us replace the `/show` view with the `/edit` view on an article:
 
-~~~erb
+```erb
 # views/articles/show.html.erb
 
 ...
@@ -97,9 +97,9 @@ Let us replace the `/show` view with the `/edit` view on an article:
   <%= link_to "Edit Article", edit_article_path(@article) %>
 <% end %>
 ...
-~~~
+```
 
-~~~erb
+```erb
 # views/articles/edit.html.erb
 
 ...
@@ -108,30 +108,30 @@ Let us replace the `/show` view with the `/edit` view on an article:
   <%= link_to "Return to Article", @article %>
 <% end %>
 ...
-~~~
+```
 
 That's all we have to do! Turbo will recognize that our destination URL, the `/show` or `/edit` page, has a matching Turbo Frame and will replace the frame region with the content from the new page's frame. Something else to note is that this does work with forms as well. In our controller, if the `update` action contains `redirect_to @article`, then our Turbo Frame will be updated when we submit our form just like if we clicked a link.
 
-Now that we have our matching frames that can replace their content, what about the content located outside of the frame? Anything outside of the frame does not change. If we were going from `/show` to `/edit`, then the content outside of the frame would still be the same content of the `/show` page and we would not receive any content from outside of the `/edit` frame either. We did not navigate to a new page, we only requested new html from another route and inserted it into our current page. The current `url` also does not change. We will stay on the `/show` path, and if we refresh, we would still see the `/show` view. (Note that it is possible to change this default behaviour by making use of Turbo Drive's `data-turbo-action` to advance the browser history and update the current `url`.)
+Now that we have our matching frames that can replace their content, what about the content located outside of the frame? Anything outside of the frame does not change. If we were going from `/show` to `/edit`, then the content outside of the frame would still be the same content of the `/show` page and we would not receive any content from outside of the `/edit` frame either. We did not navigate to a new page, we only requested new HTML from another route and inserted it into our current page. The current `url` also does not change. We will stay on the `/show` path, and if we refresh, we would still see the `/show` view. (Note that it is possible to change this default behaviour by making use of Turbo Drive's `data-turbo-action` to advance the browser history and update the current `url`.)
 
 #### Breaking out of a Turbo Frame
 
 Sometimes you may have a link inside of the Turbo Frame that you want to act as a normal page navigation. To do so, add `data-turbo-frame="_top"` to the element. An example with a Rails link helper:
 
-~~~erb
+```erb
 <%= link_to "Return to Article", @article, data: { turbo_frame: "_top" } %>
-~~~
+```
 
 #### Targeting a Turbo Frame from outside
 
 We can also do the opposite. We can make a link that exists outside of our Turbo Frame act as if it was inside of the Frame and update it. This time, we set the `turbo-frame` data attribute to point to the ID of the specific frame. Lets say we want to designate a turbo frame to show either a list of posts or a list of images:
 
-~~~erb
+```erb
 <%= link_to "Show Posts", posts_path, data: { turbo_frame: "list-region" } %>
 <%= link_to "Show Images", images_path, data: { turbo_frame: "list-region" } %>
 
 <%= turbo_frame_tag id="list-region" %>
-~~~
+```
 
 Clicking either of the above links will send a request to the respective path and return the content inside of our `"list-region"` frame.
 
@@ -141,7 +141,7 @@ Frames can be given a `src` attribute. When this is supplied, the frame will be 
 
 For example:
 
-~~~erb
+```erb
 ...
 <%= turbo_frame_tag id="Articles", src: articles_path do %>
   <div>
@@ -150,33 +150,32 @@ For example:
     with the id of "Articles".
   </div>
 <% end %>
-~~~
+```
 
 We can also make our frames **lazy loaded**. A lazy loaded frame will only fetch its content when it becomes visible on the page. We make a frame lazy load by adding `loading=lazy`. A frame with `loading=lazy` *must* also have a `src:` attribute to fetch from, or else it will not do anything. Using our previous example:
 
-~~~erb
+```erb
 ...
 <%= turbo_frame_tag id="Articles", src: articles_path, loading: "lazy" do %>
   <div>
     I am a placeholder! I will be replaced when a user scrolls down to see me on the page!
   </div>
 <% end %>
-~~~
+```
 
 ### Turbo Stream
 
 Now we know how to set up our views to use Turbo Frames, but what about content that is being changed by our users? We can't put a Turbo Frame around something that doesn't exist yet. That's where Turbo Stream comes in. Turbo Streams send page changes as HTML wrapped in `<turbo-stream>` elements. Turbo Streams specify an action to perform and the target ID of the DOM element to update with this action. For instance, a Turbo Stream where `action="replace"` and `target="body"` would replace the HTML element where `id="body"` with the new element being delivered over Turbo Stream. These streams can be sent in response to either a direct browser request, or by broadcasting over a websocket connection. This lesson will stick to the browser request implementation. Turbo Streams can take the form of 7 different actions:
 
-*  Append
-*  Prepend
-*  Before
-*  After
-*  Replace
-*  Update
-*  Remove
+- Append
+- Prepend
+- Before
+- After
+- Replace
+- Update
+- Remove
 
 Turbo Streams are delivered by use of our controller. Just like how your users make `html` requests and receive `view.html.erb` files, your users can receive `view.turbo_stream.erb` files. These are not standalone view files as you know them, they only contain a few lines and are a way of sending the user a Stream response instead of a new page.
-
 
 #### Our first Turbo Stream
 
@@ -184,18 +183,18 @@ Let's say that we have made a website where users can create posts. By adding a 
 
 Our `index` view:
 
-~~~erb
+```erb
 # views/posts/index.html.erb
 
 <%= turbo_frame_tag id="new_post", src:new_post_path %>
 <div id="posts">
   <%= render @posts %>
 </div>
-~~~
+```
 
 Our `new` page with it's form:
 
-~~~erb
+```erb
 # views/posts/new.html.erb
 
 <%= turbo_frame_tag id="new_post" do %>
@@ -205,21 +204,21 @@ Our `new` page with it's form:
     <%= form.submit %>
   <% end %>
 <% end %>
-~~~
+```
 
 Our `_post` partial that every post will be rendered with:
 
-~~~erb
+```erb
 # views/posts/_post.html.erb
 
 <div>
   <%= post.body %>
 </div>
-~~~
+```
 
 Our controller:
 
-~~~ruby
+```ruby
 # controllers/posts_controller.rb
 
 class PostsController < ApplicationController
@@ -246,7 +245,7 @@ class PostsController < ApplicationController
     params.require(:post).permit(:body)
   end
 end
-~~~
+```
 
 This will result in only the `posts#index` page loading initially and *then* another request being made to the `posts#new` action of our controller to insert the form! This also keeps our code DRY because if instead we opted to add the form by use of a partial on the index page, we would still have to repeat the `posts#new` controller action during the `posts#index` action.
 
@@ -254,12 +253,11 @@ However, if a user is to submit a post right now, something weird happens! The f
 
 All of this looks very scary and like something is wrong, but it's fine. All we have to do is set up our Turbo Stream and the pieces will all begin to work together again.
 
-
 #### Turbo Stream in the controller
 
 For starters, we tell our controller that we want to accept a Turbo Stream format. This is done in the same way as accepting a format such as JSON. Our create action may now look like:
 
-~~~ruby
+```ruby
 # controllers/posts_controller.rb
 ...
   def create
@@ -273,7 +271,7 @@ For starters, we tell our controller that we want to accept a Turbo Stream forma
       end
     end
   end
-~~~
+```
 
 What's going on here? Well, the `respond_to do |format|` block is our way of telling the controller to do more than just `html` format requests. If our post saves, we would like the format we respond with to be a `create.turbo_stream.erb` format. If it does not save, we would like to respond with the `new.html.erb` file being rendered. Notice the difference in the formats is the file extension that is after the name and before the `.erb`.
 
@@ -285,9 +283,9 @@ Now all we have to do is create our `create.turbo_stream.erb` file to respond wi
 
 You create your Turbo Stream file inside of your `views` folder the same way as any other view. In this example, it would be located at `views/posts/create.turbo_stream.erb`. Our view file will look like this:
 
-~~~erb
+```erb
 <%= turbo_stream.append "posts", @post %>
-~~~
+```
 
 That line is all we need! What this does is create a Turbo Stream packet with the `append` action. The target of the action is `"posts"`. This is the `<div>` with the `id="posts"` that contains all of our posts. Turbo Stream will locate the `<div>` and append our brand new `@post` to the bottom. Our newly created `@post` will even use the `_post.html.erb` partial to be in the proper layout as all of our other posts. For that, you can thank the Rails naming convention. If you are breaking from Rails convention, you can specify a partial to use inside of your `turbo_stream` template.
 
@@ -298,18 +296,18 @@ Now that we have added the `format.turbo_stream` response to our controller and 
 There's no time to get more in-depth on how Turbo Stream works in this lesson, but here are some topics for you to begin your personal research
 if you would like to learn more:
 
-1.  You can chain multiple `turbo_stream` actions in one `turbo_stream.erb` file, like if you wanted to append to one region and
+1. You can chain multiple `turbo_stream` actions in one `turbo_stream.erb` file, like if you wanted to append to one region and
     update another region at the same time.
 
-2.  You don't *have* to create a separate layout file for your Stream formats. For instance, we could instead change the line in our controller to:
+1. You don't *have* to create a separate layout file for your Stream formats. For instance, we could instead change the line in our controller to:
 
-    ~~~ruby
+    ```ruby
     format.turbo_stream { render turbo_stream: turbo_stream.append('posts', @post) }
-    ~~~
+    ```
 
-    However, [you shouldn't do this for anything complex or chained](https://github.com/hotwired/turbo-rails/issues/77#issuecomment-757349251).
+    However, you shouldn't do this for anything complex or chained, as explained in this [comment by one of the maintainers of Hotwire](https://github.com/hotwired/turbo-rails/issues/77#issuecomment-757349251).
 
-3.  You may have noticed that when you submit a new Post, the text box doesn't clear out. You need to reset the submission element in order for it to be empty again. Hotwire has a remedy for this problem by including Stimulus, a light JavaScript framework. Don't worry about Stimulus for this example though, the next lesson will cover how to write and make use of Stimulus Controllers.
+1. You may have noticed that when you submit a new Post, the text box doesn't clear out. You need to reset the submission element in order for it to be empty again. Hotwire has a remedy for this problem by including Stimulus, a light JavaScript framework. Don't worry about Stimulus for this example though, the next lesson will cover how to write and make use of Stimulus Controllers.
 
 ### Turbo Native
 
@@ -319,67 +317,25 @@ The final piece of Turbo is something that you don't need to know much about for
 
 <div class="lesson-content__panel" markdown="1">
 
-#### Single-page applications
-
-1. Read sections 1, 2, and 3 of Bloomreach's [What Are Single Page Applications and Why Do People Like Them So Much?](https://www.bloomreach.com/en/blog/2018/07/what-is-a-single-page-application.html#whatssingle-page-application)
-   article
-
-#### Hotwire
-
+1. Read sections 1, 2, and 3 of Bloomreach's [What Are Single Page Applications and Why Do People Like Them So Much?](https://www.bloomreach.com/en/blog/2018/07/what-is-a-single-page-application.html#whatssingle-page-application) article
 1. Watch the [Hotwire Demo Video](https://www.youtube.com/watch?v=eKY-QES1XQQ)
-    * We have only covered content up until the 5:40 mark, but you may continue watching past that point to become more familiar with
-      other aspects of Hotwire that we will be covering in upcoming lessons.
-    * The video is edited to be a very quick showcase. Don't worry about trying to pause and use this video as a tutorial. Just sit back
-      and use this demo to watch how Turbo Drive, Frames, & Streams come together visually.
-2. Skim through sections 1-4 of the [Turbo Handbook](https://turbo.hotwired.dev/handbook/introduction)
-    * This Handbook is written to be backend-agnostic, meaning that the code you will see is pure HTML and not Rails tags, but it still
-      is a useful resource for referencing how Turbo works.
-3. Take a quick glance at the Turbo-Rails gem [RubyDoc info page](https://www.rubydoc.info/gems/turbo-rails/1.0.0)
-    * This resource covers the Rails-specific syntaxes and tags you can use for Turbo. You don't need to read anything now, just know that
-      it exists so you can come back to it when you need to figure out how to use a specific piece of Turbo in your applications.
+    - We have only covered content up until the 5:40 mark, but you may continue watching past that point to become more familiar with other aspects of Hotwire that we will be covering in upcoming lessons.
+    - The video is edited to be a very quick showcase. Don't worry about trying to pause and use this video as a tutorial. Just sit back and use this demo to watch how Turbo Drive, Frames, & Streams come together visually.
+1. Skim through sections 1-4 of the [Turbo Handbook](https://turbo.hotwired.dev/handbook/introduction)
+    - This Handbook is written to be backend-agnostic, meaning that the code you will see is pure HTML and not Rails tags, but it still is a useful resource for referencing how Turbo works.
+1. Take a quick glance at the Turbo-Rails gem [RubyDoc info page](https://www.rubydoc.info/gems/turbo-rails/1.0.0)
+    - This resource covers the Rails-specific syntaxes and tags you can use for Turbo. You don't need to read anything now, just know that it exists so you can come back to it when you need to figure out how to use a specific piece of Turbo in your applications.
 
 </div>
 
 ### Knowledge check
 
-*This section contains questions for you to check your understanding of this lesson. If you’re having trouble answering the questions below on your own, clicking the small arrow to the left of the question will reveal the answers.*
+The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
 
-<details markdown="block">
-  <summary>What does SPA stand for & what is it?</summary>
-
-  *   A SPA is a single-page application.
-  *   A SPA is a web-app that doesn't need to reload the page during use to update.
-
-</details>
-
-<details markdown="block">
-  <summary>What is Turbolinks?</summary>
-
-  *   Turbolinks is the now-deprecated predecessor to Turbo.
-
-</details>
-
-<details markdown="block">
-  <summary>What is Hotwire?</summary>
-
-  *   Hotwire is the umbrella term for the Rails SPA suite containing Turbo, Stimulus, & Strada.
-
-</details>
-
-<details markdown="block">
-  <summary>How do we use a Turbo Frame?</summary>
-
-  *   By creating a `<% turbo_frame_tag %>` region on the 2+ pages we would like to connect. When making a request to a page using a link inside of a Turbo Frame, Turbo will search for a Turbo Frame with the same `id` to replace the current page's Turbo Frame content with.
-
-</details>
-
-<details markdown="block">
-  <summary>How do we set up Turbo Streams?</summary>
-
-  *   First, we tell our controller to respond with a `turbo_stream` format, rather than a `html` format. 
-  *   Second, we create a `turbo_stream.erb` file in our views folder with the same name as the controller action (Rails conventions) that contains the Turbo Stream's action and target destination.
-
-</details>
+- <a class='knowledge-check-link' href='#single-page-applications-spas'>What does SPA stand for and what is it?</a>
+- <a class='knowledge-check-link' href='#hotwire'>What is Hotwire?</a>
+- <a class='knowledge-check-link' href='#turbo-frames'>How do we use a Turbo Frame?</a>
+- <a class='knowledge-check-link' href='#turbo-stream'>How do we set up Turbo Streams?</a>
 
 ### Additional resources
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
On the Ruby-on-Rails course, Turbo and Stimulus lessons, fix 'knowledge check' sections to align with the style guide, and fix various other linting errors as discussed on my previous pull request https://github.com/TheOdinProject/curriculum/pull/27385 . Managed to mess up merging of upstream changes into local branch, so scrapped that pull request and started fresh.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Replaced drop down quiz with links to relevant lesson sections
- Replaced 'knowledge check' intro text as per markdownlint rule (TOP003/default-section-content)
- Replaced code section tildes with backticks
- Changed numbered lists from 1. 2. 3. to 1. 1. 1.
- Removed trailing spaces
- Capitalized nouns as per linting rules

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes https://github.com/TheOdinProject/curriculum/issues/27090

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [ ] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [ ] The `Because` section summarizes the reason for this PR
-   [ ] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
