### PR TITLE
NodeJS: Fix Repetition of sub-heading in the Getting Started Lesson.

### DIFF
--- a/nodeJS/introduction_to_nodeJS/getting_started.md
+++ b/nodeJS/introduction_to_nodeJS/getting_started.md
@@ -2,8 +2,6 @@
 
 Like we learned in the introduction lesson, Node.js is really just JavaScript. So a basic understanding of JavaScript is necessary in order to understand Node. For this reason, it is highly recommended that you take our prerequisite [JavaScript course](https://www.theodinproject.com/paths/full-stack-javascript/courses/javascript) before continuing with this course.
 
-### Lesson overview
-
 This lesson will take you through a tutorial that will teach you the basic modules and functions that you need to get up and running with Node.js. The project that comes at the end of this section will ask you to use Node to create a basic website that will include an `Index`, `About` and `Contact Me` page. So while learning the topics in this lesson, be on the lookout for things that might help you complete the project.
 
 <div class="lesson-note" markdown="1">


### PR DESCRIPTION
## Because

There is seems to be a typo in the _Getting Started_ lesson of the NodeJS section. The sub-heading **Lesson Overview** is repeated twice.

## This PR

- Removes the duplicated sub-heading _Lesson Overview_ from the getting started lesson of node.

## Issue

Closes #27358 

## Additional Information

It seemed strange to have repeated sub-headings. Was that intentional?

## Pull Request Requirements

-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
