### PR TITLE
Markdownlint: Add custom rule - TOP007 "Use Markdown Links"

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -87,6 +87,7 @@
     "./markdownlint/TOP003_defaultSectionContent/TOP003_defaultSectionContent.js",
     "./markdownlint/TOP004_lessonHeadings/TOP004_lessonHeadings.js",
     "./markdownlint/TOP005_blanksAroundMultilineHtmlTags/TOP005_blanksAroundMultilineHtmlTags.js",
-    "./markdownlint/TOP006_fullFencedCodeLanguage/TOP006_fullFencedCodeLanguage.js"
+    "./markdownlint/TOP006_fullFencedCodeLanguage/TOP006_fullFencedCodeLanguage.js",
+    "./markdownlint/TOP007_useMarkdownLinks/TOP007_useMarkdownLinks.js"
   ]
 }

--- a/markdownlint/TOP007_useMarkdownLinks/TOP007_useMarkdownLinks.js
+++ b/markdownlint/TOP007_useMarkdownLinks/TOP007_useMarkdownLinks.js
@@ -36,7 +36,7 @@ module.exports = {
       }
 
       // https://regexr.com/7v3bb to test this regex
-      const nonCodepenAnchorsWithHrefRegex = /<a\s[^>]*href=[^>]+>.+?<\/a>/g;
+      const nonCodepenAnchorsWithHrefRegex = /(?<!`)<a\s[^>]*href=[^>]+>.+?<\/a>(?!`)/g;
       const anchorsInCurrentLine = currentLine.match(nonCodepenAnchorsWithHrefRegex);
 
       anchorsInCurrentLine?.forEach((anchor) => {

--- a/markdownlint/TOP007_useMarkdownLinks/TOP007_useMarkdownLinks.js
+++ b/markdownlint/TOP007_useMarkdownLinks/TOP007_useMarkdownLinks.js
@@ -1,0 +1,74 @@
+function extractHref(link) {
+  // https://regexr.com/7v3ci to test this regex
+  return link.match(/(?<=href=("|'))[^"']+/)?.[0];
+}
+
+function extractLinkText(link) {
+  const textStart = link.indexOf(">") + 1;
+  const textEnd = link.lastIndexOf("<");
+  return link.substring(textStart, textEnd);
+}
+
+module.exports = {
+  names: ["TOP007", "use-markdown-links"],
+  description:
+    "Links used to navigate to external content or other landmarks in the page should use markdown links instead of HTML anchor tags.",
+  tags: ["links", "html"],
+  information: new URL(
+    "https://github.com/TheOdinProject/curriculum/blob/main/markdownlint/docs/TOP007.md"
+  ),
+  function: function TOP007(params, onError) {
+    const fencesLineRanges = params.tokens
+      .filter((token) => token.type === "fence")
+      .map((token) => token.map);
+
+    const isWithinFencedCodeBlock = (lineNumber) => {
+      return fencesLineRanges.some((range) => range[0] < lineNumber && lineNumber < range[1]);
+    };
+
+    const anchorsToFlag = params.lines.reduce((anchors, currentLine, index) => {
+      if (
+        !currentLine.includes("<a ") ||
+        !currentLine.includes("</a>") ||
+        isWithinFencedCodeBlock(index)
+      ) {
+        return anchors;
+      }
+
+      // https://regexr.com/7v3bb to test this regex
+      const nonCodepenAnchorsWithHrefRegex = /<a\s[^>]*href=[^>]+>.+?<\/a>/g;
+      const anchorsInCurrentLine = currentLine.match(nonCodepenAnchorsWithHrefRegex);
+
+      anchorsInCurrentLine?.forEach((anchor) => {
+        if (anchor.includes("codepen")) {
+          return;
+        }
+        anchors.push({
+          original: anchor,
+          href: extractHref(anchor),
+          text: extractLinkText(anchor),
+          length: anchor.length,
+          lineNumber: index + 1,
+          columnNumber: currentLine.indexOf(anchor) + 1,
+        });
+      });
+
+      return anchors;
+    }, []);
+
+    anchorsToFlag.forEach((anchor) => {
+      const replacementText = `[${anchor.text}](${anchor.href})`;
+
+      onError({
+        lineNumber: anchor.lineNumber,
+        detail: `\n  Expected: "${replacementText}"\n  Actual: "${anchor.original}"\n`,
+        fixInfo: {
+          lineNumber: anchor.lineNumber,
+          editColumn: anchor.columnNumber,
+          deleteCount: anchor.length,
+          insertText: replacementText,
+        },
+      });
+    });
+  },
+};

--- a/markdownlint/TOP007_useMarkdownLinks/tests/TOP007_test.md
+++ b/markdownlint/TOP007_useMarkdownLinks/tests/TOP007_test.md
@@ -39,6 +39,9 @@ on <a href="https://codepen.io">CodePen</a>.</span>
 
 </p>
 
+<!-- But will flag codepen anchors if they're not inside p.codepen -->
+<a href="https://codepen.io/TheOdinProjectExamples">@TheOdinProjectExamples</a>
+
 <script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
 
 ### Knowledge check

--- a/markdownlint/TOP007_useMarkdownLinks/tests/TOP007_test.md
+++ b/markdownlint/TOP007_useMarkdownLinks/tests/TOP007_test.md
@@ -24,8 +24,6 @@ Assignment section
 
 <a href="#custom-section">Will flag</a> if <a href="#assignment">multiple anchors</a> in same line.
 
-<a>Anchors without hrefs are ignored</a>
-
 `<a href="#custom-section">Anchors inside an inline code block are ignored</a>`
 
 ```html
@@ -47,7 +45,7 @@ on <a href="https://codepen.io">CodePen</a>.</span>
 
 The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
 
-- <a class="knowledge-check-link" href="#knowledge-check">Flags even if knowledge check with class</a>
+- <a class="knowledge-check-link" href="#knowledge-check">Flags with and omits non-href attributes</a>
 
 ### Additional resources
 

--- a/markdownlint/TOP007_useMarkdownLinks/tests/TOP007_test.md
+++ b/markdownlint/TOP007_useMarkdownLinks/tests/TOP007_test.md
@@ -1,0 +1,56 @@
+### Introduction
+
+This file should flag with TOP007 errors, and no other linting errors.
+
+### Lesson overview
+
+This section contains a general overview of topics that you will learn in this lesson.
+
+- LO item
+
+### Assignment
+
+<div class="lesson-content__panel" markdown="1">
+
+Assignment section
+
+</div>
+
+#### Custom section
+
+[Markdown links are desired in most cases](#custom-section)
+
+<a href="#custom-section">Link should flag as we should be using a markdown link instead</a>.
+
+<a href="#custom-section">Will flag</a> if <a href="#assignment">multiple anchors</a> in same line.
+
+<a>Anchors without hrefs are ignored</a>
+
+`<a href="#custom-section">Anchors inside an inline code block are ignored</a>`
+
+```html
+<a href="#custom-section">Anchors inside fenced code blocks are ignored</a>
+```
+
+<p class="codepen" data-height="400" data-default-tab="html,result" data-slug-hash="MWoyBzR" data-editable="true" data-user="TheOdinProjectExamples" style="height: 400px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;">
+
+<!-- Does not flag anchor tags for codepen embeds -->
+<span>See the Pen <a href="https://codepen.io/TheOdinProjectExamples/pen/MWoyBzR">
+flex-alignment example</a> by TheOdinProject (<a href="https://codepen.io/TheOdinProjectExamples">@TheOdinProjectExamples</a>)
+on <a href="https://codepen.io">CodePen</a>.</span>
+
+</p>
+
+<script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
+
+### Knowledge check
+
+The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
+
+- <a class="knowledge-check-link" href="#knowledge-check">Flags even if knowledge check with class</a>
+
+### Additional resources
+
+This section contains helpful links to related content. It isn't required, so consider it supplemental.
+
+- AR item

--- a/markdownlint/docs/TOP007.md
+++ b/markdownlint/docs/TOP007.md
@@ -29,7 +29,7 @@ The `knowledge-check-link` class is not longer required for knowledge check link
 ## Exceptions
 
 - Any anchors inside code blocks.
-- Any anchors with a Codepen href, as these are needed for Codepen embeds (alongside multiple other HTML elements).
+- Any anchors used for a codepen embed, as these do not require changing to markdown links.
 
 ## Rationale
 
@@ -39,4 +39,4 @@ Other linting rules also cannot be used on most anchors' text, due to the way ma
 
 Anchors will also not automatically include `target="_blank"` or `rel="noopener noreferrer"` unless they are manually included. Markdown links are automatically converted by the web app to anchors with both of those attributes.
 
-Anchors that are not used for this purpose (e.g. for Codepen embeds, no href, as code inside code blocks) do not require action.
+Anchors that are not used for this purpose (e.g. for Codepen embeds, as code inside code blocks etc.) do not require action.

--- a/markdownlint/docs/TOP007.md
+++ b/markdownlint/docs/TOP007.md
@@ -37,6 +37,6 @@ The `knowledge-check-link` class is not longer required for knowledge check link
 
 Other linting rules also cannot be used on most anchors' text, due to the way markdown parsers tokenize HTML elements when no blank lines are included (related to [TOP005 (Blanks around multiline HTML tags)](https://github.com/TheOdinProject/curriculum/blob/main/markdownlint/docs/TOP005.md)). `_` emphasis markers (which should be `*`) will not trigger errors.
 
-Anchors will also not automatically include `target="__blank"` or `rel="noopener noreferrer"` unless they are manually included. Markdown links are automatically converted by the web app to anchors with both of those attributes.
+Anchors will also not automatically include `target="_blank"` or `rel="noopener noreferrer"` unless they are manually included. Markdown links are automatically converted by the web app to anchors with both of those attributes.
 
 Anchors that are not used for this purpose (e.g. for Codepen embeds, no href, as code inside code blocks) do not require action.

--- a/markdownlint/docs/TOP007.md
+++ b/markdownlint/docs/TOP007.md
@@ -1,0 +1,40 @@
+# `TOP007` - Use markdown links
+
+Tags: `links`, `html`
+
+Aliases: `use-markdown-links`
+
+The rule is triggered when an anchor tag with an href attribute is used for a link **outside** of a code block (whether fenced or inline).
+
+These links should be written as markdown links instead of anchors.
+
+```markdown
+<!-- instead of an anchor -->
+<a href="https://www.theodinproject.com/">The Odin Project</a>
+
+<!-- use a markdown link -->
+[The Odin Project](https://www.theodinproject.com/)
+```
+
+The `knowledge-check-link` class is not longer required for knowledge check links.
+
+```markdown
+<!-- knowledge check items -->
+- <a class="knowledge-check-link" href="#link-here">Text</a>
+
+<!-- can be safely rewritten as markdown links without the class -->
+- [Text](#link-here)
+```
+
+## Exceptions
+
+- Any anchors inside code blocks.
+- Any anchors with a Codepen href, as these are needed for Codepen embeds (alongside multiple other HTML elements).
+
+## Rationale
+
+`markdownlint` is unable to lint HTML anchors with the same link-based rules as with markdown links. Therefore, anchors that would error with the [TOP001 (Descriptive link text)](https://github.com/TheOdinProject/curriculum/blob/main/markdownlint/docs/TOP001.md) rule would not error as an anchor. Converting to a markdown link will allow such rules to be used on it.
+
+Other linting rules also cannot be used on most anchors' text, due to the way markdown parsers tokenize HTML elements when no blank lines are included (related to [TOP005 (Blanks around multiline HTML tags)](https://github.com/TheOdinProject/curriculum/blob/main/markdownlint/docs/TOP005.md)). `_` emphasis markers (which should be `*`) will not trigger errors.
+
+Anchors that are not used for this purpose (e.g. for Codepen embeds, no href, as code inside code blocks) do not require action.

--- a/markdownlint/docs/TOP007.md
+++ b/markdownlint/docs/TOP007.md
@@ -37,4 +37,6 @@ The `knowledge-check-link` class is not longer required for knowledge check link
 
 Other linting rules also cannot be used on most anchors' text, due to the way markdown parsers tokenize HTML elements when no blank lines are included (related to [TOP005 (Blanks around multiline HTML tags)](https://github.com/TheOdinProject/curriculum/blob/main/markdownlint/docs/TOP005.md)). `_` emphasis markers (which should be `*`) will not trigger errors.
 
+Anchors will also not automatically include `target="__blank"` or `rel="noopener noreferrer"` unless they are manually included. Markdown links are automatically converted by the web app to anchors with both of those attributes.
+
 Anchors that are not used for this purpose (e.g. for Codepen embeds, no href, as code inside code blocks) do not require action.


### PR DESCRIPTION
## Because
The linter cannot operate on HTML anchors with link rules e.g. TOP001 (Descriptive link text). It requires links to be markdown links to do so. Markdown links also are automatically converted to anchors with `target="_blank" rel="noopener noreferrer"`, whereas raw anchor tags require these to be added manually, else they will not be included.

The [layout style guide enforces markdown links where appropriate](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md#use-markdown-links). Exceptions to this rule will include anchors for Codepen embeds, anchors without hrefs, and anchors inside any code blocks (fenced or inline). i.e. it only cares about links that are used with the intention of letting the user navigate to an external resource or a fragment on the page.

A common example of where anchors are used are in some lessons' knowledge check lists, as we used to require a `knowledge-check-link` class for these. Since the class is no longer required.


## This PR
- Adds TOP007 rule (with fix info), along with test and doc files
- Adds TOP007 rule file path to markdownlint config custom rules array

## Issue
Closes #27808

## Additional Information
Really annoying how anchors tokens are actually split across multiple tokens that make extracting and combining quite the hassle...yet again I had to resort to using regex on the raw text line by line :disappointed: 


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
