### PR TITLE
React Router: Introduce outlet context and remove component-based router

### DIFF
--- a/react/more_react_concepts/managing_state_with_context_api.md
+++ b/react/more_react_concepts/managing_state_with_context_api.md
@@ -115,9 +115,9 @@ This is a very basic application, but imagine the application grows in size as m
 
 To simplify our application and reduce complexity, we can implement the Context API. There are three key elements in this API that we need to understand:
 
-1. `createContext` - This "creates the context" Duh... But yes, it's how we can create the context. It takes in any value, be it a number, string, or object, which can be referred to as the _default value_ of the context, and returns a context object that can be used to pass down data to components
-2. `useContext` - This hook is used to consume data from a context object created by `createContext`. We can use this hook inside our component to retrieve the data that we need. This hook accepts the context object as an argument
-3. `ContextObject.Provider` - The context object comes with the `Provider` component that accepts a prop called `value`, which is the context value that's going to be passed down to the components no matter how deeply they're nested. In other words, a way to "provide" the context value to these components
+1. `createContext` - This "creates the context" Duh... But yes, it's how we can create the context. It takes in any value, be it a number, string, or object, which can be referred to as the *default value* of the context, and returns a context object that can be used to pass down data to components
+1. `useContext` - This hook is used to consume data from a context object created by `createContext`. We can use this hook inside our component to retrieve the data that we need. This hook accepts the context object as an argument
+1. `ContextObject.Provider` - The context object comes with the `Provider` component that accepts a prop called `value`, which is the context value that's going to be passed down to the components no matter how deeply they're nested. In other words, a way to "provide" the context value to these components
 
 We can start by using the `createContext` function that can be imported from the `react` module.
 
@@ -145,7 +145,7 @@ This object that we've defined is not necessary. We can of course do this as wel
 const ShopContext = createContext(null);
 ~~~
 
-However, the reason why we're adding the object, is so that even if we somehow use the context inside a component that is not nested inside a Provider, because we have set a _default value_, our application will not break (This is also good for testing since we don't need to wrap a component in a Provider to get a value) and also take advantage of IDE features like auto-completion when we have an object as the value. When we use this context in our components, we will be able to access the properties directly from the context. It's basically a bonus! It's up to you if you want to set the default value to the object or just `null` because we're going to overwrite this default value anyway.
+However, the reason why we're adding the object, is so that even if we somehow use the context inside a component that is not nested inside a Provider, because we have set a *default value*, our application will not break (This is also good for testing since we don't need to wrap a component in a Provider to get a value) and also take advantage of IDE features like auto-completion when we have an object as the value. When we use this context in our components, we will be able to access the properties directly from the context. It's basically a bonus! It's up to you if you want to set the default value to the object or just `null` because we're going to overwrite this default value anyway.
 
 So how do we use this context? And that is by using the `Provider` component of the Context object and nesting the children components inside it. In this example, we will remove the props altogether.
 
@@ -215,7 +215,7 @@ export default function Header() {
 }
 ~~~
 
-We've completely removed the prop drill problem, and we can conveniently get the `cartItems` directly in the `Links` component itself as we already know that no matter how deeply nested the component is, we can still get the data as long as _it's nested inside the Provider_.
+We've completely removed the prop drill problem, and we can conveniently get the `cartItems` directly in the `Links` component itself as we already know that no matter how deeply nested the component is, we can still get the data as long as *it's nested inside the Provider*.
 
 Let's also change our `ProductDetail` component to do the same:
 
@@ -253,26 +253,26 @@ Overall, the implementation of the Context API has allowed for a more efficient,
 Although the Context API can be a powerful tool for managing state in larger React applications, it also has some drawbacks that you should be aware of:
 
 1. It can lead to performance issues: When you update the state in a context, it can cause all components that are consuming that context to re-render, even if the state that they are using hasn't changed. This can lead to performance issues, especially if you have a lot of components that are consuming the same context.
-2. It can make your code harder to follow: With the Context API, it's easier to access the state from any component in your application. However, this can also make your code harder to follow, especially if you have a lot of nested components that are consuming the same context. It's important to keep your code organized and well-structured to avoid confusion.
+1. It can make your code harder to follow: With the Context API, it's easier to access the state from any component in your application. However, this can also make your code harder to follow, especially if you have a lot of nested components that are consuming the same context. It's important to keep your code organized and well-structured to avoid confusion.
 
 ### Potential solutions
 
 1. Use multiple smaller contexts instead of a single large context. Instead of using a single large context to manage all of your application states, consider using multiple smaller contexts to manage related pieces of state. This can help to reduce the number of components that are consuming the context and minimize unnecessary re-renders.
-2. Sometimes Context API might not even be the best solution for the problems that we want to deal with. Take a look at [React Component Composition](https://www.robinwieruch.de/react-component-composition/) article by Robin Wieruch.
-3. You can rely on external state management systems like [Zustand](https://github.com/pmndrs/zustand) and [Redux](https://redux.js.org/). They have a lot of optimizations built-in and are feature rich. Unfortunately, they do have a learning curve, and we recommend sticking to the Context API for the rest of this course as it's still reliable for majority of the projects we're going to build.
+1. Sometimes Context API might not even be the best solution for the problems that we want to deal with. Take a look at [React Component Composition](https://www.robinwieruch.de/react-component-composition/) article by Robin Wieruch.
+1. You can rely on external state management systems like [Zustand](https://github.com/pmndrs/zustand) and [Redux](https://redux.js.org/). They have a lot of optimizations built-in and are feature rich. Unfortunately, they do have a learning curve, and we recommend sticking to the Context API for the rest of this course as it's still reliable for majority of the projects we're going to build.
 
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">
 
 1. The React Docs provides more engaging examples and possible optimizations for the Context API. You can check it out by going through their [documentation for useContext](https://react.dev/reference/react/useContext). Be sure to try out each example!
-2. Read the short article [Prop Drilling](https://kentcdodds.com/blog/prop-drilling) by Kent C. Dodds. This is a great article to get more understanding for prop drilling, it features digestible examples.
+1. Read the short article [Prop Drilling](https://kentcdodds.com/blog/prop-drilling) by Kent C. Dodds. This is a great article to get more understanding for prop drilling, it features digestible examples.
 
 </div>
 
 ### Knowledge check
 
-This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
+The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
 
 - [What are the benefits of using the Context API over passing props down through multiple levels of components?](#context-api-benefits)
 - [What are the drawbacks in using the Context API?](#drawbacks-of-using-context-api)
@@ -280,6 +280,6 @@ This section contains questions for you to check your understanding of this less
 
 ### Additional resources
 
-This section contains helpful links to related content. It isn’t required, so consider it supplemental.
+This section contains helpful links to related content. It isn't required, so consider it supplemental.
 
-- For some extra practice/review, check out [this content from the React Docs](https://react.dev/learn/passing-data-deeply-with-context)
+- For some extra practice/review, check out the [React docs lesson on passing data with Context](https://react.dev/learn/passing-data-deeply-with-context).

--- a/react/more_react_concepts/managing_state_with_context_api.md
+++ b/react/more_react_concepts/managing_state_with_context_api.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-Throughout the lessons, we've learned how to manage state and pass data/props around components. However, as our application grows in size, not only will this process of managing states and passing data around become repetitive and inconvenient, but it will also be hard to manage. In the [React Router lesson](https://www.theodinproject.com/lessons/node-path-react-new-react-router#outlets-and-state), we mentioned how we could use outlet context to pass data from a parent component through an `<Outlet />` to a child component. This lesson will cover how we can use the Context API to do similar things outside of outlet scenarios.
+Throughout the lessons, we've learned how to manage state, and pass data and props between components. However, as our application grows in size, not only will this process of managing states and passing data around become repetitive and inconvenient, but it will also be hard to manage. In the [React Router lesson](https://www.theodinproject.com/lessons/node-path-react-new-react-router#outlets-and-state), we mentioned how we could use outlet context to pass data from a parent component through an `<Outlet />` to a child component. This lesson will cover how we can use the Context API to do similar things outside of outlet scenarios.
 
 ### Lesson overview
 

--- a/react/more_react_concepts/managing_state_with_context_api.md
+++ b/react/more_react_concepts/managing_state_with_context_api.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-Throughout the lessons, we've learned how to manage state and pass data/props around components. However, as our application grows in size, not only will this process of managing states and passing data around become repetitive and inconvenient, but it will also be hard to manage. This lesson will cover how we can reduce these complexities in our application by using the Context API.
+Throughout the lessons, we've learned how to manage state and pass data/props around components. However, as our application grows in size, not only will this process of managing states and passing data around become repetitive and inconvenient, but it will also be hard to manage. In the [React Router lesson](https://www.theodinproject.com/lessons/node-path-react-new-react-router#outlets-and-state), we mentioned how we could use outlet context to pass data from a parent component through an `<Outlet />` to a child component. This lesson will cover how we can use the Context API to do similar things outside of outlet scenarios.
 
 ### Lesson overview
 

--- a/react/the_react_ecosystem/react_router.md
+++ b/react/the_react_ecosystem/react_router.md
@@ -391,47 +391,45 @@ ReactDOM.createRoot(document.getElementById("root")).render(
 );
 ~~~
 
-### Refactoring the routing
+### Refactoring the routes
 
-Let's refactor our routes to a component of their own. By refactoring, we can add whatever conditional logic we want, if it exists as a hook (remember, we can't use hooks outside of a React component!). It's much neater to have them separate even if you are not conditionally rendering routes.
+Let's refactor our array of routes into its own file. By refactoring, we can import the routes into `main.jsx` and create a browser router from it as in the above example. What's convenient about this is that we can also import the routes array into any test files, where we might need to [create a memory router](https://reactrouter.com/en/main/routers/create-memory-router) instead of a browser router.
 
-Create a new `Router.jsx` component and move your routes to it:
+Create a new `routes.jsx` file and move the routes array to it:
 
 ~~~jsx
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import App from "./App";
 import Profile from "./Profile";
 import ErrorPage from "./ErrorPage";
 
-const Router = () => {
-  const router = createBrowserRouter([
-    {
-      path: "/",
-      element: <App />,
-      errorElement: <ErrorPage />,
-    },
-    {
-      path: "profile/:name",
-      element: <Profile />,
-    },
-  ]);
+const routes = [
+  {
+    path: "/",
+    element: <App />,
+    errorElement: <ErrorPage />,
+  },
+  {
+    path: "profile/:name",
+    element: <Profile />,
+  },
+];
 
-  return <RouterProvider router={router} />;
-};
-
-export default Router;
+export default routes;
 ~~~
 
-Add `Router.jsx` component to the `Main.jsx` file:
+Import the routes to your `Main.jsx` file:
 
 ~~~jsx
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import React from "react";
 import ReactDOM from "react-dom/client";
-import Router from "./Router";
+import routes from "./routes";
+
+const router = createBrowserRouter(routes);
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <Router />
+    <RouterProvider router={router} />
   </React.StrictMode>
 );
 ~~~

--- a/react/the_react_ecosystem/react_router.md
+++ b/react/the_react_ecosystem/react_router.md
@@ -83,7 +83,7 @@ Let us install the React Router package:
 
 `npm install react-router-dom`
 
-Add the following to `Main.jsx`, we will talk about what is happening in a little bit.
+Add the following to `main.jsx`, we will talk about what is happening in a little bit.
 
 ~~~jsx
 import React from "react";
@@ -417,7 +417,7 @@ const routes = [
 export default routes;
 ~~~
 
-Import the routes to your `Main.jsx` file:
+Import the routes to your `main.jsx` file:
 
 ~~~jsx
 import { createBrowserRouter, RouterProvider } from "react-router-dom";

--- a/react/the_react_ecosystem/react_router.md
+++ b/react/the_react_ecosystem/react_router.md
@@ -436,6 +436,16 @@ ReactDOM.createRoot(document.getElementById("root")).render(
 
 Much nicer!
 
+### State and outlets
+
+As we learned earlier, you can nest routes as children of a parent route, allowing you to use an `<Outlet />` in the parent to render the appropriate element based on the rest of the path.
+
+If we had something in the parent element, such as a state, that we wanted to pass to any components rendered by that outlet, we would have to use something called `context`. We will learn about context outside of outlets in more detail in a later lesson but for now, using outlet context does not involve much at all because it is built in. You pass any value you want (which could even be an array or object) into an outlet's `context` prop, then inside the child component(s) you want to access any of those values, calling the `useOutletContext()` hook returns whatever value you had passed in. If you passed in an array or object, you could even destructure it!
+
+Outlet context is not limited to the child component rendered directly by the outlet itself. *Any component* rendered within the outlet (even one rendered by the child route's component) can access the context value by calling `useOutletContext()`.
+
+Take a look at React Router's [documentation on `useOutletContext`](https://reactrouter.com/en/main/hooks/use-outlet-context) to learn more about how to pass context through an outlet and access that context in child components.
+
 ### Protected routes and navigation
 
 Often, you will need to decide whether a certain route should be rendered or not. One example is authentication, where you render certain routes based on if the user is logged in or not. If they are logged in, you show some information about the user like here at [The Odin Project dashboard page](https://www.theodinproject.com/dashboard). Otherwise, they are redirected to the sign-in page (this could be any page). While there are many ways to do so, one of the easiest ways is to conditionally create a config for the router.

--- a/react/the_react_ecosystem/react_router.md
+++ b/react/the_react_ecosystem/react_router.md
@@ -472,14 +472,14 @@ You should now have enough basics to get started with React routing. There are a
 
 The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
 
-- <a class="knowledge-check-link" href="#client-side-routing">What does client-side routing mean?</a>
-- <a class="knowledge-check-link" href="#adding-a-router">How do you set up a basic router?</a>
-- <a class="knowledge-check-link" href="#the-link-element">What should be used in place of "a" tags to enable client-side routing?</a>
-- <a class="knowledge-check-link" href="#nested-routes-outlets-and-dynamic-segments">How do you create nested routes?</a>
-- <a class="knowledge-check-link" href="#dynamic-segments">What do you mean by dynamic segments or URL params?</a>
-- <a class="knowledge-check-link" href="#handling-bad-urls">How do you add a "catch-all" route?</a>
-- <a class="knowledge-check-link" href="#outlets-and-state">How do you pass data from parent to child through an `<Outlet />` component?</a>
-- <a class="knowledge-check-link" href="#protected-routes-and-navigation">How do you create protected routes?</a>
+- [What does client-side routing mean?](#client-side-routing)
+- [How do you set up a basic router?](#adding-a-router)
+- [What should be used in place of "a" tags to enable client-side routing?](#the-link-element)
+- [How do you create nested routes?](#nested-routes-outlets-and-dynamic-segments)
+- [What do you mean by dynamic segments or URL params?](#nested-routes-outlets-and-dynamic-segments)
+- [How do you add a "catch-all" route?](#handling-bad-urls)
+- [How do you pass data from parent to child through an `<Outlet />` component?](#outlets-and-state)
+- [How do you create protected routes?](#protected-routes-and-navigation)
 
 ### Additional resources
 

--- a/react/the_react_ecosystem/react_router.md
+++ b/react/the_react_ecosystem/react_router.md
@@ -394,7 +394,7 @@ ReactDOM.createRoot(document.getElementById("root")).render(
 
 ### Refactoring the routes
 
-Let's refactor our array of routes into its own file. By refactoring, we can import the routes into `main.jsx` and create a browser router from it as in the above example. What's convenient about this is that we can also import the routes array into any test files, where we might need to [create a memory router](https://reactrouter.com/en/main/routers/create-memory-router) instead of a browser router.
+Let's refactor our array of routes into its own file. By refactoring, we can import the routes into `main.jsx` and create a browser router from it, as in the above example. What's convenient about this is that we can also import the routes array into any test files, where we might need to [create a memory router](https://reactrouter.com/en/main/routers/create-memory-router) instead of a browser router.
 
 Create a new `routes.jsx` file and move the routes array to it:
 
@@ -441,7 +441,7 @@ Much nicer!
 
 As we learned earlier, you can nest routes as children of a parent route, allowing you to use an `<Outlet />` in the parent to render the appropriate element based on the rest of the path.
 
-If we had something in the parent element, such as a state, that we wanted to pass to any components rendered by that outlet, we would have to use something called `context`. For now, we will focus on context with outlets but in a later lesson, we will learn more about how to use context without outlets.
+If we had data in the parent element, such as a state, that we wanted to pass to any components rendered by that outlet, we would have to use something called `context`. For now, we will focus on context with outlets, but in a later lesson, we will learn more about how to use context without outlets.
 
 Outlets have a `context` prop built in. We can pass any value we want into this prop, even an array or object. Inside *any* component that would be rendered within that outlet (even "grandchild" components), we can call the `useOutletContext()` hook which will return whatever we passed into that context prop. If we passed in an array or object, we could even destructure it!
 

--- a/react/the_react_ecosystem/react_router.md
+++ b/react/the_react_ecosystem/react_router.md
@@ -212,7 +212,7 @@ ReactDOM.createRoot(document.getElementById("root")).render(
 );
 ~~~
 
-This allows us to render the child component alongside the parent, through an [`Outlet`](https://reactrouter.com/en/main/components/outlet)! We can rewrite the Profile component to add an `Outlet` which will get replaced by the various profiles when that route is visited!
+This allows us to render the child component alongside the parent, through an [Outlet component](https://reactrouter.com/en/main/components/outlet)! We can rewrite the Profile component to add an `Outlet` which will get replaced by the various profiles when that route is visited!
 
 ~~~jsx
 import { Outlet } from "react-router-dom";
@@ -440,7 +440,7 @@ Much nicer!
 
 ### Protected routes and navigation
 
-Often, you will need to decide whether a certain route should be rendered or not. One example is authentication, where you render certain routes based on if the user is logged in or not. If they are logged in, you show some information about the user like [here at The Odin Project dashboard page](https://www.theodinproject.com/dashboard). Otherwise, they are redirected to the sign-in page (this could be any page). While there are many ways to do so, one of the easiest ways is to conditionally create a config for the router.
+Often, you will need to decide whether a certain route should be rendered or not. One example is authentication, where you render certain routes based on if the user is logged in or not. If they are logged in, you show some information about the user like here at [The Odin Project dashboard page](https://www.theodinproject.com/dashboard). Otherwise, they are redirected to the sign-in page (this could be any page). While there are many ways to do so, one of the easiest ways is to conditionally create a config for the router.
 
 You will often come across the need to reroute the user to a different URL programmatically. This is where we use [the `<Navigate />`component](https://reactrouter.com/en/main/components/navigate). The `<Navigate />` component reroutes the user to the desired URL when it is rendered. It is a wrapper around [the useNavigate hook](https://reactrouter.com/en/main/hooks/use-navigate) that lets you navigate programmatically, to URLs, or even go back down the user's history.
 
@@ -452,7 +452,7 @@ You should now have enough basics to get started with React routing. There are a
 
 <div class="lesson-content__panel" markdown="1">
 
-1. [This article on SPAs and client-side routing by Ben Holmes](https://bholmes.dev/blog/spas-clientside-routing/) goes through a lot of the routing concepts concisely.
+1. This article on [SPAs and client-side routing by Ben Holmes](https://bholmes.dev/blog/spas-clientside-routing/) goes through a lot of the routing concepts concisely.
 1. Go and fix the `/profile` page to display something more useful than an error page. Then, add a few new routes to the application we created above; This was a dense lesson, so take some time to play with the new tools you've learned. Consider deleting it completely and rewriting it using what you know.
 1. The [React Router tutorial](https://reactrouter.com/en/main/start/tutorial) goes through a lot of the stuff discussed in this lesson and much more. Have a read through the sections up to "Nested Routes".
 1. Browse through the [React Router documentation](https://reactrouter.com/en/main). Again, you don't need to read through all of it, nor understand all of it. Just browse through the concepts we discussed here and re-read them. Look into the other features that React Router offers. This is a great resource to refer back to.
@@ -475,5 +475,5 @@ The following questions are an opportunity to reflect on key topics in this less
 
 This section contains helpful links to related content. It isn't required, so consider it supplemental.
 
-- [This Stack Overflow answer](https://stackoverflow.com/a/64347082/19051112) uses a function to generate the route config object passed to `createBrowserRouter`. The function conditionally generates the different paths.
-- [This demonstration project](https://github.com/iammanishshrma/react-protected-routes/blob/master/src/routes/ProtectedRoute.jsx) creates a special Protected Route component that conditionally displays elements as necessary.
+- This Stack Overflow answer uses a [function to generate the route config object](https://stackoverflow.com/a/64347082/19051112) passed to createBrowserRouter. The function conditionally generates the different paths.
+- This demonstration project creates a [special Protected Route component that conditionally displays elements as necessary](https://github.com/iammanishshrma/react-protected-routes/blob/master/src/routes/ProtectedRoute.jsx).

--- a/react/the_react_ecosystem/react_router.md
+++ b/react/the_react_ecosystem/react_router.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-Up until this point in the curriculum, we have been building one-page applications. However, for any larger scale application, we are going to have multiple pages. Thankfully, the browser allows client-side Javascript to manage the way a user can navigate, with the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API/Working_with_the_History_API). We can leverage the power of this to manage routing in React with the help of a package like React Router.
+Up until this point in the curriculum, we have been building one-page applications. However, for any larger scale application, we are going to have multiple pages. Thankfully, the browser allows client-side JavaScript to manage the way a user can navigate, with the [History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API/Working_with_the_History_API). We can leverage the power of this to manage routing in React with the help of a package like React Router.
 
 ### Lesson overview
 
@@ -14,23 +14,23 @@ This section contains a general overview of topics that you will learn in this l
 
 ### Client-side routing
 
-Client-side routing is the type of routing where Javascript takes over the duty of handling the routes in an application. Client-side routing helps in building single-page applications (SPAs) without refreshing as the user navigates. For example, when a user clicks a navbar element, the URL changes and the view of the page is modified accordingly, within the client.
+Client-side routing is the type of routing where JavaScript takes over the duty of handling the routes in an application. Client-side routing helps in building single-page applications (SPAs) without refreshing as the user navigates. For example, when a user clicks a navbar element, the URL changes and the view of the page is modified accordingly, within the client.
 
 Say you are cooking some chicken. If you want to cook it well and nice, you will have to:
 
 1. Put the chicken in the oven and set it to cook with appropriate time and heating
-2. Wait till the dish gives out that satisfying smell
-3. Start munching!
+1. Wait till the dish gives out that satisfying smell
+1. Start munching!
 
 This is common to all websites, you set the oven up for what you want (visit any URL, like [https://theodinproject.com/](https://theodinproject.com/)), wait for the oven to be done with the cooking (the loading screen), and tada, enjoy your delicious food (your page is ready for use). But what if you forgot to add some spices before you cooked it up? You have to repeat this flow again:
 
 1. Get up from your seat
-2. Add the spices to the chicken
-3. Go back to the oven, put the chicken back in and set it up to be reheated
-4. Wait for it to be nice and warm
-5. Now you can eat it!
+1. Add the spices to the chicken
+1. Go back to the oven, put the chicken back in and set it up to be reheated
+1. Wait for it to be nice and warm
+1. Now you can eat it!
 
-Here is where we reiterate, **you need to get up from your seat**. In a general multi-page application (MPAs), the browser reloads every time you click on a link to navigate. With client-side routing, **you never leave the page you are on** - you bring a microwave to the table to ensure that you don't have to get up from your seat should you ever run into the "missing spices" issue. The link requests are intercepted by the Javascript that you write, instead of letting them go directly to the server.
+Here is where we reiterate, **you need to get up from your seat**. In a general multi-page application (MPAs), the browser reloads every time you click on a link to navigate. With client-side routing, **you never leave the page you are on** - you bring a microwave to the table to ensure that you don't have to get up from your seat should you ever run into the "missing spices" issue. The link requests are intercepted by the JavaScript that you write, instead of letting them go directly to the server.
 
 ### A Reactive solution
 
@@ -77,7 +77,7 @@ const App = () => {
 export default App;
 ~~~
 
-Now it's time to add the router! There's a couple of ways of defining our app's routes, but in **React Router v6.7.0 or higher**, it is recommended to add routes as objects. 
+Now it's time to add the router! There's a couple of ways of defining our app's routes, but in **React Router v6.7.0 or higher**, it is recommended to add routes as objects.
 
 Let us install the React Router package:
 
@@ -113,9 +113,9 @@ ReactDOM.createRoot(document.getElementById("root")).render(
 Once this is done, go ahead and run `npm run dev` and check out both routes: the home route `/` and the profile route `/profile` It works! But what is happening here?
 
 1. We import `createBrowserRouter` and `RouterProvider` from React Router.
-2. `createBrowserRouter` is used to create the configuration for a router by passing arguments in the form of an array of routes.
-3. The configuration array contains objects with two mandatory keys, the path and the corresponding element to be rendered.
-4. This generated configuration is then rendered in, by passing it to the `RouterProvider` component.
+1. `createBrowserRouter` is used to create the configuration for a router by passing arguments in the form of an array of routes.
+1. The configuration array contains objects with two mandatory keys, the path and the corresponding element to be rendered.
+1. This generated configuration is then rendered in, by passing it to the `RouterProvider` component.
 
 ### The link element
 
@@ -234,7 +234,7 @@ export default Profile;
 
 Check out the `/profile`, `/profile/popeye` and `/profile/spinach` pages. The `<Outlet />` component gets replaced with the children component when their paths are visited.
 
-If you want to render something as a default component when no path is added to Profile, you can add an index route to the children! 
+If you want to render something as a default component when no path is added to Profile, you can add an index route to the children!
 
 Create a DefaultProfile component:
 
@@ -436,7 +436,7 @@ ReactDOM.createRoot(document.getElementById("root")).render(
 );
 ~~~
 
-Much nicer! 
+Much nicer!
 
 ### Protected routes and navigation
 
@@ -452,16 +452,16 @@ You should now have enough basics to get started with React routing. There are a
 
 <div class="lesson-content__panel" markdown="1">
 
-1.  [This article on SPAs and client-side routing by Ben Holmes](https://bholmes.dev/blog/spas-clientside-routing/) goes through a lot of the routing concepts concisely.
-2.  Go and fix the `/profile` page to display something more useful than an error page. Then, add a few new routes to the application we created above; This was a dense lesson, so take some time to play with the new tools you've learned. Consider deleting it completely and rewriting it using what you know.
-3.  The [React Router tutorial](https://reactrouter.com/en/main/start/tutorial) goes through a lot of the stuff discussed in this lesson and much more. Have a read through the sections up to "Nested Routes".
-4.  Browse through the [React Router documentation](https://reactrouter.com/en/main). Again, you don't need to read through all of it, nor understand all of it. Just browse through the concepts we discussed here and re-read them. Look into the other features that React Router offers. This is a great resource to refer back to.
+1. [This article on SPAs and client-side routing by Ben Holmes](https://bholmes.dev/blog/spas-clientside-routing/) goes through a lot of the routing concepts concisely.
+1. Go and fix the `/profile` page to display something more useful than an error page. Then, add a few new routes to the application we created above; This was a dense lesson, so take some time to play with the new tools you've learned. Consider deleting it completely and rewriting it using what you know.
+1. The [React Router tutorial](https://reactrouter.com/en/main/start/tutorial) goes through a lot of the stuff discussed in this lesson and much more. Have a read through the sections up to "Nested Routes".
+1. Browse through the [React Router documentation](https://reactrouter.com/en/main). Again, you don't need to read through all of it, nor understand all of it. Just browse through the concepts we discussed here and re-read them. Look into the other features that React Router offers. This is a great resource to refer back to.
 
 </div>
 
 ### Knowledge check
 
-This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
+The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
 
 - <a class="knowledge-check-link" href="#client-side-routing">What does client-side routing mean?</a>
 - <a class="knowledge-check-link" href="#adding-a-router">How do you set up a basic router?</a>
@@ -473,8 +473,7 @@ This section contains questions for you to check your understanding of this less
 
 ### Additional resources
 
-This section contains helpful links to related content. It isn’t required, so consider it supplemental.
+This section contains helpful links to related content. It isn't required, so consider it supplemental.
 
-- Among the many ways to make protected routes, a few ways are provided below:
-    - [This Stack Overflow answer](https://stackoverflow.com/a/64347082/19051112) uses a function to generate the route config object passed to `createBrowserRouter`. The function conditionally generates the different paths.
-    - [This demonstration project](https://github.com/iammanishshrma/react-protected-routes/blob/master/src/routes/ProtectedRoute.jsx) creates a special Protected Route component that conditionally displays elements as necessary.
+- [This Stack Overflow answer](https://stackoverflow.com/a/64347082/19051112) uses a function to generate the route config object passed to `createBrowserRouter`. The function conditionally generates the different paths.
+- [This demonstration project](https://github.com/iammanishshrma/react-protected-routes/blob/master/src/routes/ProtectedRoute.jsx) creates a special Protected Route component that conditionally displays elements as necessary.

--- a/react/the_react_ecosystem/react_router.md
+++ b/react/the_react_ecosystem/react_router.md
@@ -441,9 +441,9 @@ Much nicer!
 
 As we learned earlier, you can nest routes as children of a parent route, allowing you to use an `<Outlet />` in the parent to render the appropriate element based on the rest of the path.
 
-If we had something in the parent element, such as a state, that we wanted to pass to any components rendered by that outlet, we would have to use something called `context`. We will learn about context outside of outlets in more detail in a later lesson but for now, using outlet context does not involve much at all because it is built in. You pass any value you want (which could even be an array or object) into an outlet's `context` prop, then inside the child component(s) you want to access any of those values, calling the `useOutletContext()` hook returns whatever value you had passed in. If you passed in an array or object, you could even destructure it!
+If we had something in the parent element, such as a state, that we wanted to pass to any components rendered by that outlet, we would have to use something called `context`. For now, we will focus on context with outlets but in a later lesson, we will learn more about how to use context without outlets.
 
-Outlet context is not limited to the child component rendered directly by the outlet itself. *Any component* rendered within the outlet (even one rendered by the child route's component) can access the context value by calling `useOutletContext()`.
+Outlets have a `context` prop built in. We can pass any value we want into this prop, even an array or object. Inside *any* component that would be rendered within that outlet (even "grandchild" components), we can call the `useOutletContext()` hook which will return whatever we passed into that context prop. If we passed in an array or object, we could even destructure it!
 
 Take a look at React Router's [documentation on `useOutletContext`](https://reactrouter.com/en/main/hooks/use-outlet-context) to learn more about how to pass context through an outlet and access that context in child components.
 

--- a/react/the_react_ecosystem/react_router.md
+++ b/react/the_react_ecosystem/react_router.md
@@ -10,6 +10,7 @@ This section contains a general overview of topics that you will learn in this l
 - How do you use React Router to do client-side routing?
 - How do you create nested and dynamic paths?
 - How do you add a "catch-all" route?
+- How do you pass data from a parent to any child components rendered via an outlet?
 - How do you add protected routes?
 
 ### Client-side routing
@@ -436,7 +437,7 @@ ReactDOM.createRoot(document.getElementById("root")).render(
 
 Much nicer!
 
-### State and outlets
+### Outlets and state
 
 As we learned earlier, you can nest routes as children of a parent route, allowing you to use an `<Outlet />` in the parent to render the appropriate element based on the rest of the path.
 
@@ -477,6 +478,7 @@ The following questions are an opportunity to reflect on key topics in this less
 - <a class="knowledge-check-link" href="#nested-routes-outlets-and-dynamic-segments">How do you create nested routes?</a>
 - <a class="knowledge-check-link" href="#dynamic-segments">What do you mean by dynamic segments or URL params?</a>
 - <a class="knowledge-check-link" href="#handling-bad-urls">How do you add a "catch-all" route?</a>
+- <a class="knowledge-check-link" href="#outlets-and-state">How do you pass data from parent to child through an `<Outlet />` component?</a>
 - <a class="knowledge-check-link" href="#protected-routes-and-navigation">How do you create protected routes?</a>
 
 ### Additional resources


### PR DESCRIPTION
## Because
The current [React Router lesson](https://www.theodinproject.com/lessons/node-path-react-new-react-router) demonstrates creating a Router component that contains a router, which would allow for things like props/state to be passed in to any of the router route's elements.

This is advised against by the React Router team who advise [routers should be singletons where data passed from parent to child in nested routes should be done via outlet context](https://github.com/remix-run/react-router/discussions/10440). The React Router docs have since been updated to match this advice, as opposed to the component version present at the time the lessons were written.

Having a component-based router and using state/props to pass data to nested routes/outlet components has often led to issues caused by the Router component rerendering and thus generating a completely fresh router with new components with new keys.

Therefore, the Router component example needs to be removed, and outlet context needs to be introduced at some point before the Shopping Cart project.

The current [Context lesson](https://www.theodinproject.com/lessons/node-path-react-new-managing-state-with-the-context-api) is written specifically with the Shopping Cart project in mind. Its examples and framing are all based on that project. Bringing the context lesson forward to be before that project would require far more significant changes to that lesson:
 - It can no longer reference the "shopping cart project you just did"
 - Its examples need be changed from Shopping Cart components to also not potentially solve some problems learners might face in that project.

Therefore, to minimise how disruptive any changes would be, the decision was made to leave the lesson order as is but to only introduce outlet context in the React Router lesson. Awareness and research into outlet context is by far one of the most common issues and resolutions in the `#react-help` channel in the discord server. Its usage is also straightforward (a built in `context` prop to `<Outlet />` and a simple `useOutletContext()` call in whatever descendent component within that outlet). There should not need to be much more of a significant change made than just introducing this concept and hook before the Shopping Cart project.


## This PR
- Changes the router refactoring section in the router lesson to extract only the routes array to a separate file, as opposed to creating a new Router component.
- Adds an "Outlets and state" section to the router lesson that introduces outlet context.
- Tweaks the post-Shopping Cart Context lesson's introduction to accommodate for the now-earlier mention of outlet context.
- Fixes linting errors in both affected files
- Converts React Router's knowledge check links from anchor tags to markdown links in line with the style guide and other lessons.


## Issue
Closes #26502

## Additional Information
N/A

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
