### PR TITLE
Update mocking_callbacks_and_components.md

### DIFF
--- a/react/react_testing/mocking_callbacks_and_components.md
+++ b/react/react_testing/mocking_callbacks_and_components.md
@@ -18,7 +18,7 @@ If you've been following along with our lessons so far, the concept of mocking h
 
 Callbacks are ubiquitous. Every avenue of user interaction involves callbacks. Sometimes they're passed in as props to alter state of the parent component. Consider this button component:
 
-~~~jsx
+```jsx
 // CustomButton.jsx
 
 const CustomButton = ({ onClick }) => {
@@ -28,13 +28,13 @@ const CustomButton = ({ onClick }) => {
 };
 
 export default CustomButton;
-~~~
+```
 
 Nothing fancy. `CustomButton` is a component with a prop passed in. We're interested in the `onClick` prop. We have no idea what the function does. We have no idea how the function will affect the application. All we know is it must be called when user clicks the button. Let's test it.
 
 <span id="testing-callback-handlers">Notice how we mock and test the `onClick` function</span>:
 
-~~~jsx
+```jsx
 // CustomButton.test.jsx
 
 import { vi } from 'vitest'
@@ -70,7 +70,7 @@ describe("CustomButton", () => {
         expect(onClick).not.toHaveBeenCalled();
     });
 });
-~~~
+```
 
 Three tests and we are done with this component. You should be already familiar with how the first test works. Take some time to figure out what functions come from which package.
 
@@ -116,14 +116,14 @@ We notice there are two child components of `SubmissionsList`. One of them is fr
 
 <span id="mock-child-component">Notice how we mock the `Submission` component</span>:
 
-~~~jsx
+```jsx
 jest.mock('../submission', () => ({ submission, isDashboardView }) => (
   <>
     <div data-test-id="submission">{submission.id}</div>
     <div data-test-id="dashboard">{isDashboardView.toString()}</div>
   </>
 ));
-~~~
+```
 
 We only render the bare minimum to realize the validity of the component we're testing. Next, we set up our props with fake data and mocked functions.
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
New changes in Odin's [layout style guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md#codeblocks) require updating the way codeblocks are written in lesson markdown. This PR addresses updates to the React course's section on States and Effects.


## This PR
Replace triple tildes (~~~) with triple backticks (```) to delimit codeblocks in 3 files within `react/states_and_effects`

## Issue

Related to https://github.com/TheOdinProject/curriculum/issues/27459

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
