### PR TITLE
Foundations HTML boilerplate: Mention meta viewport tag

### DIFF
--- a/foundations/html_css/html-foundations/html-boilerplate.md
+++ b/foundations/html_css/html-foundations/html-boilerplate.md
@@ -150,6 +150,14 @@ Now, if you refresh the page in the browser, you should see the changes take eff
 
 VSCode has a built-in shortcut you can use for generating all the boilerplate in one go. Please note that this shortcut only works while editing a file with the `.html` extension or a text file with the HTML language already selected. To trigger the shortcut, delete everything in the `index.html` file and just enter `!` on the first line. This will bring up a couple of options. Press the <kbd>Enter</kbd> key to choose the first one, and voila, you should have all the boilerplate populated for you.
 
+You may notice that the boilerplate produced by this shortcut includes a line we have not yet mentioned:
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+```
+
+This is not something we need to know about until we discuss responsive design, an advanced topic involving different screen sizes which we will cover much later in the curriculum. For now, you can leave that line as it is.
+
 But it's still good to know how to write the boilerplate yourself in case you find yourself using a text editor like notepad (heaven forbid), which doesn't have this shortcut. Try not to use the shortcut in your first few HTML projects, so you can build some muscle memory for writing the boilerplate code.
 
 ### Assignment

--- a/foundations/html_css/html-foundations/html-boilerplate.md
+++ b/foundations/html_css/html-foundations/html-boilerplate.md
@@ -51,7 +51,7 @@ Back in the `index.html` file, let's add the `<html>` element by typing out its 
 
 Noticed the word `lang` here? It represents an HTML attribute which is associated with the given HTML tag i.e. `<html>` in this case. These attributes provide additional information about HTML elements. (More about `HTML attributes` in the following lesson.)
 
-#### What is the lang attribute? 
+#### What is the lang attribute?
 
 `lang` specifies the language of the text content in that element. This attribute is primarily used for improving accessibility of the webpage. It allows assistive technologies, for example screen readers, to adapt according to the language and invoke correct pronunciation.
 
@@ -115,13 +115,13 @@ To complete the boilerplate, add a `<body>` element to the `index.html` file. Th
 The HTML boilerplate in the `index.html` file is complete at this point, but how do you view it in the browser?  There are a couple of different options:
 
 > A note:
-> In order to avoid branching our lesson's instructions to accommodate for all of the differences between browsers, we are going to be using Google Chrome as our primary browser for the remainder of this course.  All references to the browser will pertain specifically to Google Chrome.  We **strongly** suggest that you use Google Chrome for all of your testing going forward.  
+> In order to avoid branching our lesson's instructions to accommodate for all of the differences between browsers, we are going to be using Google Chrome as our primary browser for the remainder of this course.  All references to the browser will pertain specifically to Google Chrome.  We **strongly** suggest that you use Google Chrome for all of your testing going forward.
 
 1. You can drag and drop an HTML file from your text editor into the address bar of your browser.
 
-2. You can find the HTML file in your file system and then double click it. This will open up the file in the default browser your system uses.
+1. You can find the HTML file in your file system and then double click it. This will open up the file in the default browser your system uses.
 
-3. You can use the terminal to open the file in your browser.
+1. You can use the terminal to open the file in your browser.
 
     - `Ubuntu` - Navigate to the directory containing the file and type `google-chrome index.html`
     - `macOS` - Navigate to the directory containing the file and type `open ./index.html`
@@ -158,15 +158,15 @@ But it's still good to know how to write the boilerplate yourself in case you fi
 
 1. Watch and follow along to Kevin Powell's brilliant [Building Your First Web Page video](https://www.youtube.com/watch?v=V8UAEoOvqFg&t=93s).
 
-2. Build some muscle memory by deleting the contents of the `index.html` file and trying to write out all the boilerplate again from memory. Don't worry if you have to peek at the lesson content the first few times if you get stuck. Just keep going until you can do it a couple of times from memory.
+1. Build some muscle memory by deleting the contents of the `index.html` file and trying to write out all the boilerplate again from memory. Don't worry if you have to peek at the lesson content the first few times if you get stuck. Just keep going until you can do it a couple of times from memory.
 
-3. Run your boilerplate through the W3 [HTML validator](https://validator.w3.org/) or alternatively this [HTML validator](https://www.freeformatter.com/html-validator.html). Validators ensure your markup is correct and are an excellent learning tool, as they provide feedback on syntax errors you may be making often and aren't aware of, such as missing closing tags and extra spaces in your HTML.
+1. Run your boilerplate through the W3 [HTML validator](https://validator.w3.org/). Validators ensure your markup is correct and are an excellent learning tool, as they provide feedback on syntax errors you may be making often and aren't aware of, such as missing closing tags and extra spaces in your HTML.
 
 </div>
 
 ### Knowledge check
 
-This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
+The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
 
 - [What is the purpose of the doctype declaration?](#the-doctype)
 - [What is the HTML element?](#html-element)
@@ -175,9 +175,8 @@ This section contains questions for you to check your understanding of this less
 
 ### Additional resources
 
-This section contains helpful links to related content. It isn’t required, so consider it supplemental.
+This section contains helpful links to related content. It isn't required, so consider it supplemental.
 
 - Another option for opening your HTML pages in the browser is using the [live server extension](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer) with VSCode. This will open your HTML document and automatically refresh it every time you save the document. However, we recommend not using this extension and instead doing it the old-fashioned way, by opening the page and refreshing the page manually in the browser for your first few HTML projects. This way, you can get used to that process and won't become reliant on extensions right away. One reason is that there may be subtle differences when using extensions. For example, live server will always use UTF-8 character encoding and not the charset value defined in your `<meta>` element. This could potentially hide some characters on your site as they will not be encoded the way you expect.
 
-- If you wish, you can add the `lang` attribute to individual elements throughout the webpage. Read through [this doc](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang) for a better understanding of the `lang` attribute.
-
+- If you wish, you can add [the `lang` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang) to individual elements throughout the webpage.

--- a/foundations/html_css/html-foundations/html-boilerplate.md
+++ b/foundations/html_css/html-foundations/html-boilerplate.md
@@ -158,7 +158,7 @@ You may notice that the boilerplate produced by this shortcut includes a line we
 
 This is not something we need to know about until we discuss responsive design, an advanced topic involving different screen sizes which we will cover much later in the curriculum. For now, you can leave that line as it is.
 
-But it's still good to know how to write the boilerplate yourself in case you find yourself using a text editor like notepad (heaven forbid), which doesn't have this shortcut. Try not to use the shortcut in your first few HTML projects, so you can build some muscle memory for writing the boilerplate code.
+It's still good to know how to write the boilerplate yourself in case you find yourself using a text editor like notepad (heaven forbid), which doesn't have this shortcut. Try not to use the shortcut in your first few HTML projects, so you can build some muscle memory for writing the boilerplate code.
 
 ### Assignment
 


### PR DESCRIPTION
## Because
The [HTML Boilerplate](https://www.theodinproject.com/lessons/foundations-html-boilerplate#lesson-overview) lesson talks through each part of the basic boilerplate. It then tells you how to get that same boilerplate via VSCode's `!` snippet.

Currently, the `!` snippet also includes the meta viewport tag which is not mentioned in the lesson at all, which can be confusing for learners.

While we needn't explain the tag much here, we should still mention it in relation to the `!` snippet so learners know to expect it and to know it's not something they need to learn about yet.

## This PR
- Fixes list style lint errors
- Fixes accessible link and removes redundant link (2nd HTML validator - not necessary)
- Adds mention of meta viewport tag and highlights non-importance until much later in the course

## Issue
Closes #27646

## Additional Information
https://discord.com/channels/505093832157691914/516751477306294273/1219950453345751071 <- discord question highlighting how the lesson contents does not mention something that the `!` snippet provides, causing confusion.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
