### PR TITLE
Getting Started With React: Update tildes to backticks for style guide

### DIFF
--- a/foundations/javascript_basics/variables_and_operators.md
+++ b/foundations/javascript_basics/variables_and_operators.md
@@ -81,7 +81,7 @@ Try the following exercises (and don't forget to use `console.log()`!):
 
 1. Add 2 numbers together! (just type  `console.log(23 + 97)`   into your HTML file)
 1. Add a sequence of 6 different numbers together.
-1. Print the solution to the following equation: `(4 + 6 + 9) / 77`
+1. Print the value of the following expression: `(4 + 6 + 9) / 77`
     - Answer should be approximately `0.24675`
 1. Let's use variables!
     - Type this statement at the top of the script tag: `let a = 10`

--- a/foundations/javascript_basics/variables_and_operators.md
+++ b/foundations/javascript_basics/variables_and_operators.md
@@ -62,7 +62,7 @@ You can think of variables as "storage containers" for data in your code.
 
 <span id="variable-declaration">Until recently there was only one way to create a variable in JavaScript &mdash; the `var` statement. But in the newest JavaScript versions we have two more ways &mdash; `let` and `const`.</span>
 
-1. [This variable tutorial](http://javascript.info/variables) will explain everything you need to know! Be sure to do the **Tasks** at the end. Information won't stick without practice!
+1. This tutorial on [JavaScript variables](http://javascript.info/variables) will explain everything you need to know! Be sure to do the **Tasks** at the end. Information won't stick without practice!
 
 The above tutorial mentioned this, but it's important enough to note again: `let` and `const` are both relatively new ways to declare variables in JavaScript. <span id="avoid-var">In *many* tutorials (and code) across the internet you're likely to encounter `var` statements. Don't let it bother you! There's nothing inherently wrong with `var`, and in most cases `var` and `let` behave the same way. But sometimes the behavior of `var` is *not* what you would expect. Just stick to `let` (and `const`) for now.</span>
 
@@ -70,9 +70,9 @@ The above tutorial mentioned this, but it's important enough to note again: `let
 
 Numbers are the building blocks of programming logic!  In fact, it's hard to think of any useful programming task that doesn't involve at least a little basic math... so knowing how numbers work is obviously quite important.  Luckily, it's also fairly straightforward.
 
-1. [This W3Schools lesson](https://www.w3schools.com/js/js_arithmetic.asp) followed by [this one](https://www.w3schools.com/js/js_numbers.asp), are good introductions to what you can accomplish with numbers in JavaScript.
-1. [This MDN article](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Math) covers the same info from a slightly different point of view, while also teaching you how to apply some basic math in JavaScript. There's much more that you can do with numbers, but this is all you need at the moment.
-1. Read through \(and code along with!\) [this article](http://javascript.info/operators) about operators in JavaScript.  Don't forget to do the "Tasks" at the bottom of the page!  It will give you a pretty good idea of what you can accomplish with numbers (among other things!) in JavaScript.
+1. This W3Schools lesson on [JavaScript arithmetic](https://www.w3schools.com/js/js_arithmetic.asp) followed by this on [JavaScript numbers](https://www.w3schools.com/js/js_numbers.asp), are good introductions to what you can accomplish with numbers in JavaScript.
+1. This MDN article on [JavaScript math](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Math) covers the same info from a slightly different point of view, while also teaching you how to apply some basic math in JavaScript. There's much more that you can do with numbers, but this is all you need at the moment.
+1. Read through \(and code along with!\) this article on [JavaScript operators](http://javascript.info/operators).  Don't forget to do the "Tasks" at the bottom of the page!  It will give you a pretty good idea of what you can accomplish with numbers (among other things!) in JavaScript.
 
 ### Assignment
 
@@ -120,5 +120,5 @@ This section contains questions for you to check your understanding of this less
 
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
-- The differences between `var` and `let` are explained in [this JavaScript.info article titled the old "var"](https://javascript.info/var).
+- The differences between `var` and `let` are explained in this JavaScript.info article titled the [old "var"](https://javascript.info/var).
 - This [MDN article on what is JavaScript](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/What_is_JavaScript) explains a bit more about it on a high-level.

--- a/foundations/javascript_basics/variables_and_operators.md
+++ b/foundations/javascript_basics/variables_and_operators.md
@@ -100,7 +100,7 @@ Try the following exercises (and don't forget to use `console.log()`!):
 
 ### Knowledge check
 
-This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
+The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
 
 - [Name the three ways to declare a variable](#variable-declaration)
 - [Which of the three variable declarations should you avoid and why?](#avoid-var)
@@ -118,7 +118,7 @@ This section contains questions for you to check your understanding of this less
 
 ### Additional resources
 
-This section contains helpful links to other content. It isn't required, so consider it supplemental.
+This section contains helpful links to related content. It isn't required, so consider it supplemental.
 
 - The differences between `var` and `let` are explained in this JavaScript.info article titled the [old "var"](https://javascript.info/var).
 - This [MDN article on what is JavaScript](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/What_is_JavaScript) explains a bit more about it on a high-level.

--- a/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
+++ b/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
@@ -34,7 +34,7 @@ myObject.variable; // this gives us 'undefined' because it's looking for a prope
 myObject[variable]; // this is equivalent to myObject['property'] and returns 'Value!'
 ```
 
-If you are feeling rusty on using objects, now might be a good time to go back and review the content in [__Fundamentals 5__](https://www.theodinproject.com/lessons/foundations-fundamentals-part-5) from our JavaScript Basics course.
+If you are feeling rusty on using objects, now might be a good time to go back and review the content in our [object basics lesson](https://www.theodinproject.com/lessons/foundations-object-basics) from our JavaScript Basics course.
 
 ### Lesson overview
 
@@ -378,11 +378,11 @@ This section contains questions for you to check your understanding of this less
 
 This section contains helpful links to other content. It isn't required, so consider it supplemental.
 
-- [This article](https://dev.to/lydiahallie/javascript-visualized-prototypal-inheritance-47co) from Lydia Hallie and [This video](https://www.youtube.com/watch?v=sOrtAjyk4lQ) from Avelx explains the Prototype concept with graphics and beginner friendly language. Try using these resources if you want another perspective to understand the concept.
-- [This video](https://www.youtube.com/watch?v=CDFN1VatiJA) from mpj explains `Object.create` method with great details about it, he walks through what it is, why `Object.create` exists in JavaScript, and how to use `Object.create`. Also you can check [This video](https://www.youtube.com/watch?v=MACDGu96wrA) from techsith to understand another point of view of extending objects from others by `Object.create`.
+- Lydia Hallie has a [visual article on prototypal inheritance](https://dev.to/lydiahallie/javascript-visualized-prototypal-inheritance-47co) and [prototype inheritance by Programming With Avelx](https://www.youtube.com/watch?v=sOrtAjyk4lQ) explains the Prototype concept with graphics and beginner friendly language. Try using these resources if you want another perspective to understand the concept.
+- This [`Object.create` video by FunFunFunction](https://www.youtube.com/watch?v=CDFN1VatiJA) explains the method with great details about it, he walks through what it is, why `Object.create` exists in JavaScript, and how to use `Object.create`. Also you can check this [`Object.create` method video by techsith](https://www.youtube.com/watch?v=MACDGu96wrA) for another point of view on extending objects.
 - [The Principles of Object-Oriented JavaScript](https://www.amazon.com/Principles-Object-Oriented-JavaScript-Nicholas-Zakas/dp/1593275404) book by
 Nicholas C. Zakas is really great to understand OOP in javascript, which explains concepts in-depth, which explores JavaScript's object-oriented nature, revealing the language's unique implementation of inheritance and other key characteristics, it's not free but it's very valuable.
-- [This stack overflow question](https://stackoverflow.com/questions/9772307/declaring-javascript-object-method-in-constructor-function-vs-in-prototype/9772864#9772864) explains the difference between defining methods via the prototype vs defining them in the constructor.
+- The first answer on this StackOverflow question regarding [defining methods via the prototype vs in the constructor](https://stackoverflow.com/questions/9772307/declaring-javascript-object-method-in-constructor-function-vs-in-prototype/9772864#9772864) helps explain when you might want to use one over the other.
 - [A Beginner’s Guide to JavaScript’s Prototype](https://medium.com/free-code-camp/a-beginners-guide-to-javascript-s-prototype-9c049fe7b34) and [JavaScript Inheritance and the Prototype Chain](https://medium.com/free-code-camp/javascript-inheritance-and-the-prototype-chain-d4298619bdae) from Tyler Mcginnis has great examples to help you understand Prototype and Prototype Chain better from the beginner's perspective.
 - [This video ](https://www.youtube.com/watch?v=wstwjQ1yqWQ) from Akshay Saini is an easy way to understand the concept of Prototype, Prototype Chain and prototypal inheritance.
 - [Interactive Scrim on objects and object constructors.](https://scrimba.com/scrim/co2624f87981575448091d5a2)

--- a/react/getting_started_with_react/passing_data_between_components.md
+++ b/react/getting_started_with_react/passing_data_between_components.md
@@ -17,7 +17,7 @@ In React, data is transferred from parent components to child components via pro
 
 Now that we know *how* data transfers between components, let's explore *why* this might be a useful feature in React. Consider the following `Button` component, which then gets rendered multiple times within our `App` component.
 
-~~~jsx
+```jsx
 function Button() {
   return (
     <button>Click Me!</button>
@@ -33,12 +33,12 @@ export default function App() {
     </div>
   );
 }
-~~~
+```
 So far so good right? We have a beautiful reusable button that we can use as many times as we like, there is just one small problem.
 
 What if we wanted the text within our second button to be “Don’t Click Me!’? Right now, we would have to create a second button component with this different text.
 
-~~~jsx
+```jsx
 function Button() {
   return (
     <button>Click Me!</button>
@@ -60,12 +60,12 @@ export default function App() {
     </div>
   );
 }
-~~~
+```
 This may not seem like a huge deal right now, but what if we had 10 buttons, each one having different text, fonts, colors, sizes, and any other variation you can think of. Creating a new component for each of these button variations would very quickly lead to a LOT of code duplication.
 
 Let's see how by using props, we can account for any number of variations with a *single* button component.
 
-~~~jsx
+```jsx
 function Button(props) {
   const buttonStyle = {
     color: props.color,
@@ -86,7 +86,7 @@ export default function App() {
     </div>
   );
 }
-~~~
+```
 There are a few things going on here.
 
 - The `Button` functional component now receives `props` as a function argument. The individual properties are then referenced within the component via `props.propertyName`.
@@ -97,7 +97,7 @@ There are a few things going on here.
 
 A very common pattern you will come across in React is prop [destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment). Unpacking your props in the component arguments allows for more concise and readable code. Check out prop destructuring in action in the example below.
 
-~~~jsx
+```jsx
 function Button({ text, color, fontSize }) {
   const buttonStyle = {
     color: color,
@@ -116,13 +116,13 @@ export default function App() {
     </div>
   );
 }
-~~~
+```
 
 ### Default props
 
 You may have noticed in the above examples that there is some repetition when defining props on the `Button` components within `App`. In order to stop repeating ourselves re-defining these common values, and to protect our application from undefined values, we can define default props that will be used by the component in the absence of supplied values.
 
-~~~jsx
+```jsx
 function Button({ text, color, fontSize }) {
   const buttonStyle = {
     color: color,
@@ -147,12 +147,12 @@ export default function App() {
     </div>
   );
 }
-~~~
+```
 As you can see, we now only need to supply prop values to `Button` when rendering within `App` if they differ from the default values defined on `Button.defaultProps`.
 
 You can also combine default props and prop destructuring. Here's how it looks in action.
 
-~~~jsx
+```jsx
 function Button({ text = "Click Me!", color = "blue", fontSize = 12 }) {
   const buttonStyle = {
     color: color,
@@ -162,13 +162,13 @@ function Button({ text = "Click Me!", color = "blue", fontSize = 12 }) {
   return <button style={buttonStyle}>{text}</button>;
 }
 
-~~~
+```
 
 ### Functions as props
 
 In addition to passing variables through to child components as props, you can also pass through functions. Consider the following example.
 
-~~~jsx
+```jsx
 function Button({ text = "Click Me!", color = "blue", fontSize = 12, handleClick }) {
   const buttonStyle = {
     color: color,
@@ -193,7 +193,7 @@ export default function App() {
     </div>
   );
 }
-~~~
+```
 
 - The function `handleButtonClick` is defined in the parent component.
 - A reference to this function is passed through as the value for the `handleClick` prop on the `Button` component.
@@ -207,7 +207,7 @@ There are a few things to note here.
 
 - Every `Button` calling this function will navigate to the same page. We can refactor the function and supply a parameter within `Button` to customize this functionality.
 
-~~~jsx
+```jsx
 function Button({ text = "Click Me!", color = "blue", fontSize = 12, handleClick }) {
   const buttonStyle = {
     color: color,
@@ -232,7 +232,7 @@ export default function App() {
     </div>
   );
 }
-~~~
+```
 
 When supplying a parameter to the function we can't just write `onClick={handleClick('www.theodinproject.com')}`, and instead must attach a reference to an anonymous function which then calls the function with the parameter. Like the previous example, this is to prevent the function being called during the render.
 

--- a/react/getting_started_with_react/react_components.md
+++ b/react/getting_started_with_react/react_components.md
@@ -29,11 +29,11 @@ Think of these reusable chunks as JavaScript functions which can take some kind 
 
 To get the feel of working with components, we're going to practice creating functional components. What are functional components? Javascript functions! Let's have a look.
 
-~~~jsx
+```jsx
 function Greeting() {
   return <h1>&quot;I swear by my pretty floral bonnet, I will end you.&quot;</h1>;
 }
-~~~
+```
 
 This might look mostly familiar to you - it's a JavaScript function, which returns JSX. Open up the project you were working on, create a new file named `Greeting.jsx`, and in that file write your own handmade functional component. Name it whatever you wish, and have it return whatever JSX you wish.
 
@@ -55,17 +55,17 @@ It's JSX. It looks jarring at first, but soon we'll realize how cool it is. We'l
 
 So remember how our component is just hanging out in its own dedicated file? This makes it independent from the rest of the codebase! That said, while independence is great, we do want the component to use functionality created elsewhere, and to share itself with other components. How can we do this? `import`ing and `export`ing! For a very long time in React development, it was necessary to `import` React in your JavaScript files that used React components, but since React v17.0 it is no longer required. Let's `export` our newly created component so that parent components can use it as a child throughout your project.
 
-~~~jsx
+```jsx
 function Greeting() {
   return <h1>&quot;I swear by my pretty floral bonnet, I will end you.&quot;</h1>;
 }
 
 export default Greeting;
-~~~
+```
 
 Are we done? Well let's think about this - we've declared our component, and exported it, but does `main.jsx` know about it yet? Nope! Let's fix that. Let's look at `main.jsx`, we can see that `render()` is rendering the `App` component. Let's replace that `App` component with our newly created greeting, which we'll have to make sure is first imported properly. The end result should look something like this:
 
-~~~jsx
+```jsx
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
@@ -77,7 +77,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
     <Greeting />
   </React.StrictMode>,
 )
-~~~
+```
 
 Remember that `<Greeting />` should be capitalized! Try using lower case for the import, function name and component and see what happens! When the JSX is parsed, React uses the capitalization to tell the difference between an HTML tag and an instance of a React component. `<greeting />` would be interpreted as a normal HTML element with no special meaning, instead of your shiny new React component.
 

--- a/react/getting_started_with_react/rendering_techniques.md
+++ b/react/getting_started_with_react/rendering_techniques.md
@@ -13,7 +13,7 @@ This section contains a general overview of topics that you will learn in this l
 
 Let us say we want to create a component that lists multiple animals:
 
-~~~javascript
+```javascript
 function App() {
   return (
     <div>
@@ -27,11 +27,11 @@ function App() {
     </div>
   );
 }
-~~~
+```
 
 It is perfectly acceptable, but what if we want to render more than just four? It can be tedious and long, and most of the time, we will be dealing with a data structure (like a list) rather than hard-coding each animal. You have previously learned that we can embed expressions inside JSX with curly braces. So let us do just that:
 
-~~~javascript
+```javascript
 function App() {
   const animals = ["Lion", "Cow", "Snake", "Lizard"];
 
@@ -46,11 +46,11 @@ function App() {
     </div>
   );
 }
-~~~
+```
 
 We define an array called `animals`. Now inside our JSX, we use `map` to return a new array of `li` elements, adding `animal` as its text. It should now render the same as the previous snippet we wrote. This is because JSX has the ability to automatically render arrays. The following code is identical:
 
-~~~javascript
+```javascript
 function App() {
   const animals = ["Lion", "Cow", "Snake", "Lizard"];
   const animalsList = animals.map((animal) => <li key={animal}>{animal}</li>)
@@ -64,7 +64,7 @@ function App() {
     </div>
   );
 }
-~~~
+```
 
 You may be curious as to what the `key` is in our `<li>` element. We will dive into how keys work in the next lesson. But, to explain briefly, it is to let React know the identity of each element in the list. React must know this information if you are dealing with a dynamic list where you add or remove elements. Since we are only dealing with a static list, it does not matter for now.
 
@@ -74,7 +74,7 @@ You may be curious as to what the `key` is in our `<li>` element. We will dive i
 We will use `props` here, and you will learn more about them in a future lesson. For now, you just need to know that `props` are arguments that are passed into components. We will just be writing a short implementation.
 </div>
 
-~~~javascript
+```javascript
 function ListItem(props) {
   return <li>{props.animal}</li>
 }
@@ -99,7 +99,7 @@ function App() {
     </div>
   );
 }
-~~~
+```
 
 <div class="lesson-note lesson-note--tip" markdown="1">
   <h4>"Missing in props validation"</h4>
@@ -124,7 +124,7 @@ Let us make some decisions within our component. What if we only want to render 
 
 One way to conditionally render an element is with a ternary operator, using a boolean value to decide what to render:
 
-~~~javascript
+```javascript
 function List(props) {
   return (
     <ul>
@@ -145,7 +145,7 @@ function App() {
     </div>
   );
 }
-~~~
+```
 
 We are using the [String method `startsWith`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) to check if the `animal` starts with the letter L. This method either returns true or false.
 
@@ -155,7 +155,7 @@ If the animal starts with the letter L, then we return the `<li>` element, which
 
 Another quick way of conditionally rendering an element is by using the `&&` operator.
 
-~~~javascript
+```javascript
 function List(props) {
   return (
     <ul>
@@ -176,7 +176,7 @@ function App() {
     </div>
   );
 }
-~~~
+```
 
 We will leverage the return value of `startsWith` with the `&&` operator. If the result of the `startsWith` function is `true`, then it returns the second operand, which is the `<li>` element, and renders it. Otherwise, if the condition is `false` it just gets ignored.
 
@@ -199,7 +199,7 @@ This time we will have two conditions:
 
 We will frequently be dealing with lists in the future, and we also need to consider what to render if the list is empty or does not exist at all. You certainly would not want to see a blank page, would you? Let us try to implement that:
 
-~~~javascript
+```javascript
 function List(props) {
   if (!props.animals) {
     return <div>Loading...</div>;
@@ -228,7 +228,7 @@ function App() {
     </div>
   );
 }
-~~~
+```
 
 In our `<List />` component, we have two `if` statements acting as a guard that immediately returns an element based on the condition.
 
@@ -236,7 +236,7 @@ One is to check if the property `animals` exists, and the other is to check if t
 
 If we remove the `animals` property:
 
-~~~javascript
+```javascript
 function App() {
   const animals = [];
 
@@ -247,7 +247,7 @@ function App() {
     </div>
   );
 }
-~~~
+```
 
 The first `if` statement will now execute and return a `<div>` with the text "Loading..." This is often the case when you are fetching from an API, since it might take some time to actually retrieve the data, it is good practice to show an indicator for that.
 
@@ -255,7 +255,7 @@ If none of those checks passed, then we have the data we need to render the list
 
 You can, of course, also accomplish this with just the ternary and `&&` operators.
 
-~~~javascript
+```javascript
 function List(props) {
   return (
     <>
@@ -301,7 +301,7 @@ function App() {
     </div>
   );
 }
-~~~
+```
 
 Nested ternaries and multiple `&&` operators can be intimidating to look at, so be sure to test things out!
 

--- a/react/getting_started_with_react/what_is_jsx.md
+++ b/react/getting_started_with_react/what_is_jsx.md
@@ -35,7 +35,7 @@ If you were to take some valid HTML and copy it straight into your React compone
 
    Correct:
 
-   ~~~jsx
+   ```jsx
    function App() {
      return (
        <>
@@ -45,18 +45,18 @@ If you were to take some valid HTML and copy it straight into your React compone
        // Could replace <></> with <div></div>
      );
    }
-   ~~~
+   ```
 
    Incorrect:
 
-   ~~~jsx
+   ```jsx
    function App() {
      return (
        <h1>Example h1</h1>
        <h2>Example h2</h2>
      );
    }
-   ~~~
+   ```
 
 2. Close all tags.
 
@@ -66,7 +66,7 @@ If you were to take some valid HTML and copy it straight into your React compone
 
    Correct:
 
-   ~~~jsx
+   ```jsx
    function App() {
      return (
        <>
@@ -75,11 +75,11 @@ If you were to take some valid HTML and copy it straight into your React compone
        </>
      );
    }
-   ~~~
+   ```
 
    Incorrect:
 
-   ~~~jsx
+   ```jsx
    function App() {
      return (
        <>
@@ -88,7 +88,7 @@ If you were to take some valid HTML and copy it straight into your React compone
        </>
      );
    }
-   ~~~
+   ```
 
 3. camelCase **Most** things.
 
@@ -96,7 +96,7 @@ If you were to take some valid HTML and copy it straight into your React compone
 
    Correct:
 
-   ~~~jsx
+   ```jsx
    function App() {
      return (
       <div className="container">
@@ -106,11 +106,11 @@ If you were to take some valid HTML and copy it straight into your React compone
       </div>
      );
    }
-   ~~~
+   ```
 
    Incorrect:
 
-   ~~~jsx
+   ```jsx
    function App() {
      return (
       <div class="container">
@@ -120,13 +120,13 @@ If you were to take some valid HTML and copy it straight into your React compone
       </div>
      );
    }
-   ~~~
+   ```
 
 ### Converting HTML to JSX
 
 Now that we've covered the Rules of JSX, we'll go through the conversion of a chunk of HTML to JSX.
 
-~~~jsx
+```jsx
 <h1>Test title</h1>
 <ol class="test-list">
   <li>List item 1
@@ -137,7 +137,7 @@ Now that we've covered the Rules of JSX, we'll go through the conversion of a ch
    <circle cx="25" cy="75" r="20" stroke="green" stroke-width="2" />
 </svg>
 <form><input type="text"></form>
-~~~
+```
 
 If you try to return this from a React component, you would get many errors, so we are going to fix that!
 
@@ -145,7 +145,7 @@ If you try to return this from a React component, you would get many errors, so 
 
 The first issue we get is that this would not return a single root element, so let's give it a container.
 
-~~~jsx
+```jsx
 <div>
   <h1>Test title</h1>
   <ol class="test-list">
@@ -158,13 +158,13 @@ The first issue we get is that this would not return a single root element, so l
   </svg>
   <form><input type="text"></form>
 </div>
-~~~
+```
 
 You should see that another error appears now that we've fixed the initial one. This doesn't mean we created the error with our previous changes, just that React wasn't showing this one yet.
 
 Now, onto the second issue, which is that we haven't closed all of our tags, in particular, the `<li>` and the `<input>`.
 
-~~~jsx
+```jsx
 <div>
   <h1>Test title</h1>
   <ol class="test-list">
@@ -179,13 +179,13 @@ Now, onto the second issue, which is that we haven't closed all of our tags, in 
     <input type="text" />
   </form>
 </div>
-~~~
+```
 
 If you are following along, at this point you will stop seeing an error being rendered on-screen, this time it will be in the console.
 
 The last issue is that we haven't camelCased our attributes, and so are using invalid DOM properties for JSX, specifically the `class` and the `stroke-width`.
 
-~~~jsx
+```jsx
 <div>
   <h1>Test title</h1>
   <ol className="test-list">
@@ -200,7 +200,7 @@ The last issue is that we haven't camelCased our attributes, and so are using in
     <input type="text" />
   </form>
 </div>
-~~~
+```
 
 Now that we've applied all of the fixes to the errors that React gave us, this is fully fledged JSX code that can be used in a React component without any issues.
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
Codeblocks should be updated to align with new changes in our layout style guide


## This PR
Replace triple tildes (~~~) with triple backticks (```) to delimit codeblocks in 3 files within react/getting_started_with_react


## Issue
Related to #27459

## Additional Information



## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
