### PR TITLE
Object Basics (Foundation): Updated Reduce method's output in the given example to the correct output.

### DIFF
--- a/foundations/javascript_basics/object_basics.md
+++ b/foundations/javascript_basics/object_basics.md
@@ -118,7 +118,7 @@ However, there are two key differences with this array method:
 - It also takes in an `initialValue` as a second argument (after the callback), which helps when we don't want our initial value to be the first element in the array. For instance, if we wanted to sum all numbers in an array, we could call reduce without an `initialValue`, but if we wanted to sum all numbers in an array and add 10, we could use 10 as our `initialValue`.
 
 ```js
-arr.reduce((total, currentItem) => total * currentItem, 1); // Outputs 120
+arr.reduce((total, currentItem) => total * currentItem, 1); // Outputs 120;
 ```
 
 In the above function, we:

--- a/foundations/javascript_basics/object_basics.md
+++ b/foundations/javascript_basics/object_basics.md
@@ -118,7 +118,7 @@ However, there are two key differences with this array method:
 - It also takes in an `initialValue` as a second argument (after the callback), which helps when we don't want our initial value to be the first element in the array. For instance, if we wanted to sum all numbers in an array, we could call reduce without an `initialValue`, but if we wanted to sum all numbers in an array and add 10, we could use 10 as our `initialValue`.
 
 ```js
-arr.reduce((total, currentItem) => total * currentItem, 1); // Outputs [1, 2, 6, 24, 120];
+arr.reduce((total, currentItem) => total * currentItem, 1); // Outputs 120
 ```
 
 In the above function, we:


### PR DESCRIPTION
## Because

The example using array's reduce method in the _Object Basics_ lesson has an incorrect output of [1, 2, 6, 24, 120]. The result of the reduce method returns a **single value**. The updated markdown changes the output from [1, 2, 6, 24, 120] to 120.

## This PR

- Replaces the output of the example which uses the array's reduce method.

## Issue

Closes #27383 

## Additional Information

N/A

## Pull Request Requirements

-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
