### PR TITLE
Restaurant project: Note on gitignores

### DIFF
--- a/javascript/organizing_your_javascript_code/project_restaurant_page.md
+++ b/javascript/organizing_your_javascript_code/project_restaurant_page.md
@@ -4,6 +4,15 @@ Let's use what we've learned and take a chance to continue practicing DOM manipu
 
 **Note: DOM elements should be created using JavaScript but styling can be done in a separate CSS file.**
 
+<div class="lesson-note lesson-note--tip" markdown="1">
+
+#### .gitignore
+
+When working with packages that are installed with npm, you don't need to track the contents of `node_modules` with git, or push those files to GitHub either. This is because the `package.json` file contains all the information, so that anyone can clone your project and install them on their machine with `npm install`.
+
+You can make a `.gitignore` file in the root of the project, and by writing file or directory names in it, you can tell git what things you don't want to track. It's customary to add `node_modules` to `.gitignore`, since it can get really big.
+</div>
+
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">
@@ -13,14 +22,14 @@ Let's use what we've learned and take a chance to continue practicing DOM manipu
 
     1. run `npm install webpack webpack-cli --save-dev` to install webpack to the node_modules directory of your project.
 
-        - Quick tip: the `node_modules` folder can get *really* big. It is customary to   add a `.gitignore` file to your project so that you don't have to sync the contents of `node_modules` to github. The dependencies that are stored there can be installed from your package.json by running `npm install`, so you don't need to sync them.
-
     1. Create a `src` and `dist` directory with the following contents:
         1. an `index.js` file in `src`.
 
         1. an `index.html` file in `src`. This file will not need a script tag, because we're using `html-webpack-plugin`, which automatically adds that in. You will also not need to link a CSS stylesheet as you should be importing it into your JavaScript and letting your webpack configuration handle bundling.
 
         1. create a `webpack.config.js` file that looks just like our file from the [Webpack "Getting Started" tutorial](https://webpack.js.org/guides/getting-started/#using-a-configuration). Don't forget to add the `html-webpack-plugin` config to your `webpack.config.js` and set its `template` option with a path to `src/index.html`.
+
+1. Create a `.gitignore` file in the root of your project. It should contain `node_modules` and `dist` on separate lines.
 
 1. Set up an HTML skeleton inside of `src/index.html`. Inside the body, add a `<header>` element that contains a `<nav>` with buttons (not links!) for different "tabs" (for example buttons for "Home", "Menu" or "About" etc). Below the `<header>`, add a single `<div id="content">`.
 

--- a/javascript/organizing_your_javascript_code/project_restaurant_page.md
+++ b/javascript/organizing_your_javascript_code/project_restaurant_page.md
@@ -8,7 +8,7 @@ Let's use what we've learned and take a chance to continue practicing DOM manipu
 
 #### .gitignore
 
-When working with packages that are installed with npm, you don't need to track the contents of `node_modules` with git, or push those files to GitHub either. This is because the `package.json` file contains all the information, so that anyone can clone your project and install them on their machine with `npm install`.
+When working with packages that are installed with npm, you don't need to track the contents of `node_modules` with git, nor push those files to GitHub. This is because the `package.json` file contains all the information, so that anyone can clone your project and install them on their machine with `npm install`.
 
 You can make a `.gitignore` file in the root of the project, and by writing file or directory names in it, you can tell git what things you don't want to track. It's customary to add `node_modules` to `.gitignore`, since it can get really big.
 </div>
@@ -18,16 +18,16 @@ You can make a `.gitignore` file in the root of the project, and by writing file
 <div class="lesson-content__panel" markdown="1">
 
 1. Start the project the same way you began the webpack tutorial project.
-    1. run `npm init` in your project directory to generate a `package.json` file.
+    1. Run `npm init` in your project directory to generate a `package.json` file.
 
-    1. run `npm install webpack webpack-cli --save-dev` to install webpack to the node_modules directory of your project.
+    1. Run `npm install webpack webpack-cli --save-dev` to install webpack to the node_modules directory of your project.
 
     1. Create a `src` and `dist` directory with the following contents:
-        1. an `index.js` file in `src`.
+        1. An `index.js` file in `src`.
 
-        1. an `index.html` file in `src`. This file will not need a script tag, because we're using `html-webpack-plugin`, which automatically adds that in. You will also not need to link a CSS stylesheet as you should be importing it into your JavaScript and letting your webpack configuration handle bundling.
+        1. An `index.html` file in `src`. This file will not need a script tag, because we're using `html-webpack-plugin`, which automatically adds that in. You will also not need to link a CSS stylesheet as you should be importing it into your JavaScript and letting your webpack configuration handle bundling.
 
-        1. create a `webpack.config.js` file that looks just like our file from the [Webpack "Getting Started" tutorial](https://webpack.js.org/guides/getting-started/#using-a-configuration). Don't forget to add the `html-webpack-plugin` config to your `webpack.config.js` and set its `template` option with a path to `src/index.html`.
+        1. Create a `webpack.config.js` file that looks just like our file from the [Webpack "Getting Started" tutorial](https://webpack.js.org/guides/getting-started/#using-a-configuration). Don't forget to add the `html-webpack-plugin` config to your `webpack.config.js` and set its `template` option with a path to `src/index.html`.
 
 1. Create a `.gitignore` file in the root of your project. It should contain `node_modules` and `dist` on separate lines.
 
@@ -35,7 +35,7 @@ You can make a `.gitignore` file in the root of the project, and by writing file
 
 1. Inside of `src/index.js` write a `console.log` or `alert` statement and then run `npx webpack`. Load up `dist/index.html` in a browser to make sure everything is working correctly.
 
-    - Quick tip #2: if you run `npx webpack --watch` you will not have to rerun webpack every time you make a change.
+    - Quick tip: If you run `npx webpack --watch` you will not have to rerun webpack every time you make a change.
 
 1. Inside `div#content`, create a homepage for your restaurant. You might want to include an image, headline, and some text about how wonderful the restaurant is; you do not have to make this look too fancy. It’s okay to hard-code these into the HTML for now just to see how they look on the page.
 


### PR DESCRIPTION
## Because
Learners were unsure about the usage of `.gitignore` with regards to `node_modules` in webpack projects


## This PR
- Adds a note describing the motivations behind ignoring modules
- Removes the old "Quick tip" from the instructions
- Adds an instruction to create a `.gitignore` without explanation, since that's now covered by the note

## Issue
Closes #27192

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
