### PR TITLE
Git basics: Make warning into warning box

### DIFF
--- a/git/foundations_git/git_basics.md
+++ b/git/foundations_git/git_basics.md
@@ -24,7 +24,7 @@ This section contains a general overview of topics that you will learn in this l
 
 #### Create the repository
 
-1. <span id="new-github-repo"></span>You should have already created a GitHub account in the [Setting Up Git](https://www.theodinproject.com/lessons/foundations-setting-up-git) lesson. 
+1. <span id="new-github-repo"></span>You should have already created a GitHub account in the [Setting Up Git](https://www.theodinproject.com/lessons/foundations-setting-up-git) lesson.
 
 1. Create a new repository by clicking the button shown in the screenshot below.
 

--- a/git/foundations_git/git_basics.md
+++ b/git/foundations_git/git_basics.md
@@ -130,6 +130,8 @@ Finally, let's upload your work to the GitHub repository you created at the star
 
 <div class="lesson-note lesson-note--warning" markdown="1">
 
+#### Avoid editing directly on GitHub
+
 When trying to make quick changes to the files in your repo, such as attempting to fix a typo in your README.md you might be tempted to make this change directly via Github. However, it is best to avoid this as it will cause issues that require more advanced Git knowledge than we want to go over at this stage (it is covered in a future lesson), for now it is advised to make any changes via your local files then commit and push them using Git commands in your terminal once ready.
 
 </div>

--- a/git/foundations_git/git_basics.md
+++ b/git/foundations_git/git_basics.md
@@ -128,9 +128,11 @@ Finally, let's upload your work to the GitHub repository you created at the star
 
 </div>
 
-#### Note/Warning
+<div class="lesson-note lesson-note--warning" markdown="1">
 
 When trying to make quick changes to the files in your repo, such as attempting to fix a typo in your README.md you might be tempted to make this change directly via Github. However, it is best to avoid this as it will cause issues that require more advanced Git knowledge than we want to go over at this stage (it is covered in a future lesson), for now it is advised to make any changes via your local files then commit and push them using Git commands in your terminal once ready.
+
+</div>
 
 #### Cheatsheet
 


### PR DESCRIPTION
## Because
There has been a warning here since 2022, I think it predates this part of the style guide. It also wouldn't hurt to draw more attention to this point, since diverging histories is every second problem in the git-help channel in discord


## This PR
Puts a warning box around the warning


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
