### PR TITLE
Markdownlint TOP006: Fix bug not recognising tilde delimiters or indented blocks

### DIFF
--- a/markdownlint/TOP006_fullFencedCodeLanguage/TOP006_fullFencedCodeLanguage.js
+++ b/markdownlint/TOP006_fullFencedCodeLanguage/TOP006_fullFencedCodeLanguage.js
@@ -23,13 +23,13 @@ module.exports = {
       }
 
       const fenceDelimiter = currentLine.trim()[0];
-      const delimiterCount = currentLine.lastIndexOf(fenceDelimiter) + 1;
-      const language = currentLine.substring(delimiterCount);
+      const delimiterEndColumn = currentLine.lastIndexOf(fenceDelimiter) + 1;
+      const language = currentLine.substring(delimiterEndColumn);
 
       if (LANGUAGES_WITH_ABBREVIATIONS.has(language)) {
         fences.push({
           text: currentLine,
-          delimiterCount: delimiterCount,
+          languageStartingColumn: delimiterEndColumn + 1,
           abbreviatedName: language,
           fullName: LANGUAGES_WITH_ABBREVIATIONS.get(language),
           lineNumber: index + 1,
@@ -44,7 +44,7 @@ module.exports = {
         detail: `Expected: ${fence.fullName}; Actual: ${fence.abbreviatedName} `,
         context: fence.text,
         fixInfo: {
-          editColumn: fence.delimiterCount + 1,
+          editColumn: fence.languageStartingColumn,
           deleteCount: fence.abbreviatedName.length,
           insertText: fence.fullName,
         },

--- a/markdownlint/TOP006_fullFencedCodeLanguage/TOP006_fullFencedCodeLanguage.js
+++ b/markdownlint/TOP006_fullFencedCodeLanguage/TOP006_fullFencedCodeLanguage.js
@@ -17,18 +17,19 @@ module.exports = {
   function: function TOP006(params, onError) {
     const fencesWithAbbreviatedName = params.lines.reduce((fences, currentLine, index) => {
       // https://regexr.com/7v119 to test the following regex:
-      const fenceWithLanguageRegex = /^`{3,4}[^`]+$/;
-      if (!fenceWithLanguageRegex.test(currentLine)) {
+      const fenceWithLanguageRegex = /^[`~]{3,4}[^`~]+$/;
+      if (!fenceWithLanguageRegex.test(currentLine.trim())) {
         return fences;
       }
 
-      const backtickCount = currentLine.lastIndexOf("`") + 1;
-      const language = currentLine.substring(backtickCount);
+      const fenceDelimiter = currentLine.trim()[0];
+      const delimiterCount = currentLine.lastIndexOf(fenceDelimiter) + 1;
+      const language = currentLine.substring(delimiterCount);
 
       if (LANGUAGES_WITH_ABBREVIATIONS.has(language)) {
         fences.push({
           text: currentLine,
-          backtickCount: backtickCount,
+          delimiterCount: delimiterCount,
           abbreviatedName: language,
           fullName: LANGUAGES_WITH_ABBREVIATIONS.get(language),
           lineNumber: index + 1,
@@ -43,7 +44,7 @@ module.exports = {
         detail: `Expected: ${fence.fullName}; Actual: ${fence.abbreviatedName} `,
         context: fence.text,
         fixInfo: {
-          editColumn: fence.backtickCount + 1,
+          editColumn: fence.delimiterCount + 1,
           deleteCount: fence.abbreviatedName.length,
           insertText: fence.fullName,
         },

--- a/markdownlint/TOP006_fullFencedCodeLanguage/tests/TOP006_test.md
+++ b/markdownlint/TOP006_fullFencedCodeLanguage/tests/TOP006_test.md
@@ -22,6 +22,10 @@ Valid div due to each tag being surrounded by blank lines.
 console.log("This code block should flag an error as it uses "js" instead of "javascript".");
 ```
 
+~~~js
+console.log("The rule will still flag even if tilde delimiters are used");
+~~~
+
 ```javascript
 console.log("This code block is valid as it uses the appropriate full name.");
 ```
@@ -84,6 +88,12 @@ like --this
 console.log("Flags abbreviated names even with nested code blocks.");
 ```
 ````
+
+1. List item
+
+   ```js
+   console.log("Flags abbreviated names even with indented code blocks.");
+   ```
 
 ### Knowledge check
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Tilde delimiters need to be recognised as well as backticks, else the fixer in #27915's custom rule will only fix the code block delimiters but not an abbreviated name.
e.g. `~~~md` will be fixed to `` ```md `` instead of `` ```markdown ``.

With this bug fix, the new delimiter custom rule will result int `~~~md` being fixed to `` ```markdown ``.

The rule was also not accounting for indented fenced code blocks.


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Makes TOP006 account for tilde code blocks
- Makes TOP006 account for indented code blocks
- Adds a `~~~js` example and indented code block example to the TOP006_test file
- Amends https://regexr.com/7v119 to account for the new Regex, including new tests

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
N/A

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
The TOP006 test file includes a single MD048 error on line 25, but #27915 will disable MD048, so it shouldn't be an issue once that's done.


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
