### PR TITLE
Block and Inline: Fix additional resources link info

### DIFF
--- a/foundations/html_css/css-foundations/block-and-inline.md
+++ b/foundations/html_css/css-foundations/block-and-inline.md
@@ -83,6 +83,6 @@ The following questions are an opportunity to reflect on key topics in this less
 
 This section contains helpful links to related content. It isn't required, so consider it supplemental.
 
-- [Learn CSS Layout](https://learnlayout.com/no-layout.html) is tutorial that is a little dated at this point, but its examples are clear. is a little dated at this point, but its examples are clear. The first 6 slides cover the material we've seen so far.
+- [Learn CSS Layout](https://learnlayout.com/no-layout.html) is a tutorial that is a little dated at this point, but its examples are clear. The first 6 slides cover the material we've seen so far.
 - Watch this short video on [what the term “Normal Flow” means](https://www.youtube.com/watch?v=nfXRw06FgK8) in CSS.
 - For a more interactive explanation and example, try this [Scrim on block and inline display](https://scrimba.com/scrim/co5024997a7e46c232d9abe55).


### PR DESCRIPTION
Fix errors in the additional resources section

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The additional resources section has typographic errors.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
1. correct the line "is tutorial that is a little dated at this point, but its examples are clear. is a little dated at this point, but its examples are clear. " to "is a tutorial that is a little dated at this point, but its examples are clear."


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
