### PR TITLE
Fix: Deployment lesson headings to align with style guide

### DIFF
--- a/nodeJS/express_and_mongoose/deployment.md
+++ b/nodeJS/express_and_mongoose/deployment.md
@@ -100,14 +100,14 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - $20 a month should be enough to host eight apps (including three apps for free).
 - Fly.io charges $0.15/GB of RootFS for machines stopped for 30 days.
 
-**Free plan**
+#### Fly.io Free Plan
 
 - You can host three apps for free before you need to start paying.
 - Requires a credit card.
 - Fly.io waives monthly invoices that total less than $5 USD. So, although it may look like
   you are being charged, it's very unlikely that you will exceed $5 and actually have to pay.
 
-**Links**
+#### Fly.io Links
 
 - [Homepage](https://fly.io/)
 - [Documentation](https://fly.io/docs/)
@@ -121,12 +121,12 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - Pay for what you use model.
 - $5 a month should be enough to host four applications.
 
-**Free plan**
+#### Railway.app Free Plan
 
 - You get a free one-time grant of $5 on their free trial, and the applications are never put to sleep when inactive.
 - However, the longevity of your free allowance depends on how many resources you consume. More complex apps with more traffic may consume all free resources within a month, whereas simpler apps may last longer.
 
-**Links**
+#### Railway.app Links
 
 - [Homepage](https://railway.app/)
 - [Documentation](https://docs.railway.app/)
@@ -139,14 +139,14 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - Free plan does not limit the number of applications you can deploy.
 - Also has fixed and usage-based payment plans.
 
-**Free plan**
+#### Adaptable.io Free Plan
 
 - No limits on the number of applications you can deploy on the free plan.
 - Monthly performance allowance is more than sufficient for course/personal projects (approximately 25,000 API requests per month).
 - Applications are put to sleep when inactive but wake up speed is quicker than Render.
 - Requires a credit card.
 
-**Links**
+#### Adaptable.io Links
 
 - [Homepage](https://adaptable.io/)
 - [Documentation](https://adaptable.io/docs/what-is-adaptable)
@@ -160,13 +160,13 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - The free 750-hour allowance is enough to host a few apps without paying anything. However, databases are separate on Render, and the lowest spec databases cost $7 each. This is a good option to use in tandem with MongoDB Atlas.
 - $21 a month is enough to host three applications as each app's database will cost $7.
 
-**Free plan**
+#### Render Free Plan
 
 - 750 hours of free usage per month.
 - Applications are put to sleep automatically after 15 minutes of inactivity, so the 750 free hours should be enough to host a few apps for the entire month.
 - Requires a credit card.
 
-**Links**
+#### Render Links
 
 - [Homepage](https://render.com/)
 - [Documentation](https://render.com/docs/)
@@ -183,11 +183,11 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - Heroku's lowest-tier Postgresql databases cost $5 per month, effectively costing each application $5 to host.
 - $20 a month will be enough to host three applications. $5 eco plan for 1000 server hours + an additional $5 for each app.
 
-**Free plan**
+#### Heroku Free Plan
 
 - N/A
 
-**Links**
+#### Heroku Links
 
 - [Homepage](https://www.heroku.com/)
 - [Documentation](https://devcenter.heroku.com/)

--- a/nodeJS/express_and_mongoose/deployment.md
+++ b/nodeJS/express_and_mongoose/deployment.md
@@ -250,7 +250,7 @@ This will be where the Git skills you've been learning will start to really pay 
 
 ### Knowledge check
 
-This section contains questions for you to check your understanding of this lesson on your own. If you're having trouble answering a question, click it and review the material it links to.
+The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
 
 - [What's the difference between static and dynamic websites?](#static-vs-dynamic-sites)
 - [What does 'PaaS' stand for?](#what-is-a-paas)

--- a/nodeJS/express_and_mongoose/deployment.md
+++ b/nodeJS/express_and_mongoose/deployment.md
@@ -100,14 +100,14 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - $20 a month should be enough to host eight apps (including three apps for free).
 - Fly.io charges $0.15/GB of RootFS for machines stopped for 30 days.
 
-#### Fly.io Free Plan
+#### Fly.io: Free Plan
 
 - You can host three apps for free before you need to start paying.
 - Requires a credit card.
 - Fly.io waives monthly invoices that total less than $5 USD. So, although it may look like
   you are being charged, it's very unlikely that you will exceed $5 and actually have to pay.
 
-#### Fly.io Links
+#### Fly.io: Links
 
 - [Homepage](https://fly.io/)
 - [Documentation](https://fly.io/docs/)
@@ -121,12 +121,12 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - Pay for what you use model.
 - $5 a month should be enough to host four applications.
 
-#### Railway.app Free Plan
+#### Railway.app: Free Plan
 
 - You get a free one-time grant of $5 on their free trial, and the applications are never put to sleep when inactive.
 - However, the longevity of your free allowance depends on how many resources you consume. More complex apps with more traffic may consume all free resources within a month, whereas simpler apps may last longer.
 
-#### Railway.app Links
+#### Railway.app: Links
 
 - [Homepage](https://railway.app/)
 - [Documentation](https://docs.railway.app/)
@@ -139,14 +139,14 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - Free plan does not limit the number of applications you can deploy.
 - Also has fixed and usage-based payment plans.
 
-#### Adaptable.io Free Plan
+#### Adaptable.io: Free Plan
 
 - No limits on the number of applications you can deploy on the free plan.
 - Monthly performance allowance is more than sufficient for course/personal projects (approximately 25,000 API requests per month).
 - Applications are put to sleep when inactive but wake up speed is quicker than Render.
 - Requires a credit card.
 
-#### Adaptable.io Links
+#### Adaptable.io: Links
 
 - [Homepage](https://adaptable.io/)
 - [Documentation](https://adaptable.io/docs/what-is-adaptable)
@@ -160,13 +160,13 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - The free 750-hour allowance is enough to host a few apps without paying anything. However, databases are separate on Render, and the lowest spec databases cost $7 each. This is a good option to use in tandem with MongoDB Atlas.
 - $21 a month is enough to host three applications as each app's database will cost $7.
 
-#### Render Free Plan
+#### Render: Free Plan
 
 - 750 hours of free usage per month.
 - Applications are put to sleep automatically after 15 minutes of inactivity, so the 750 free hours should be enough to host a few apps for the entire month.
 - Requires a credit card.
 
-#### Render Links
+#### Render: Links
 
 - [Homepage](https://render.com/)
 - [Documentation](https://render.com/docs/)
@@ -183,11 +183,11 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - Heroku's lowest-tier Postgresql databases cost $5 per month, effectively costing each application $5 to host.
 - $20 a month will be enough to host three applications. $5 eco plan for 1000 server hours + an additional $5 for each app.
 
-#### Heroku Free Plan
+#### Heroku: Free Plan
 
 - N/A
 
-#### Heroku Links
+#### Heroku: Links
 
 - [Homepage](https://www.heroku.com/)
 - [Documentation](https://devcenter.heroku.com/)

--- a/ruby_on_rails/rails_basics/deployment.md
+++ b/ruby_on_rails/rails_basics/deployment.md
@@ -227,11 +227,12 @@ This will be where the Git skills you've been learning will start to really pay 
 1. Deploy your [Blog App project](https://www.theodinproject.com/lessons/ruby-on-rails-blog-app) to one of the hosting providers we've mentioned. If you need help deciding which one to use, we recommend Fly.io. The important thing to take away from this first deployment is getting experience deploying. Don't worry if you don't understand everything that's happening. That will come with time.
    - Use one of the linked deploy guides for your PaaS provider to help you through the process.
    - If you're having trouble deploying, check out the [Debugging and Troubleshooting Deployments](#debugging-and-troubleshooting-deployments) section for some tips.
+
 </div>
 
 ### Knowledge check
 
-This section contains questions for you to check your understanding of this lesson on your own. If you're having trouble answering a question, click it and review the material it links to.
+The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
 
 - [What's the difference between static and dynamic websites?](#static-vs-dynamic-sites)
 - [What does 'PaaS' stand for?](#what-is-a-paas)

--- a/ruby_on_rails/rails_basics/deployment.md
+++ b/ruby_on_rails/rails_basics/deployment.md
@@ -97,14 +97,14 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - $20 a month should be enough to host eight apps (including three apps for free).
 - Fly.io charges $0.15/GB of RootFS for machines stopped for 30 days.
 
-**Free plan**
+#### Fly.io Free Plan
 
 - You can host three apps for free before you need to start paying.
 - Requires a credit card.
 - Fly.io waives monthly invoices that total less than $5 USD. So, although it may look like
   you are being charged, it's very unlikely that you will exceed $5 and actually have to pay.
 
-**Links**
+#### Fly.io Links
 
 - [Homepage](https://fly.io/)
 - [Documentation](https://fly.io/docs/)
@@ -119,12 +119,12 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - Pay for what you use model.
 - $5 a month should be enough to host four applications.
 
-**Free plan**
+#### Railway.app Free Plan
 
 - You get a free one-time grant of 5$ on their free trial, and the applications are never put to sleep when inactive.
 - However, the longevity of your free allowance depends on how many resources you consume. More complex apps with more traffic may consume all free resources within a month, whereas simpler apps may last longer.
 
-**Links**
+#### Railway.app Links
 
 - [Homepage](https://railway.app/)
 - [Documentation](https://docs.railway.app/)
@@ -138,13 +138,13 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - The free 750-hour allowance is enough to host a few apps without paying anything. However, databases are separate on Render, and the lowest spec databases cost $7 each.
 - $21 a month is enough to host three applications as each app's database will cost $7.
 
-**Free plan**
+#### Render Free Plan
 
 - 750 hours of free usage per month.
 - Applications are put to sleep automatically after 15 minutes of inactivity, so the 750 free hours should be enough to host a few apps for the entire month.
 - You only get one free database at a time which lasts 90 days before being deleted. With this strict database allowance, the free tier is enough to host one free app for 90 days.
 
-**Links**
+#### Render Links
 
 - [Homepage](https://render.com/)
 - [Documentation](https://render.com/docs/)
@@ -161,11 +161,11 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - Heroku's lowest-tier PostgreSQL databases cost $5 per month, effectively costing each application $5 to host.
 - $20 a month will be enough to host three applications. $5 Eco plan for 1000 server hours + an additional $5 for each app.
 
-**Free plan**
+#### Heroku Free Plan
 
 - N/A
 
-**Links**
+#### Heroku Links
 
 - [Homepage](https://www.heroku.com/)
 - [Documentation](https://devcenter.heroku.com/)

--- a/ruby_on_rails/rails_basics/deployment.md
+++ b/ruby_on_rails/rails_basics/deployment.md
@@ -97,14 +97,14 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - $20 a month should be enough to host eight apps (including three apps for free).
 - Fly.io charges $0.15/GB of RootFS for machines stopped for 30 days.
 
-#### Fly.io Free Plan
+#### Fly.io: Free Plan
 
 - You can host three apps for free before you need to start paying.
 - Requires a credit card.
 - Fly.io waives monthly invoices that total less than $5 USD. So, although it may look like
   you are being charged, it's very unlikely that you will exceed $5 and actually have to pay.
 
-#### Fly.io Links
+#### Fly.io: Links
 
 - [Homepage](https://fly.io/)
 - [Documentation](https://fly.io/docs/)
@@ -119,12 +119,12 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - Pay for what you use model.
 - $5 a month should be enough to host four applications.
 
-#### Railway.app Free Plan
+#### Railway.app: Free Plan
 
 - You get a free one-time grant of 5$ on their free trial, and the applications are never put to sleep when inactive.
 - However, the longevity of your free allowance depends on how many resources you consume. More complex apps with more traffic may consume all free resources within a month, whereas simpler apps may last longer.
 
-#### Railway.app Links
+#### Railway.app: Links
 
 - [Homepage](https://railway.app/)
 - [Documentation](https://docs.railway.app/)
@@ -138,13 +138,13 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - The free 750-hour allowance is enough to host a few apps without paying anything. However, databases are separate on Render, and the lowest spec databases cost $7 each.
 - $21 a month is enough to host three applications as each app's database will cost $7.
 
-#### Render Free Plan
+#### Render: Free Plan
 
 - 750 hours of free usage per month.
 - Applications are put to sleep automatically after 15 minutes of inactivity, so the 750 free hours should be enough to host a few apps for the entire month.
 - You only get one free database at a time which lasts 90 days before being deleted. With this strict database allowance, the free tier is enough to host one free app for 90 days.
 
-#### Render Links
+#### Render: Links
 
 - [Homepage](https://render.com/)
 - [Documentation](https://render.com/docs/)
@@ -161,11 +161,11 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - Heroku's lowest-tier PostgreSQL databases cost $5 per month, effectively costing each application $5 to host.
 - $20 a month will be enough to host three applications. $5 Eco plan for 1000 server hours + an additional $5 for each app.
 
-#### Heroku Free Plan
+#### Heroku: Free Plan
 
 - N/A
 
-#### Heroku Links
+#### Heroku: Links
 
 - [Homepage](https://www.heroku.com/)
 - [Documentation](https://devcenter.heroku.com/)


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Deployment lesson headings do not align with the style guide

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Changed asterisk use to hashtag for headings

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #27394 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
`Render Free Plan` doesn't have quite a good ring to me. It could be read as `Render-free Plan`, which I'm not a fan of. What do we think about adding a colon `:` or a dash `-` like so: 
`Render - Free Plan` or `Render: Free Plan`
to all of the headings?

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
