### PR TITLE
Default Styles lesson: Add missing word

### DIFF
--- a/intermediate_html_css/intermediate_css_concepts/default_styles.md
+++ b/intermediate_html_css/intermediate_css_concepts/default_styles.md
@@ -11,11 +11,11 @@ This section contains a general overview of topics that you will learn in this l
 
 ### What are default styles and where do they come from?
 
-As you have worked on projects, you likely observed default styles applied to certain elements, such as larger and bolder headings on `h1` elements, and blue, underlined links on `a' elements. There is also a good chance you struggled with things like default margins and padding. These styles are part of the user-agent stylesheets, ensuring basic styling for webpages without CSS. Each browser has it's own set of user-agent stylesheets so the default styles do slightly between browsers.
+As you have worked on projects, you likely observed default styles applied to certain elements, such as larger and bolder headings on `h1` elements, and blue, underlined links on `a' elements. There is also a good chance you struggled with things like default margins and padding. These styles are part of the user-agent stylesheets, ensuring basic styling for webpages without CSS. Each browser has it's own set of user-agent stylesheets so the default styles do vary slightly between browsers.
 
 ### What if I don't like the defaults?
 
-With very few exceptions you can simply write your own CSS rules.  The rules you write in your stylesheet have higher precedence than the user-agents rules, and therefore overwrite the defaults. However, there is another option.
+With very few exceptions you can simply write your own CSS rules. The rules you write in your stylesheet have higher precedence than the user-agents rules, and therefore overwrite the defaults. However, there is another option.
 
 To address inconsistencies across browsers and establish a consistent starting point for styling, some developers started using CSS resets. These resets are stylesheets containing CSS rules aimed at altering or removing the defaults set by user-agent stylesheets. Using them can help achieve consistency, and can provide a clean slate for developers to apply their styles without interference.
 

--- a/intermediate_html_css/intermediate_css_concepts/default_styles.md
+++ b/intermediate_html_css/intermediate_css_concepts/default_styles.md
@@ -11,7 +11,7 @@ This section contains a general overview of topics that you will learn in this l
 
 ### What are default styles and where do they come from?
 
-As you have worked on projects, you likely observed default styles applied to certain elements, such as larger and bolder headings on `h1` elements, and blue, underlined links on `a' elements. There is also a good chance you struggled with things like default margins and padding. These styles are part of the user-agent stylesheets, ensuring basic styling for webpages without CSS. Each browser has it's own set of user-agent stylesheets so the default styles do vary slightly between browsers.
+As you have worked on projects, you likely observed default styles applied to certain elements, such as larger and bolder headings on `h1` elements, and blue, underlined links on `a' elements. There is also a good chance you struggled with things like default margins and padding. These styles are part of the user-agent stylesheets, ensuring basic styling for webpages without CSS. Each browser has its own set of user-agent stylesheets so the default styles do vary slightly between browsers.
 
 ### What if I don't like the defaults?
 


### PR DESCRIPTION
## Because
Under the "What are default styles and where do they come from?" header, the last sentence is missing a word.


## This PR

- Add the missing word "vary" to the sentence.


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
