### PR TITLE
JS Form Validation: Clarify form validation requirements

### DIFF
--- a/javascript/javascript_in_the_real_world/form_validation_with_javascript.md
+++ b/javascript/javascript_in_the_real_world/form_validation_with_javascript.md
@@ -22,17 +22,11 @@ This section contains a general overview of topics that you will learn in this l
 
 1. For reference, [W3Schools' page on the JavaScript validation API](https://www.w3schools.com/js/js_validation_api.asp) covers things in a more concise format. These functions were explained in the previous article. Typically, with HTML forms, the inputs are validated upon form submission, but you can use these functions to check validity whenever you like (such as when a user clicks or tabs out of a specific input field).
 
-</div>
-
-### Practice
-
-<div class="lesson-content__panel" markdown="1">
-
 #### Warmup
 
 Go back to your 'Library' project and add validation to that form! Don't let your users submit without filling in all the fields! Don’t forget to use the git branch workflow you learned in [Revisiting Rock Paper Scissors](https://www.theodinproject.com/lessons/foundations-revisiting-rock-paper-scissors) from Foundations to work on a new feature.
 
-### Project
+#### A little more practice
 
 Build a browser form which collects Email, Country, Zip Code, Password and Password Confirmation fields.  It should use live inline validation to inform the user whether a field is properly filled in or not.  That means highlighting a field red and providing a helpful error message until it has been filled in properly.
 

--- a/javascript/javascript_in_the_real_world/form_validation_with_javascript.md
+++ b/javascript/javascript_in_the_real_world/form_validation_with_javascript.md
@@ -36,7 +36,7 @@ Go back to your 'Library' project and add validation to that form! Don't let you
 
 Build a browser form which collects Email, Country, Zip Code, Password and Password Confirmation fields.  It should use live inline validation to inform the user whether a field is properly filled in or not.  That means highlighting a field red and providing a helpful error message until it has been filled in properly.
 
-The form doesn't need to actually submit, but you should give an error message if the button is pushed with any active errors or unfilled required fields. For the sake of this lesson, make sure **all** of the validation occurs in the JavaScript file. If all is well and the form is "submitted", give the user a high five.
+The form doesn't need to actually submit, but you should give an error message if the button is pushed with any active errors or unfilled required fields. For the sake of this lesson, make sure the `<form>` element has the [`novalidate` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#novalidate) which will allow you to do **all** of your validation in your JavaScript files. You can still use different `<input>` types, but you will need to use JavaScript to check and report their validity. If all is well and the form is "submitted", give the user a high five.
 
 1. Set up a blank HTML document
 1. Think about how you would set up the different form elements and their accompanying validators.  What objects and functions will you need? A few minutes of thought can save you from wasting an hour of coding.  The best thing you can do is whiteboard the entire solution before even touching the computer.

--- a/javascript/javascript_in_the_real_world/form_validation_with_javascript.md
+++ b/javascript/javascript_in_the_real_world/form_validation_with_javascript.md
@@ -16,11 +16,11 @@ This section contains a general overview of topics that you will learn in this l
 
 <div class="lesson-content__panel" markdown="1">
 
-1. [This tutorial on Form Validation](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation#validating_forms_using_javascript) covers how we can use JavaScript to validate forms, including the constraint validation API.
+1. This [tutorial on Form Validation](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation#validating_forms_using_javascript) covers how we can use JavaScript to validate forms, including the constraint validation API.
 
-2. It'll also prove beneficial to go through the [Constraint Validation docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Constraint_validation).
+1. It'll also prove beneficial to go through the [Constraint Validation docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Constraint_validation).
 
-3. For Reference, [this document](https://www.w3schools.com/js/js_validation_api.asp) covers the JavaScript validation API in a more concise format.  These functions were explained in the previous article.  Typically, with HTML forms, the inputs are validated upon form submission, but you can use these functions to check validity whenever you like (such as when a user clicks or tabs out of a specific input field).
+1. For reference, [W3Schools' page on the JavaScript validation API](https://www.w3schools.com/js/js_validation_api.asp) covers things in a more concise format. These functions were explained in the previous article. Typically, with HTML forms, the inputs are validated upon form submission, but you can use these functions to check validity whenever you like (such as when a user clicks or tabs out of a specific input field).
 
 </div>
 
@@ -30,26 +30,26 @@ This section contains a general overview of topics that you will learn in this l
 
 #### Warmup
 
-Go back to your 'Library' project and add validation to that form! Don't let your users submit without filling in all the fields! Don't forget to use your Git workflow skills you learned in [this foundations lesson](https://www.theodinproject.com/lessons/foundations-revisiting-rock-paper-scissors) to make a new branch, work on your feature and merge it back to main when it's all done.
+Go back to your 'Library' project and add validation to that form! Don't let your users submit without filling in all the fields! Don’t forget to use the git branch workflow you learned in [Revisiting Rock Paper Scissors](https://www.theodinproject.com/lessons/foundations-revisiting-rock-paper-scissors) from Foundations to work on a new feature.
 
-#### Project
+### Project
 
 Build a browser form which collects Email, Country, Zip Code, Password and Password Confirmation fields.  It should use live inline validation to inform the user whether a field is properly filled in or not.  That means highlighting a field red and providing a helpful error message until it has been filled in properly.
 
 The form doesn't need to actually submit, but you should give an error message if the button is pushed with any active errors or unfilled required fields. For the sake of this lesson, make sure **all** of the validation occurs in the JavaScript file. If all is well and the form is "submitted", give the user a high five.
 
 1. Set up a blank HTML document
-2. Think about how you would set up the different form elements and their accompanying validators.  What objects and functions will you need? A few minutes of thought can save you from wasting an hour of coding.  The best thing you can do is whiteboard the entire solution before even touching the computer.
-3. Write the form elements.
-4. Add the JavaScript code that checks validation as the user progresses through the form.  When a user leaves a form field, it should automatically validate that field.
-5. Test out all possible cases.
-6. Don't forget to style validations with CSS by using the `:valid` and `:invalid` pseudo-classes!
+1. Think about how you would set up the different form elements and their accompanying validators.  What objects and functions will you need? A few minutes of thought can save you from wasting an hour of coding.  The best thing you can do is whiteboard the entire solution before even touching the computer.
+1. Write the form elements.
+1. Add the JavaScript code that checks validation as the user progresses through the form.  When a user leaves a form field, it should automatically validate that field.
+1. Test out all possible cases.
+1. Don't forget to style validations with CSS by using the `:valid` and `:invalid` pseudo-classes!
 
 </div>
 
 ### Knowledge check
 
-This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
+The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
 
 - [Explain the importance of validating HTML forms before submitting them to a server.](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation#what_is_form_validation)
 - [Describe the two types of client-side form validation.](https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation#different_types_of_client-side_validation)


### PR DESCRIPTION
## Because
A surprisingly common occurrence I've seen in the community is confusion as to what the [Form Validation with JS lesson](https://www.theodinproject.com/lessons/node-path-javascript-form-validation-with-javascript)'s instruction to do "all" validation in JS actually means.

Some have interpreted this to mean that you cannot even use different input types with the form having the `novalidate` attribute. Meaning they use only text inputs and manually validate every small detail inc. input format.

Instead, I believe the intent is to disable automatic HTML validation and to handle it via JS instead, where the learner can still use different input types (just needing to use the constraint validation API to check and report validity).


## This PR
- Adds a instruction to set `novalidate` on the `<form>` element, and use JS to check and report validity via the constraint validation API as was taught in the lesson.
- Fixes linting errors.
- Combined the `### Practice` block into the `### Assignment` block.


## Issue
Closes #27316

## Additional Information
The decision to combine `### Practice` and `### Assignment` came from mdlint not liking `Practice` being a `###` instead of `####`. However, setting it as a `####` looks odd given it's a block heading where the block already has `####` subheadings.

The `Practice` material is also essentially an assignment anyway, so I felt it might as well be combined with the `Assignment` section as well.

I did this combination in its own commit - so if this would preferably be done in a separate PR, I can always revert it to make the main change for `novalidate` and open a new PR for the section combination. Equally, if it would be preferable to just keep the section structure separated as is and ignore the `### Practice` lint error via a comment, a revert could easily handle that as well.


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
