### PR TITLE
JavaScript lessons: Add descriptive link text

### DIFF
--- a/javascript/introduction/a_quick_review.md
+++ b/javascript/introduction/a_quick_review.md
@@ -16,7 +16,7 @@ It might also be a good idea to do a little practicing before moving on. If you 
 
 Before you press on, a note about jQuery. We occasionally get questions about why we don't include jQuery in our curriculum. jQuery was very popular in the past, but has fallen out of the limelight in recent years. One of the biggest reasons it has begun to fall out of favor is that you don't _need_ it anymore. When it became popular, doing things like DOM manipulation and AJAX calls were difficult in plain JavaScript, but that is no longer the case.
 
-A quick web-search on the topic will be more useful than any explanations here, and if you still want to learn it (many older codebases still use it, and you will see it on many older Stack Overflow posts) we are confident that you can pick it up quite easily by reading the documentation on [their website](https://jquery.com/).
+A quick web-search on the topic will be more useful than any explanations here, and if you still want to learn it (many older codebases still use it, and you will see it on many older Stack Overflow posts) we are confident that you can pick it up quite easily by reading the [jQuery documentation](https://jquery.com/).
 
 ### Additional resources
 

--- a/javascript/introduction/a_quick_review.md
+++ b/javascript/introduction/a_quick_review.md
@@ -15,7 +15,7 @@ It might also be a good idea to do a little practicing before moving on. If you 
 
 ### jQuery?
 
-Before you press on, a note about jQuery. We occasionally get questions about why we don't include jQuery in our curriculum. jQuery was very popular in the past, but has fallen out of the limelight in recent years. One of the biggest reasons it has begun to fall out of favor is that you don't _need_ it anymore. When it became popular, doing things like DOM manipulation and AJAX calls were difficult in plain JavaScript, but that is no longer the case.
+Before you press on, a note about jQuery. We occasionally get questions about why we don't include jQuery in our curriculum. jQuery was very popular in the past, but has fallen out of the limelight in recent years. One of the biggest reasons it has begun to fall out of favor is that you don't *need* it anymore. When it became popular, doing things like DOM manipulation and AJAX calls were difficult in plain JavaScript, but that is no longer the case.
 
 A quick web-search on the topic will be more useful than any explanations here, and if you still want to learn it (many older codebases still use it, and you will see it on many older Stack Overflow posts) we are confident that you can pick it up quite easily by reading the [jQuery documentation](https://jquery.com/).
 

--- a/javascript/introduction/a_quick_review.md
+++ b/javascript/introduction/a_quick_review.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable TOP004 -->
 ### Introduction
 
 This course assumes that you have a decent grasp on the fundamentals of JavaScript. If you just finished our [Foundations course](https://theodinproject.com/paths/foundations) then you should skip this review and move on to the next lesson. If it's been a while and you're coming from the Ruby courses, you will probably want to take a day or two to refresh yourself on the basics.

--- a/javascript/organizing_your_javascript_code/factory_functions_and_module_pattern.md
+++ b/javascript/organizing_your_javascript_code/factory_functions_and_module_pattern.md
@@ -263,9 +263,8 @@ Take the calculator example into consideration. It's very easy to imagine a scen
 <div class="lesson-content__panel" markdown="1">
 
 1. WesBos has a beautiful and in-depth section on scopes and closures. Please check out these sections under "Module 3 - The Tricky Bits":
-
-- [The article on scope](https://wesbos.com/javascript/03-the-tricky-bits/scope)
-- [The article on closures](https://wesbos.com/javascript/03-the-tricky-bits/closures)
+-    [The article on scope](https://wesbos.com/javascript/03-the-tricky-bits/scope)
+-    [The article on closures](https://wesbos.com/javascript/03-the-tricky-bits/closures)
 
 1. [Tarek Sherif's article discussing the problems with constructors](https://tsherif.wordpress.com/2013/08/04/constructors-are-bad-for-javascript/) goes into depth while suggesting factories as a solution.
 1. Read this article on [module pattern in JavaScript](https://dev.to/tomekbuszewski/module-pattern-in-javascript-56jm) by Tomek Buszewski.

--- a/javascript/organizing_your_javascript_code/factory_functions_and_module_pattern.md
+++ b/javascript/organizing_your_javascript_code/factory_functions_and_module_pattern.md
@@ -164,7 +164,7 @@ const [ zerothEle, firstEle ] = array;
 // to the elements in the 0th and 1st indices of the array
 ```
 
-[The MDN article](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) on destructuring has some great examples and should be a good read for this concept.
+The [MDN documentation on destructuring assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) has some great examples and should be a good read for this concept.
 
 </div>
 
@@ -267,7 +267,7 @@ Take the calculator example into consideration. It's very easy to imagine a scen
   - [The article on closures](https://wesbos.com/javascript/03-the-tricky-bits/closures)
 1. [Tarek Sherif's article discussing the problems with constructors](https://tsherif.wordpress.com/2013/08/04/constructors-are-bad-for-javascript/) goes into depth while suggesting factories as a solution.
 1. Read this article on [module pattern in JavaScript](https://dev.to/tomekbuszewski/module-pattern-in-javascript-56jm) by Tomek Buszewski.
-1. As an optional alternative, in case you prefer video lessons, [this YouTube series on module pattern](https://www.youtube.com/playlist?list=PLoYCgNOIyGABs-wDaaxChu82q_xQgUb4f) covers most of the content that we have discussed. Note that the videos include jQuery, but you don't need to understand the jQuery syntax since the focus is on the module pattern concept.
+1. As an optional alternative, in case you prefer video lessons, this [YouTube series on module pattern](https://www.youtube.com/playlist?list=PLoYCgNOIyGABs-wDaaxChu82q_xQgUb4f) covers most of the content that we have discussed. Note that the videos include jQuery, but you don't need to understand the jQuery syntax since the focus is on the module pattern concept.
 
 </div>
 
@@ -288,7 +288,7 @@ This section contains questions for you to check your understanding of this less
 
 This section contains helpful links to related content. It isn’t required, so consider it supplemental.
 
-- [This video explains closures with a good example.](https://www.youtube.com/watch?v=80O6L2Ez3GM)
-- [Here is an interactive scrim on factory functions.](https://scrimba.com/scrim/c2aaKzcV)
-- [This article discusses three different kinds of prototypal inheritance with some good examples](https://medium.com/javascript-scene/3-different-kinds-of-prototypal-inheritance-es6-edition-32d777fa16c9)
+- This video explains [a good example of closures](https://www.youtube.com/watch?v=80O6L2Ez3GM).
+- Here is an [interactive scrim on factory functions](https://scrimba.com/scrim/c2aaKzcV).
+- This article discusses [three different kinds of prototypal inheritance](https://medium.com/javascript-scene/3-different-kinds-of-prototypal-inheritance-es6-edition-32d777fa16c9) with some good examples.
 - [Learning JavaScript Design Patterns by Addy Osmani and Lydia Hallie](https://www.patterns.dev/)

--- a/javascript/organizing_your_javascript_code/factory_functions_and_module_pattern.md
+++ b/javascript/organizing_your_javascript_code/factory_functions_and_module_pattern.md
@@ -263,8 +263,8 @@ Take the calculator example into consideration. It's very easy to imagine a scen
 <div class="lesson-content__panel" markdown="1">
 
 1. WesBos has a beautiful and in-depth section on scopes and closures. Please check out these sections under "Module 3 - The Tricky Bits":
--    [The article on scope](https://wesbos.com/javascript/03-the-tricky-bits/scope)
--    [The article on closures](https://wesbos.com/javascript/03-the-tricky-bits/closures)
+   - [The article on scope](https://wesbos.com/javascript/03-the-tricky-bits/scope)
+   - [The article on closures](https://wesbos.com/javascript/03-the-tricky-bits/closures)
 
 1. [Tarek Sherif's article discussing the problems with constructors](https://tsherif.wordpress.com/2013/08/04/constructors-are-bad-for-javascript/) goes into depth while suggesting factories as a solution.
 1. Read this article on [module pattern in JavaScript](https://dev.to/tomekbuszewski/module-pattern-in-javascript-56jm) by Tomek Buszewski.

--- a/javascript/organizing_your_javascript_code/factory_functions_and_module_pattern.md
+++ b/javascript/organizing_your_javascript_code/factory_functions_and_module_pattern.md
@@ -76,7 +76,7 @@ console.log(add5(2)) // logs 7
 A lot going on, so let's break it down:
 
 1. The `makeAdding` function takes an argument, `firstNumber`, declares a constant `first` with the value of `firstNumber`, and returns another **function**.
-2. When an argument is passed to the returned function, which we have assigned to **add5**, it returns the result of adding up the number passed earlier to the number passed now (`first` to `second`).
+1. When an argument is passed to the returned function, which we have assigned to **add5**, it returns the result of adding up the number passed earlier to the number passed now (`first` to `second`).
 
 Now, while it may sound good at first glance, you may already be raising your eyebrows at the second statement. As we've learned, the `first` variable is scoped within the `makeAdding` function. When we declare and use `add5`, however, we're **outside** the `makeAdding` function. How does the `first` variable still exist, ready to be added when we pass an argument to the `add5` function? This is where we encounter the concept of closures.
 
@@ -263,8 +263,10 @@ Take the calculator example into consideration. It's very easy to imagine a scen
 <div class="lesson-content__panel" markdown="1">
 
 1. WesBos has a beautiful and in-depth section on scopes and closures. Please check out these sections under "Module 3 - The Tricky Bits":
-  - [The article on scope](https://wesbos.com/javascript/03-the-tricky-bits/scope)
-  - [The article on closures](https://wesbos.com/javascript/03-the-tricky-bits/closures)
+
+- [The article on scope](https://wesbos.com/javascript/03-the-tricky-bits/scope)
+- [The article on closures](https://wesbos.com/javascript/03-the-tricky-bits/closures)
+
 1. [Tarek Sherif's article discussing the problems with constructors](https://tsherif.wordpress.com/2013/08/04/constructors-are-bad-for-javascript/) goes into depth while suggesting factories as a solution.
 1. Read this article on [module pattern in JavaScript](https://dev.to/tomekbuszewski/module-pattern-in-javascript-56jm) by Tomek Buszewski.
 1. As an optional alternative, in case you prefer video lessons, this [YouTube series on module pattern](https://www.youtube.com/playlist?list=PLoYCgNOIyGABs-wDaaxChu82q_xQgUb4f) covers most of the content that we have discussed. Note that the videos include jQuery, but you don't need to understand the jQuery syntax since the focus is on the module pattern concept.
@@ -273,7 +275,7 @@ Take the calculator example into consideration. It's very easy to imagine a scen
 
 ### Knowledge check
 
-This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
+The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
 
 - [Explain how scope works in JavaScript.](https://wesbos.com/javascript-scoping)
 - [Explain what closures are and how they help in creating private variables.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures#closure)
@@ -286,7 +288,7 @@ This section contains questions for you to check your understanding of this less
 
 ### Additional resources
 
-This section contains helpful links to related content. It isn’t required, so consider it supplemental.
+This section contains helpful links to related content. It isn't required, so consider it supplemental.
 
 - This video explains [a good example of closures](https://www.youtube.com/watch?v=80O6L2Ez3GM).
 - Here is an [interactive scrim on factory functions](https://scrimba.com/scrim/c2aaKzcV).


### PR DESCRIPTION
## Because
Improves accessibility by making the links in the lessons "A Quick Review" and "Factory Functions and the Module Pattern" more descriptive.


## This PR
- Updates link text in "A Quick Review"
- Updates link texts in "Factory Functions and the Module Pattern"


## Issue
Related to #27819.

## Additional Information
N/A


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
