### PR TITLE
Markdownlint new rule: Custom replacement for MD048 - fenced codeblocks rule with fixer

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -66,10 +66,8 @@
       "style": "fenced"
     },
     // code-fence-style
-    // Enforces backticks for codeblocks
-    "MD048": {
-      "style": "backtick"
-    },
+    // Disabled because the TOP008 custom rule covers this
+    "MD048": false,
     // emphasis-style
     // Enforces asterisk syntax instead of underscore syntax
     "MD049": {
@@ -88,6 +86,7 @@
     "./markdownlint/TOP004_lessonHeadings/TOP004_lessonHeadings.js",
     "./markdownlint/TOP005_blanksAroundMultilineHtmlTags/TOP005_blanksAroundMultilineHtmlTags.js",
     "./markdownlint/TOP006_fullFencedCodeLanguage/TOP006_fullFencedCodeLanguage.js",
-    "./markdownlint/TOP007_useMarkdownLinks/TOP007_useMarkdownLinks.js"
+    "./markdownlint/TOP007_useMarkdownLinks/TOP007_useMarkdownLinks.js",
+    "./markdownlint/TOP008_useBackticksForFencedCodeBlocks/TOP008_useBackticksForFencedCodeBlocks.js"
   ]
 }

--- a/markdownlint/TOP008_useBackticksForFencedCodeBlocks/TOP008_useBackticksForFencedCodeBlocks.js
+++ b/markdownlint/TOP008_useBackticksForFencedCodeBlocks/TOP008_useBackticksForFencedCodeBlocks.js
@@ -1,0 +1,38 @@
+module.exports = {
+  names: ["TOP008", "use-backticks-for-fenced-code-blocks"],
+  description: "Fenced code blocks should use backticks instead of tildes",
+  tags: ["code"],
+  information: new URL(
+    "https://github.com/TheOdinProject/curriculum/blob/main/markdownlint/docs/TOP008.md"
+  ),
+  function: function TOP008(params, onError) {
+    const fencedCodeBlocks = params.lines.reduce((codeBlocks, currentLine, index) => {
+      if (currentLine.trim().startsWith("~~~")) {
+        codeBlocks.push({
+          lineNumber: index + 1,
+          text: currentLine.trim(),
+          tildeCount: currentLine.lastIndexOf("~") + 1,
+          startingColumn: currentLine.indexOf("~") + 1,
+        });
+      }
+
+      return codeBlocks;
+    }, []);
+
+    fencedCodeBlocks.forEach((codeBlock) => {
+      onError({
+        lineNumber: codeBlock.lineNumber,
+        detail: `Expected: "${"`".repeat(codeBlock.tildeCount)}"; Actual: "${"~".repeat(
+          codeBlock.tildeCount
+        )}"`,
+        context: codeBlock.text,
+        fixInfo: {
+          lineNumber: codeBlock.lineNumber,
+          editColumn: codeBlock.startingColumn,
+          deleteCount: codeBlock.tildeCount,
+          insertText: "`".repeat(codeBlock.tildeCount),
+        },
+      });
+    });
+  },
+};

--- a/markdownlint/TOP008_useBackticksForFencedCodeBlocks/TOP008_useBackticksForFencedCodeBlocks.js
+++ b/markdownlint/TOP008_useBackticksForFencedCodeBlocks/TOP008_useBackticksForFencedCodeBlocks.js
@@ -7,11 +7,13 @@ module.exports = {
   ),
   function: function TOP008(params, onError) {
     const fencedCodeBlocks = params.lines.reduce((codeBlocks, currentLine, index) => {
-      if (currentLine.trim().startsWith("~~~")) {
+      const trimmedLine = currentLine.trim();
+
+      if (trimmedLine.startsWith("~~~")) {
         codeBlocks.push({
           lineNumber: index + 1,
-          text: currentLine.trim(),
-          tildeCount: currentLine.lastIndexOf("~") + 1,
+          text: currentLine,
+          tildeCount: trimmedLine.lastIndexOf("~") + 1,
           startingColumn: currentLine.indexOf("~") + 1,
         });
       }
@@ -20,9 +22,11 @@ module.exports = {
     }, []);
 
     fencedCodeBlocks.forEach((codeBlock) => {
+      const backtickReplacement = "`".repeat(codeBlock.tildeCount);
+
       onError({
         lineNumber: codeBlock.lineNumber,
-        detail: `Expected: "${"`".repeat(codeBlock.tildeCount)}"; Actual: "${"~".repeat(
+        detail: `Expected: "${backtickReplacement}"; Actual: "${"~".repeat(
           codeBlock.tildeCount
         )}"`,
         context: codeBlock.text,
@@ -30,7 +34,7 @@ module.exports = {
           lineNumber: codeBlock.lineNumber,
           editColumn: codeBlock.startingColumn,
           deleteCount: codeBlock.tildeCount,
-          insertText: "`".repeat(codeBlock.tildeCount),
+          insertText: backtickReplacement,
         },
       });
     });

--- a/markdownlint/TOP008_useBackticksForFencedCodeBlocks/tests/TOP008_test.md
+++ b/markdownlint/TOP008_useBackticksForFencedCodeBlocks/tests/TOP008_test.md
@@ -1,0 +1,51 @@
+### Introduction
+
+This file should flag with TOP008 errors, and no other linting errors.
+
+### Lesson overview
+
+This section contains a general overview of topics that you will learn in this lesson.
+
+- LO item
+
+### Assignment
+
+<div class="lesson-content__panel" markdown="1">
+
+Assignment section
+
+</div>
+
+#### Custom section
+
+~~~text
+This codeblock should flag an error as it uses tildes instead of backticks.
+~~~
+
+~~~~md
+~~~text
+Parent and nested code blocks should both individually flag if tildes are used instead of backticks.
+~~~
+~~~~
+
+```text
+Backticks are valid and will not flag errors.
+```
+
+````markdown
+```text
+As will backticked parent and nested code blocks.
+```
+````
+
+### Knowledge check
+
+The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
+
+- KC item
+
+### Additional resources
+
+This section contains helpful links to related content. It isn't required, so consider it supplemental.
+
+- AR item

--- a/markdownlint/TOP008_useBackticksForFencedCodeBlocks/tests/TOP008_test.md
+++ b/markdownlint/TOP008_useBackticksForFencedCodeBlocks/tests/TOP008_test.md
@@ -22,11 +22,17 @@ Assignment section
 This codeblock should flag an error as it uses tildes instead of backticks.
 ~~~
 
-~~~~md
+~~~~markdown
 ~~~text
 Parent and nested code blocks should both individually flag if tildes are used instead of backticks.
 ~~~
 ~~~~
+
+1. List item
+
+   ~~~text
+   Indented code blocks are treated all the same.
+   ~~~
 
 ```text
 Backticks are valid and will not flag errors.

--- a/markdownlint/docs/TOP008.md
+++ b/markdownlint/docs/TOP008.md
@@ -1,0 +1,23 @@
+# `TOP008` - Use backticks for fenced code blocks
+
+Tags: `code`
+
+Aliases: `use-backticks-for-fenced-code-blocks`
+
+This rule is triggered when a fenced code block uses tildes (`~`) as its delimiters instead of backticks (`` ` ``). The rule applies regardless of whether three or four tildes are used.
+
+````markdown
+~~~text
+This fenced code block uses tildes, which will flag an error
+~~~
+
+```text
+You should use backticks instead
+```
+````
+
+## Rationale
+
+Consistent formatting makes it easier to understand a document.
+
+Markdown lint's [MD048 rule](https://github.com/DavidAnson/markdownlint/blob/main/doc/md048.md) already covers this check, but does not include fix information, therefore can only be used to raise errors for manual fixing. This custom rule enforces the same style but includes fix information that can be used alongside our fix scripts.


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Markdownlint's [built-in MD048 rule](https://github.com/DavidAnson/markdownlint/blob/main/doc/md048.md) for fenced code block style does not include fix information, so will require manual fixing. It would be more straightforward for us to disable the built-in and use a custom rule to enforce the same style and provide a custom fixer for our fix scripts.


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds a custom version of the MD048 built-in, with fix info
- Adds appropriate test and doc files
- Appends custom rule to markdownlint config custom rules array
- Disables the built-in MD048 rule


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
N/A

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
~~Discovered through this, TOP006 will need amending to account for `~` code blocks as well. Currently it only recognises `` ` `` code blocks, so something like `~~~md` will be fixed to `` ```md `` instead of `` ```markdown ``. This will be handled in a separate PR.~~ Fixed in #27916



## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
