### PR TITLE
Ruby Course Project HashMap lesson: Fix grammar mistake

### DIFF
--- a/ruby/computer_science/project_hash_map.md
+++ b/ruby/computer_science/project_hash_map.md
@@ -4,7 +4,7 @@ You already know the magic behind hash maps, now it's time to write your own imp
 
 #### Limitation
 
-  Before we get started, we need to lay down some ground rules. Ruby's dynamic nature of array allows us to insert and retrieve indexes that are outside our array size range. Example: if we create an array of size `16` to be our buckets size, nothing stopping us from storing items at index `500`. This defeats the purpose we are trying to demonstrate, so we need to put some self restriction to work around this.
+  Before we get started, we need to lay down some ground rules. Ruby's dynamic nature of array allows us to insert and retrieve indexes that are outside our array size range. Example: if we create an array of size `16` to be our buckets size, nothing is stopping us from storing items at index `500`. This defeats the purpose we are trying to demonstrate, so we need to put some self restriction to work around this.
 
   Use the following snippet whenever you access a bucket through an index. We want to raise an error if we try to access an out of bound index:
 


### PR DESCRIPTION
## Because
Fix grammar mistake in lesson sentence: 

> Example: if we create an array of size 16 to be our buckets size, nothing stopping us from storing items at index 500.


## This PR

- Add 'is' between 'nothing' and 'stopping'.


## Issue
None


## Additional Information


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
