### PR TITLE
React testing: Correct codeblock language to jsx

### DIFF
--- a/react/react_testing/introduction_to_react_testing.md
+++ b/react/react_testing/introduction_to_react_testing.md
@@ -38,7 +38,7 @@ Now that we have everything we need, let's briefly go over what some of those pa
 
 First, we'll render the component using `render`. The API will return an object and we'll use destructuring syntax to obtain a subset of the methods required. You can read all about what `render` can do in [the React Testing Library API docs about render](https://testing-library.com/docs/react-testing-library/api/#render).
 
-```javascript
+```jsx
 // App.jsx
 
 const App = () => <h1>Our First Test</h1>;
@@ -46,7 +46,7 @@ const App = () => <h1>Our First Test</h1>;
 export default App;
 ```
 
-```javascript
+```jsx
 // App.test.jsx
 
 import { render, screen } from "@testing-library/react";
@@ -69,7 +69,7 @@ Execute `npm test App.test.jsx` on the terminal and see the test pass. `getByRol
 
 There are numerous ways a user can interact with a webpage. Even though live user feedback and interaction is irreplaceable, we can still build some confidence in our components through tests. Here's a button which changes the heading of the App:
 
-```javascript
+```jsx
 // App.jsx
 
 import React, { useState } from "react";
@@ -96,7 +96,7 @@ export default App;
 
 Let's test if the button works as intended. In this test suite, we'll use a separate utility to query our UI elements. React Testing Library provides the `screen` object which has all the methods for querying. With `screen`, we don't have to worry about keeping `render`'s destructuring up-to-date. Hence, it's better to use `screen` to access queries rather than to destructure `render`.
 
-```javascript
+```jsx
 // App.test.jsx
 
 import { render, screen } from "@testing-library/react";
@@ -131,7 +131,7 @@ It's also important to note that after every test, React Testing Library unmount
 
 Snapshot testing is just comparing our rendered component with an associated snapshot file. For example, the snapshot file which was automatically generated after we ran the *"magnificent monkeys renders"* test was:
 
-```javascript
+```jsx
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`App component > renders magnificent monkeys 1`] = `


### PR DESCRIPTION
## Because
The language was incorrectly specified as JS instead of JSX


## This PR
changes the language


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
