### PR TITLE
Motivation and Mindset lesson: Remove duplicate "Monkeytype" link

### DIFF
--- a/foundations/introduction/motivation_and_mindset.md
+++ b/foundations/introduction/motivation_and_mindset.md
@@ -177,7 +177,7 @@ This section contains helpful links to related content. It isn't required, so co
 - [Becoming a TOP Success Story](https://dev.to/theodinproject/becoming-a-top-success-story-mindset-3dp2)
 - [Managing inspiration and motivation](https://markmanson.net/do-something)
 - [Learning to code when it gets dark](https://medium.freecodecamp.org/learning-to-code-when-it-gets-dark-e485edfb58fd#.yjh0fehje)
-- If you find your typing speed is holding you back, you can improve your typing skills by utilizing keyword trainers for at least 5 minutes every day. Some excellent options include [Monkeytype](https://monkeytype.com/), [typing.com](https://www.typing.com/), [TypingClub.com](https://www.typingclub.com) and [Monkeytype](https://monkeytype.com/).
+- If you find your typing speed is holding you back, you can improve your typing skills by utilizing keyword trainers for at least 5 minutes every day. Some excellent options include [typing.com](https://www.typing.com/), [TypingClub.com](https://www.typingclub.com) and [Monkeytype](https://monkeytype.com/).
 - [Why Procrastinators Procrastinate](https://waitbutwhy.com/2013/10/why-procrastinators-procrastinate.html) Learn about the Instant Gratification Monkey, Rational Decision Maker, Panic Monster, and how to navigate the Dark Playground. [Short video introduction from the same author](https://youtu.be/arj7oStGLkU)
 - 100 Days of Code is a challenge that new developers often use to track their coding journey and showcase their work. Consider joining by checking out [their website](https://www.100daysofcode.com/) if you are looking for a way to stay motivated and inspire other developers.
 - Check out the [Learning How to Learn](https://www.coursera.org/learn/learning-how-to-learn) course from Coursera.


### PR DESCRIPTION
## Because
The "Additional resources" section of the Motivation and Mindset lesson lists a couple of websites to learn/practice typing; in them, Monkeytype is listed twice.


## This PR
Removes the first Monkeytype link, so the remaining resources are: typing.com, TypingClub.com, Monkeytype.


## Issue
Closes #XXXXX


## Additional Information


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
