### PR TITLE
Markdownlint TOP007 bug: Account for non-codepen closing </p> tags

### DIFF
--- a/markdownlint/TOP007_useMarkdownLinks/TOP007_useMarkdownLinks.js
+++ b/markdownlint/TOP007_useMarkdownLinks/TOP007_useMarkdownLinks.js
@@ -23,12 +23,14 @@ module.exports = {
       .map((token) => token.map);
 
     const codepenLineRanges = params.lines.reduce((lineRanges, currentLine, index) => {
-      const range = [];
       const lineNumber = index + 1;
-      if (currentLine.includes('class="codepen"')) {
-        range.push(lineNumber);
-        lineRanges.push(range);
-      } else if (currentLine.trim().startsWith("</p>")) {
+      const isCodepenOpeningTag = currentLine.includes('class="codepen"');
+      const isCodepenClosingTag =
+        currentLine.trim().startsWith("</p>") && lineRanges.at(-1)?.length < 2;
+
+      if (isCodepenOpeningTag) {
+        lineRanges.push([lineNumber]);
+      } else if (isCodepenClosingTag) {
         lineRanges.at(-1).push(lineNumber);
       }
 

--- a/markdownlint/TOP007_useMarkdownLinks/tests/TOP007_test.md
+++ b/markdownlint/TOP007_useMarkdownLinks/tests/TOP007_test.md
@@ -18,6 +18,12 @@ Assignment section
 
 #### Custom section
 
+```html
+<p>
+    The following  &lt;/p&gt; should be ignored by this rule as it does not belong to a codepen embed.
+</p>
+```
+
 [Markdown links are desired in most cases](#custom-section)
 
 <a href="#custom-section">Link should flag as we should be using a markdown link instead</a>.


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Was not accounting for `</p>` tags that weren't closing a codepen embed. Triggers a "can't read `push`" error for files where a `</p>` existed before a codepen embed, or if the lesson did not include codepen embeds.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Fixes bug by only acting upon `</p>` tags that close a codepen embed.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
