### PR TITLE
Markdownlint: Add fixers for TOP005 and TOP006

### DIFF
--- a/markdownlint/TOP005_blanksAroundMultilineHtmlTags/TOP005_blanksAroundMultilineHtmlTags.js
+++ b/markdownlint/TOP005_blanksAroundMultilineHtmlTags/TOP005_blanksAroundMultilineHtmlTags.js
@@ -42,8 +42,10 @@ module.exports = {
 
       // https://regexr.com/7u89c to test the following regex:
       const blankCodeBlockRegex = /^$|^`{3,4}.*$/;
-      const lineBeforeIsValid = blankCodeBlockRegex.test(params.lines[lineNumber - 1] ?? "");
-      const lineAfterIsValid = blankCodeBlockRegex.test(params.lines[lineNumber + 1] ?? "");
+      const lineBefore = params.lines[lineNumber - 1] ?? "";
+      const lineBeforeIsValid = blankCodeBlockRegex.test(lineBefore);
+      const lineAfter = params.lines[lineNumber + 1] ?? "";
+      const lineAfterIsValid = blankCodeBlockRegex.test(lineAfter);
 
       if (lineBeforeIsValid && lineAfterIsValid) {
         return;
@@ -52,10 +54,10 @@ module.exports = {
       const lineAfterIsTheNextHtmlTag = lineNumber + 1 === isolatedHtmlTagsLineNumbers[i + 1];
       let replacementText = params.lines[lineNumber];
 
-      if (!lineBeforeIsValid) {
+      if (!lineBeforeIsValid && lineBefore.trim() !== "") {
         replacementText = `\n${replacementText}`;
       }
-      if (!lineAfterIsValid && !lineAfterIsTheNextHtmlTag) {
+      if (!lineAfterIsValid && !lineAfterIsTheNextHtmlTag && lineAfter.trim() !== "") {
         replacementText = `${replacementText}\n`;
       }
 
@@ -72,7 +74,7 @@ module.exports = {
         fixInfo: {
           deleteCount: params.lines[lineNumber].length,
           insertText: replacementText,
-        }
+        },
       });
     });
   },

--- a/markdownlint/TOP005_blanksAroundMultilineHtmlTags/TOP005_blanksAroundMultilineHtmlTags.js
+++ b/markdownlint/TOP005_blanksAroundMultilineHtmlTags/TOP005_blanksAroundMultilineHtmlTags.js
@@ -54,6 +54,7 @@ module.exports = {
       const lineAfterIsTheNextHtmlTag = lineNumber + 1 === isolatedHtmlTagsLineNumbers[i + 1];
       let replacementText = params.lines[lineNumber];
 
+      // .trim() !== "" prevents interference with MD009 whitespace fixer
       if (!lineBeforeIsValid && lineBefore.trim() !== "") {
         replacementText = `\n${replacementText}`;
       }

--- a/markdownlint/TOP005_blanksAroundMultilineHtmlTags/TOP005_blanksAroundMultilineHtmlTags.js
+++ b/markdownlint/TOP005_blanksAroundMultilineHtmlTags/TOP005_blanksAroundMultilineHtmlTags.js
@@ -35,7 +35,7 @@ module.exports = {
       []
     );
 
-    isolatedHtmlTagsLineNumbers.forEach((lineNumber) => {
+    isolatedHtmlTagsLineNumbers.forEach((lineNumber, i) => {
       if (isWithinIgnoredFence(lineNumber)) {
         return;
       }
@@ -49,6 +49,16 @@ module.exports = {
         return;
       }
 
+      const lineAfterIsTheNextHtmlTag = lineNumber + 1 === isolatedHtmlTagsLineNumbers[i + 1];
+      let replacementText = params.lines[lineNumber];
+
+      if (!lineBeforeIsValid) {
+        replacementText = `\n${replacementText}`;
+      }
+      if (!lineAfterIsValid && !lineAfterIsTheNextHtmlTag) {
+        replacementText = `${replacementText}\n`;
+      }
+
       /**
        * lineNumber is params.lines index (0-indexed).
        * +1 required as file line numbers are 1-indexed.
@@ -59,6 +69,10 @@ module.exports = {
           lineBeforeIsValid ? 1 : 0
         }, After: ${lineAfterIsValid ? 1 : 0} }\n`,
         context: params.lines[lineNumber],
+        fixInfo: {
+          deleteCount: params.lines[lineNumber].length,
+          insertText: replacementText,
+        }
       });
     });
   },

--- a/markdownlint/TOP006_fullFencedCodeLanguage/TOP006_fullFencedCodeLanguage.js
+++ b/markdownlint/TOP006_fullFencedCodeLanguage/TOP006_fullFencedCodeLanguage.js
@@ -2,7 +2,9 @@ const LANGUAGES_WITH_ABBREVIATIONS = new Map()
   .set("js", "javascript")
   .set("rb", "ruby")
   .set("txt", "text")
-  .set("md", "markdown");
+  .set("md", "markdown")
+  .set("sh", "bash")
+  .set("yml", "yaml");
 
 module.exports = {
   names: ["TOP006", "full-fenced-code-language"],
@@ -21,13 +23,24 @@ module.exports = {
         abbreviatedName: token.info,
         fullName: LANGUAGES_WITH_ABBREVIATIONS.get(token.info),
         lineNumber: token.lineNumber,
+        hasFourBackticks: token.markup.length === 4,
+        get nameStartingColumn() {
+          return this.hasFourBackticks ? 5 : 4;
+        },
       }));
 
     fencesWithAbbreviatedName.forEach((fence) => {
+      const leadingBackticks = fence.hasFourBackticks ? "````" : "```";
+
       onError({
         lineNumber: fence.lineNumber,
         detail: `Expected: ${fence.fullName}; Actual: ${fence.abbreviatedName} `,
-        context: `\`\`\`${fence.abbreviatedName}`,
+        context: `${leadingBackticks}${fence.abbreviatedName}`,
+        fixInfo: {
+          editColumn: fence.nameStartingColumn,
+          deleteCount: fence.abbreviatedName.length,
+          insertText: fence.fullName,
+        },
       });
     });
   },

--- a/markdownlint/TOP006_fullFencedCodeLanguage/TOP006_fullFencedCodeLanguage.js
+++ b/markdownlint/TOP006_fullFencedCodeLanguage/TOP006_fullFencedCodeLanguage.js
@@ -2,9 +2,7 @@ const LANGUAGES_WITH_ABBREVIATIONS = new Map()
   .set("js", "javascript")
   .set("rb", "ruby")
   .set("txt", "text")
-  .set("md", "markdown")
-  .set("sh", "bash")
-  .set("yml", "yaml");
+  .set("md", "markdown");
 
 module.exports = {
   names: ["TOP006", "full-fenced-code-language"],
@@ -15,29 +13,35 @@ module.exports = {
     "https://github.com/TheOdinProject/curriculum/blob/main/markdownlint/docs/TOP006.md"
   ),
   function: function TOP006(params, onError) {
-    const fencesWithAbbreviatedName = params.tokens
-      .filter((token) => {
-        return token.type === "fence" && LANGUAGES_WITH_ABBREVIATIONS.has(token.info);
-      })
-      .map((token) => ({
-        abbreviatedName: token.info,
-        fullName: LANGUAGES_WITH_ABBREVIATIONS.get(token.info),
-        lineNumber: token.lineNumber,
-        hasFourBackticks: token.markup.length === 4,
-        get nameStartingColumn() {
-          return this.hasFourBackticks ? 5 : 4;
-        },
-      }));
+    const fencesWithAbbreviatedName = params.lines.reduce((fences, currentLine, index) => {
+      // https://regexr.com/7v119 to test the following regex:
+      const fenceWithLanguageRegex = /^`{3,4}[^`]+$/;
+      if (!fenceWithLanguageRegex.test(currentLine)) {
+        return fences;
+      }
+
+      const backtickCount = currentLine.lastIndexOf("`") + 1;
+      const language = currentLine.substring(backtickCount);
+
+      if (LANGUAGES_WITH_ABBREVIATIONS.has(language)) {
+        fences.push({
+          text: currentLine,
+          backtickCount: backtickCount,
+          abbreviatedName: language,
+          fullName: LANGUAGES_WITH_ABBREVIATIONS.get(language),
+          lineNumber: index + 1,
+        });
+      }
+      return fences;
+    }, []);
 
     fencesWithAbbreviatedName.forEach((fence) => {
-      const leadingBackticks = fence.hasFourBackticks ? "````" : "```";
-
       onError({
         lineNumber: fence.lineNumber,
         detail: `Expected: ${fence.fullName}; Actual: ${fence.abbreviatedName} `,
-        context: `${leadingBackticks}${fence.abbreviatedName}`,
+        context: fence.text,
         fixInfo: {
-          editColumn: fence.nameStartingColumn,
+          editColumn: fence.backtickCount + 1,
           deleteCount: fence.abbreviatedName.length,
           insertText: fence.fullName,
         },

--- a/markdownlint/TOP006_fullFencedCodeLanguage/TOP006_fullFencedCodeLanguage.js
+++ b/markdownlint/TOP006_fullFencedCodeLanguage/TOP006_fullFencedCodeLanguage.js
@@ -2,7 +2,9 @@ const LANGUAGES_WITH_ABBREVIATIONS = new Map()
   .set("js", "javascript")
   .set("rb", "ruby")
   .set("txt", "text")
-  .set("md", "markdown");
+  .set("md", "markdown")
+  .set("sh", "bash")
+  .set("yml", "yaml");
 
 module.exports = {
   names: ["TOP006", "full-fenced-code-language"],

--- a/markdownlint/TOP006_fullFencedCodeLanguage/tests/TOP006_test.md
+++ b/markdownlint/TOP006_fullFencedCodeLanguage/tests/TOP006_test.md
@@ -26,12 +26,14 @@ console.log("This code block should flag an error as it uses "js" instead of "ja
 console.log("This code block is valid as it uses the appropriate full name.");
 ```
 
-```md
+```markdown
 The rule catches the following languages, as they are they ones expected to be seen in this repo's files
 md => markdown
 rb => ruby
 js => javascript
 txt => text
+sh => bash
+yml => yaml
 ```
 
 ```rb

--- a/markdownlint/TOP006_fullFencedCodeLanguage/tests/TOP006_test.md
+++ b/markdownlint/TOP006_fullFencedCodeLanguage/tests/TOP006_test.md
@@ -19,11 +19,11 @@ Valid div due to each tag being surrounded by blank lines.
 #### Custom section
 
 ```js
-console.log('This code block should flag an error as it uses "js" instead of "javascript".');
+console.log("This code block should flag an error as it uses "js" instead of "javascript".");
 ```
 
 ```javascript
-console.log('This code block is valid as it uses the appropriate full name.');
+console.log("This code block is valid as it uses the appropriate full name.");
 ```
 
 ```md
@@ -60,6 +60,12 @@ As does txt.
 ```jsx
 {isExempt && <p>No error here!</p>}
 ```
+
+````md
+```js
+console.log("Flags abbreviated names even with nested code blocks.");
+```
+````
 
 ### Knowledge check
 

--- a/markdownlint/TOP006_fullFencedCodeLanguage/tests/TOP006_test.md
+++ b/markdownlint/TOP006_fullFencedCodeLanguage/tests/TOP006_test.md
@@ -48,6 +48,22 @@ puts "Use the full name!"
 As does txt.
 ```
 
+```yml
+description: This will flag
+```
+
+```yaml
+description: Unless you use the full name
+```
+
+```sh
+prefer --bash-over-sh
+```
+
+```bash
+like --this
+```
+
 ```html
 <p>HTML is not considered as only the abbreviated name is a valid option.</p>
 <p>The same applies to similar languages like CSS and JSX.</p>

--- a/markdownlint/docs/TOP006.md
+++ b/markdownlint/docs/TOP006.md
@@ -12,9 +12,11 @@ In this repo, the expected languages for this to affect are:
 - `rb` => `ruby`
 - `md` => `markdown`
 - `txt` => `text`
+- `sh` => `bash`
+- `yml` => `yaml`
 
 Other languages that have abbreviated names, such as HTML and CSS, are not affected by this rule, as only the abbreviated forms are valid options.
 
 ## Rationale
 
-Alongside other rules such as code block delimiters, list styles, and blank lines, the purpose of this is to enforce consistency within and between our files.
+Alongside other rules such as code block delimiters, list styles, and blank lines, the purpose of this rule is to enforce consistency within and between our files.


### PR DESCRIPTION
## Because
As of #27511, `markdownlint` is now officially a repo dependency as so fixers will be required for any custom rules that would be appropriate to have fixers for (i.e. not context-based).

## This PR
- Adds fix info for TOP005 and TOP006, so that any of those rule errors can be fixed when running the `fix:lesson` npm script.
- Rewrites TOP006 function in order to allow nested code blocks to be flagged and fixed as necessary. The previous token-based approach would not allow this due to the way markdown-it parses fences.
- Adds `sh` and `yml` to the abbreviations map in TOP006.
- Updates TOP006 docs and test files to account for the new languages, and nested code block behaviour.

## Issue
N/A

## Additional Information


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
