### PR TITLE
Project: Etch-a-Sketch: Fix 'Extra Credit' wording

### DIFF
--- a/foundations/javascript_basics/project_etch_a_sketch.md
+++ b/foundations/javascript_basics/project_etch_a_sketch.md
@@ -38,7 +38,7 @@ Don't forget to commit early & often! You can [reference the Commit Message less
 
 Transform the behavior of a square when interacting with the mouse by introducing a series of modifications.
 
-1. Rather than a color change from black to white, each interaction should randomize the square's RGB value entirely.
+1. Rather than squares being the same color throughout the grid, randomize squares' RGB values with each interaction.
 1. Additionally, implement a progressive darkening effect where each interaction adds 10% more black or color to the square. The objective is to achieve a completely black square only after ten interactions.
 
 You can choose to do either one or both of these challenges, it's up to you.

--- a/foundations/javascript_basics/project_etch_a_sketch.md
+++ b/foundations/javascript_basics/project_etch_a_sketch.md
@@ -38,7 +38,7 @@ Don't forget to commit early & often! You can [reference the Commit Message less
 
 Transform the behavior of a square when interacting with the mouse by introducing a series of modifications.
 
-1. Rather than squares being the same color throughout the grid, randomize squares' RGB values with each interaction.
+1. Rather than squares being the same color throughout the grid, randomize the squares' RGB values with each interaction.
 1. Additionally, implement a progressive darkening effect where each interaction adds 10% more black or color to the square. The objective is to achieve a completely black square only after ten interactions.
 
 You can choose to do either one or both of these challenges, it's up to you.


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
The "Extra Credit" section of the "Project: Etch-a-Sketch" page mentions the colors "black" / "white", but the instructions earlier did not prescribe/mention any colors for squares. This can cause some confusion for the student.


## This PR

- Removes mention of the color "black" or "white"
- Clarifies that what the user _can_ do for "extra credit" is allow the colors to randomize, rather than keeping them a single color (not necessarily "black" or "white')


## Issue
Related to #25619 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
