### PR TITLE
Fix incorrect error handling for TOP004 lint rule

### DIFF
--- a/markdownlint/TOP004_lessonHeadings/TOP004_lessonHeadings.js
+++ b/markdownlint/TOP004_lessonHeadings/TOP004_lessonHeadings.js
@@ -93,13 +93,15 @@ module.exports = {
     let anyHeadings = false;
     const getExpected = () => requiredHeadings[i++] || "[None]";
     const handleCase = (str) => (matchCase ? str : str.toLowerCase());
+    // https://regexr.com/7rf1o to test the following regex:
+    const wildcardRegex = new RegExp(/^(#*\s)?\*$/);
+
     forEachHeading(params, (heading, content) => {
       if (!hasError) {
         anyHeadings = true;
         const actual = levels[heading.tag] + " " + content;
         const expected = getExpected();
-        // https://regexr.com/7rf1o to test the following regex
-        const wildcardRegex = new RegExp(/^(#*\s)?\*$/);
+
         if (wildcardRegex.test(expected)) {
           const nextExpected = getExpected();
           if (handleCase(nextExpected) !== handleCase(actual)) {
@@ -147,7 +149,7 @@ module.exports = {
     if (
       !hasError &&
       (extraHeadings > 1 ||
-        (extraHeadings === 1 && wildcardRegex.test(requiredHeadings[i]))) &&
+        (extraHeadings === 1 && !wildcardRegex.test(requiredHeadings[i]))) &&
       (anyHeadings ||
         !requiredHeadings.every((heading) => wildcardRegex.test(heading)))
     ) {


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Error was being thrown due to incorrect placement of variable + incorrect boolean

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Moves wildcardRegex variable
- Updates a regex test function to check for the correct boolean

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #27496

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [ ] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [ ] The `Because` section summarizes the reason for this PR
-   [ ] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
