### PR TITLE
Websockets and Actioncable: Remove unnecessary word in actioncable_lesson.md

### DIFF
--- a/ruby_on_rails/mailers_advanced_topics/actioncable_lesson.md
+++ b/ruby_on_rails/mailers_advanced_topics/actioncable_lesson.md
@@ -340,7 +340,7 @@ And then
 bundle exec rails db:migrate
 ~~~
 
-Next we need a controller to for our messages. We only need a create action since we aren't doing anything else with them
+Next we need a controller for our messages. We only need a create action since we aren't doing anything else with them
 
 ~~~bash
 bundle exec rails generate controller messages


### PR DESCRIPTION
Removed the word "to" that grammatically did not make sense from line 343.

## Because
The line contained an additional word that did not make sense.


## This PR

- The word "to" in this sentence does not belong and should be removed: "Next we need a controller **to** for our messages."


## Issue
No currently open issue.

## Additional Information
None applicable.


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
