### PR TITLE
Layout Style Guide: Add new rules

### DIFF
--- a/LAYOUT_STYLE_GUIDE.md
+++ b/LAYOUT_STYLE_GUIDE.md
@@ -384,6 +384,7 @@ cd Documents
 If you need a codeblock within a list, you should follow the same indenting rules for [multi-line list items](#multi-line-list-items), with the codeblock being indented with 2 spaces for a bulleted list item and 3 spaces for a numbered list item. The following Markdown:
 
 <pre>
+
 - Bullet.
 
   ```javascript
@@ -394,6 +395,7 @@ If you need a codeblock within a list, you should follow the same indenting rule
   ```
 
 - Next bullet.
+
 </pre>
 
 Will result in the following output:
@@ -417,6 +419,8 @@ For nested markdown inside note boxes to be displayed properly additional `markd
 
 A heading can be added to a note by using a `####` heading. When adding a heading, be sure to provide text that helps describe the note rather than "A note" or "Warning".
 
+The opening and closing tags must each be wrapped with a single blank line on either side, or a codeblock delimiter (triple backticks). This applies to any line that contains only a single HTML tag. The only exceptions to this rule are HTML tags inside `html` or `jsx` codeblocks.
+
 ### Variations
 
 Note boxes come in two variations, which can be set by adding an extra class together with `lesson-note`:
@@ -432,6 +436,7 @@ Note boxes come in two variations, which can be set by adding an extra class tog
 #### An optional title
 
 A sample note box.
+
 </div>
 ```
 
@@ -441,6 +446,7 @@ A sample note box.
 #### An optional title
 
 A sample note box, variation: tip.
+
 </div>
 ```
 
@@ -561,7 +567,9 @@ To add a Mermaid diagram to a lesson, visit the [Mermaid docs](https://mermaid.j
 
 ```markdown
 <pre class="mermaid">
-  mermaid diagram content here
+
+mermaid diagram content here
+
 </pre>
 ```
 

--- a/LAYOUT_STYLE_GUIDE.md
+++ b/LAYOUT_STYLE_GUIDE.md
@@ -454,7 +454,19 @@ A sample note box, variation: tip.
 
 Long links make source Markdown difficult to read and break the 80 character wrapping. **Wherever possible, shorten your links**.
 
-### Use informative Markdown link titles
+### Use Markdown links
+
+Instead of using HTML anchor tags for links, use Markdown links instead.
+
+```markdown
+// Don't use HTML links
+See the <a href="./templates/lesson-template.md" target="_blank" rel="noreferrer">lesson template</a> for a more easily copyable lesson file.
+
+// Use Markdown links
+See the [lesson template](./templates/lesson-template.md) for a more easily copyable lesson file.
+```
+
+### Use informative titles
 
 Markdown link syntax allows you to set a link title, just as HTML does. Use it wisely.
 

--- a/LAYOUT_STYLE_GUIDE.md
+++ b/LAYOUT_STYLE_GUIDE.md
@@ -365,7 +365,7 @@ const obj = {
 It is best practice to explicitly declare the language immediately after the opening backticks, so that neither the
 syntax highlighter nor the next editor must guess.
 
-If a language has both a long and short form that markdown will accept, for example `javascript` will also be accepted as `js`, and `plaintext` will also be accepted as `txt`, the long form should be used.
+If a language has both a long and short form that markdown will accept, for example `javascript` will also be accepted as `js`, and `text` will also be accepted as `txt`, the long form should be used.
 
 #### No extraneous characters
 

--- a/LAYOUT_STYLE_GUIDE.md
+++ b/LAYOUT_STYLE_GUIDE.md
@@ -351,6 +351,7 @@ Create a new file named `styles.css` first.
 For code quotations longer than a single line, use a codeblock with 3 opening and closing backticks:
 
 <pre>
+
 ```javascript
 const obj = {
   name: "object",
@@ -361,8 +362,10 @@ const obj = {
 
 #### Declare the language
 
-It is best practice to explicitly declare the language immediately after the opening tilde marks, so that neither the
+It is best practice to explicitly declare the language immediately after the opening backticks, so that neither the
 syntax highlighter nor the next editor must guess.
+
+If a language has both a long and short form that markdown will accept, for example `javascript` will also be accepted as `js`, and `plaintext` will also be accepted as `txt`, the long form should be used.
 
 #### No extraneous characters
 

--- a/LAYOUT_STYLE_GUIDE.md
+++ b/LAYOUT_STYLE_GUIDE.md
@@ -365,7 +365,7 @@ const obj = {
 It is best practice to explicitly declare the language immediately after the opening backticks, so that neither the
 syntax highlighter nor the next editor must guess.
 
-If a language has both a long and short form that markdown will accept, for example `javascript` will also be accepted as `js`, and `text` will also be accepted as `txt`, the long form should be used.
+If a language has both a long and short form that markdown will accept, for example `javascript` will also be accepted as `js`, and `text` will also be accepted as `txt`, the long form must be used.
 
 #### No extraneous characters
 

--- a/markdownlint/TOP005_blanksAroundMultilineHtmlTags/TOP005_blanksAroundMultilineHtmlTags.js
+++ b/markdownlint/TOP005_blanksAroundMultilineHtmlTags/TOP005_blanksAroundMultilineHtmlTags.js
@@ -1,7 +1,7 @@
 module.exports = {
   names: ["TOP005", "blanks-around-multiline-html-tags"],
   description: "Multiline HTML tags should be surrounded by blank lines or code block delimiters",
-  tags: ["html", "blanks"],
+  tags: ["html", "blank_lines"],
   information: new URL(
     "https://github.com/TheOdinProject/curriculum/blob/main/markdownlint/docs/TOP005.md"
   ),

--- a/markdownlint/TOP005_blanksAroundMultilineHtmlTags/tests/TOP005_test.md
+++ b/markdownlint/TOP005_blanksAroundMultilineHtmlTags/tests/TOP005_test.md
@@ -45,7 +45,7 @@ Also invalidates when HTML blocks are chained without blank lines between them.
 Also invalidates when HTML blocks are chained without blank lines between them.
 </div>
 
-```md
+```markdown
 <div>
 
 The only exception to blank lines is a code block delimiter.
@@ -53,7 +53,7 @@ The only exception to blank lines is a code block delimiter.
 </div>
 ```
 
-```md
+```markdown
 <div>
 
 This line above the closing tag is not a blank line nor a code block delimiter, so the closing tag errors.
@@ -74,7 +74,7 @@ This line above the closing tag is not a blank line nor a code block delimiter, 
 </p>
 ```
 
-```md
+```markdown
 <p>
     But does not like it if done in a non-HTML/JSX code block
 </p>

--- a/markdownlint/docs/TOP005.md
+++ b/markdownlint/docs/TOP005.md
@@ -1,8 +1,8 @@
 # `TOP005` - Blanks around multiline HTML tags
 
-Tags: `html`, `blanks`
+Tags: `html`, `blank_lines`
 
-Aliases: `lesson-headings`
+Aliases: `blanks-around-multiline-html-tags`
 
 The rule is triggered when a line containing only an opening or closing HTML tag is surrounded by anything other than a blank line or fenced code block.
 


### PR DESCRIPTION
## Because
With the addition of the `TOP005` rule in #27674, the layout style guide needs to be updated to include that rule.

Two other rules were missing from the style guide:
1. Use markdown links instead of HTML anchor tags
2. Use the long name for codeblock languages, for any languages that have a long and short form (e.g. `javascript` and `js`)


## This PR
- Adds the rule covered by `TOP005` to the layout style guide
- Also adds a clarification to use markdown links instead of HTML anchor tags
- Adds clarification for using the long language name for codeblocks if a short option is also acceptable
- Fixed TOP005_test.md to abide by the long language name rule


## Issue
N/A

## Additional Information
The only linting errors that should be present are the expected TOP005 errors from `TOP005_test.md`.


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
