### PR TITLE
Linting: Update instructions for ESLint v9

### DIFF
--- a/javascript/javascript_in_the_real_world/linting.md
+++ b/javascript/javascript_in_the_real_world/linting.md
@@ -28,6 +28,8 @@ The style guides we mentioned above are full of really helpful advice for format
 There are multiple options for linting your JavaScript, but the most popular (and most common in the industry) is [ESLint](https://eslint.org/). Getting it installed and the initial set-up is straightforward.
 
 1. [The official 'Getting Started' page](https://eslint.org/docs/user-guide/getting-started) is a good place to start. It covers installation and basic setup. The basic way to use this tool is to run the `eslint` command in your terminal with a specific file.
+    - You may also want to look at the [docs on configuring ESLint](https://eslint.org/docs/latest/use/configure/) for a list of options that you can change.
+
 1. There is an [ESLint extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) with which you can get automatic lint highlighting for your files as you write, without you needing to rerun the `eslint` command every time. If your project also contains an ESLint configuration file, the extension will automatically use those rules for that project.
 
 <div class="lesson-note lesson-note--tip" markdown="1">

--- a/javascript/javascript_in_the_real_world/linting.md
+++ b/javascript/javascript_in_the_real_world/linting.md
@@ -25,10 +25,18 @@ The style guides we mentioned above are full of really helpful advice for format
 1. This article on [JavaScript linters](https://gomakethings.com/javascript-linters/) gets right to the point... start here!
 1. Read this article that [goes a little further](https://hackernoon.com/how-linting-and-eslint-improve-code-quality-fa83d2469efe) by discussing exactly *how* linters do what they do.
 
-There are multiple options for linting your JavaScript, but the most popular (and most common in the industry) is [eslint](https://eslint.org/). Getting it installed and the initial set-up is straightforward.
+There are multiple options for linting your JavaScript, but the most popular (and most common in the industry) is [ESLint](https://eslint.org/). Getting it installed and the initial set-up is straightforward.
 
 1. [The official 'Getting Started' page](https://eslint.org/docs/user-guide/getting-started) is a good place to start. It covers installation and basic setup. The basic way to use this tool is to run the `eslint` command in your terminal with a specific file.
-1. There is an [ESLint extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) which can lint your files as you write, without you needing to rerun the `eslint` command every time. If your project also contains an ESLint configuration file, the extension will automatically use those rules for that project. Here is a [tutorial on using the ESLint extension in Visual Studio Code](https://www.digitalocean.com/community/tutorials/linting-and-formatting-with-eslint-in-vs-code).
+1. There is an [ESLint extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) with which you can get automatic lint highlighting for your files as you write, without you needing to rerun the `eslint` command every time. If your project also contains an ESLint configuration file, the extension will automatically use those rules for that project.
+
+<div class="lesson-note lesson-note--tip" markdown="1">
+
+#### A note if your ESLint config is not loading
+
+The current version of the extension (2.4.4) will only pick up the workspace folder's ESLint config file, and not a config file for a subdirectory of that workspace. Switching to the pre-release version solves this.
+
+</div>
 
 ### Prettier
 
@@ -42,9 +50,7 @@ Using prettier makes coding faster and easier! You don't have to worry about nai
 
 ### Using ESLint and Prettier
 
-We **highly** recommend that you install ESlint and Prettier and use them for all future projects. It will make your code easier to read, both for yourself and for anyone else looking at it.
-However, using ESLint and Prettier together causes conflicts. To fix that follow the instructions to install [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier#installation). It turns off all ESLint rules that are unnecessary or might conflict with Prettier. Doing just this is enough to resolve the conflict and get them both working smoothly with one another.
-Another way to address the conflict is to use `eslint-plugin-prettier`. It lets you run Prettier as if it were a rule in ESLint. However, [using `eslint-plugin-prettier` is not recommended](https://prettier.io/docs/en/integrating-with-linters.html#notes).
+We **highly** recommend that you install ESlint and Prettier and use them for all future projects. It will make your code easier to read, both for yourself and for anyone else looking at it. There is no special setup needed apart from installing both of them.
 
 ### Template repositories
 

--- a/javascript/javascript_in_the_real_world/linting.md
+++ b/javascript/javascript_in_the_real_world/linting.md
@@ -23,7 +23,7 @@ Code style is important! Having a consistent set of style rules for things such 
 The style guides we mentioned above are full of really helpful advice for formatting, organizing and composing your code. But there are a *lot* of rules - it can be difficult to internalize them all. **Linters** are tools that will scan your code with a set of style rules and will report any errors to you that they find. In some cases, they can even auto-fix the errors! The following articles explain in more detail the benefits of using a linter while you code.
 
 1. This article on [JavaScript linters](https://gomakethings.com/javascript-linters/) gets right to the point... start here!
-1. Read this article that [goes a little further](https://hackernoon.com/how-linting-and-eslint-improve-code-quality-fa83d2469efe) by discussing exactly *how* linters do what they do.
+1. Read this article that goes a little further by discussing exactly [*how* linters do what they do](https://hackernoon.com/how-linting-and-eslint-improve-code-quality-fa83d2469efe).
 
 There are multiple options for linting your JavaScript, but the most popular (and most common in the industry) is [ESLint](https://eslint.org/). Getting it installed and the initial set-up is straightforward.
 

--- a/javascript/javascript_in_the_real_world/linting.md
+++ b/javascript/javascript_in_the_real_world/linting.md
@@ -34,7 +34,7 @@ There are multiple options for linting your JavaScript, but the most popular (an
 
 #### A note if your ESLint config is not loading
 
-The current version of the extension (2.4.4) will only pick up the workspace folder's ESLint config file, and not a config file for a subdirectory of that workspace. Switching to the pre-release version solves this.
+The current version of the extension (2.4.4) will only pick up the workspace folder's ESLint config file, and not a config file for a subdirectory of that workspace. Switching to the pre-release version solves this. You will also need to enable `Eslint: Use Flat Config` in VSCode's settings.
 
 </div>
 


### PR DESCRIPTION
## Because
The recent ESLint V9 update made breaking changes to the default configuration file format, which resulted in the old instructions becoming out-of-date and some plugins to stop working with the new default format among other changes.


## This PR
- Corrects link text from eslint to ESLint
- Removes DigitalOcean tutorial for setting up ESLint extension as it's outdated and not needed anymore
- Adds a lesson note about the current version of ESLint not picking up configurations for workspace sub-directories and fixing that behaviour
- Removes instructions for making ESLint and Prettier work together, as they work out of the box now



## Issue

Closes #27818 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
