### PR TITLE
Authentication Basics: Change link address to mongoose documentation

### DIFF
--- a/nodeJS/authentication/authentication_basics.md
+++ b/nodeJS/authentication/authentication_basics.md
@@ -192,7 +192,7 @@ passport.deserializeUser(async (id, done) => {
 ```
 
 <div class="lesson-note" markdown="1">
-  `user.id` is a virtual getter provided by mongoose which returns the document's _id field cast to a string.  [Documentation](#strategy)
+  `user.id` is a virtual getter provided by mongoose which returns the document's _id field cast to a string.  [Documentation](https://mongoosejs.com/docs/guide.html#id)
 </div>
 
 When a session is created, passport.serializeUser will receive the user object found from a successful login and store its .id property in the session data. Upon some other request, if it finds a matching session for that request, passport.deserializeUser will retrieve the id we stored in the session data. We then use that id to query our database for the specified user, then done(null, user) attaches that user object to req.user. Now in the rest of the request, we have access to that user object via req.user.


### PR DESCRIPTION
I'm not 100% certain, but I **think** that this is meant to link to the mongoose documentation on id? Right now it just links back to an earlier portion of the lesson.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
From context, I'm guessing this is meant to link to mongoose documentation on the virtual ID field


## This PR

- Updates the link href to mongoose documentation on id, rather than strategy section of lesson.




## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [ x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x ] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [ x] The `Because` section summarizes the reason for this PR
-   [ x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x ] If this PR addresses an open issue, it is linked in the `Issue` section
-   x[ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
