### PR TITLE
Command Line Basics lesson: Move "Assignment" Section

### DIFF
--- a/foundations/installations/command_line_basics.md
+++ b/foundations/installations/command_line_basics.md
@@ -44,40 +44,6 @@ You will be making heavy use of the command line throughout this curriculum, and
   This is a security feature to protect confidential information, like how password fields on websites use asterisks or dots. By not displaying the characters you write, the terminal keeps your password secure.
 
   You can still enter your password as normal and press Enter to submit it.
-</div>
-
-### Assignment
-
-<div class="lesson-content__panel" markdown="1">
-
-<div class="lesson-note" markdown="1">
-**Note for WSL2 users**: You will have to use the `wget` command along with the link given in the `Download files` section in order to have the zip file in your WSL2 installation (`wget https://swcarpentry.github.io/shell-novice/data/shell-lesson-data.zip`). You will also have to install unzip by using the command `sudo apt install unzip` and then `unzip shell-lesson-data.zip` to unzip the file. Keep in mind that throughout the course linked in the first step below, your terminal output may look slightly different to what is shown in the lessons. Anytime the course asks you to go to the Desktop, you will instead be going to the home directory which can be done by using the cd command (`cd ~`).
-</div>
-
-<div class="lesson-note lesson-note--warning" markdown=1>
-Many of these resources assume you're using a Mac or Linux environment. If you did our previous installation lesson, you should already have Linux installed in dual-boot or a virtual machine. Or, you might be using macOS. If you don't have macOS, or any official Ubuntu flavor installed, please return to the [Installations lesson](https://www.theodinproject.com/lessons/foundations-installations).
-</div>
-
-1. Visit [The Unix Shell](https://swcarpentry.github.io/shell-novice/) course designed by the Software Carpentry Foundation. There you will find a full complement of lessons on using the CLI, but for now just focus on completing the following lessons:
-
-   - [Download files](https://swcarpentry.github.io/shell-novice/#download-files) - only follow the instructions in this section, you don't need to install any software and can move onto the next bullet point in this list.
-   - [Introducing the Shell](https://swcarpentry.github.io/shell-novice/01-intro.html)
-   - [Navigating Files and Directories](https://swcarpentry.github.io/shell-novice/02-filedir.html)
-   - [Working With Files and Directories](https://swcarpentry.github.io/shell-novice/03-create.html)
-   - [Pipes and Filters](https://swcarpentry.github.io/shell-novice/04-pipefilter.html)
-
-1. With your newly discovered CLI super powers, practice creating a folder and a few files using the `mkdir`, `touch`, and `cd` commands introduced in the previous step. As an example, a basic website might have a main `index.html` file, a CSS stylesheet file called `style.css`, and a folder for `images`. Think about how you could create these files with the commands and put it into practice!
-
-1. Let's practice creating files and directories and deleting them! You'll need to enter the commands for the steps below in your terminal. If you can't recall how to open a terminal, scroll up for a reminder.
-
-    1. Create a new directory in your home directory with the name `test`.
-    1. Navigate to the `test` directory.
-    1. Create a new file called `test.txt`. *Hint: use the `touch` or `echo` command.*
-    1. Open your newly created file in VSCode and make some changes, save the file, and close it.
-    1. Navigate back out of the `test` directory.
-    1. Delete the `test` directory.
-
-    That's it---you're done with practice! If you commit to doing most things from the command line from here on out, these commands will become second nature to you. Moving and copying files is much more efficiently done through the command line, even if it feels like more of a hassle at this point.
 
 </div>
 
@@ -106,6 +72,45 @@ Third, there's a really handy shortcut for opening everything within a project d
 - **macOS**: Some setup is required. After installing VSCode, launch it any way you're comfortable with. Once it's running, open the Command Palette with <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>. In the little dialog that appears, type `shell command`. One of the choices that appears will be `Shell Command: Install 'code' command in PATH`. Select that option, and restart the terminal if you have it open.
 
 - **WSL2**: Opening up VSCode from the command line in WSL2 is just as easy as it is in Linux. Just enter `code` which will open VSCode in WSL2.
+
+### Assignment
+
+<div class="lesson-content__panel" markdown="1">
+
+<div class="lesson-note" markdown="1">
+
+**Note for WSL2 users**: You will have to use the `wget` command along with the link given in the `Download files` section in order to have the zip file in your WSL2 installation (`wget https://swcarpentry.github.io/shell-novice/data/shell-lesson-data.zip`). You will also have to install unzip by using the command `sudo apt install unzip` and then `unzip shell-lesson-data.zip` to unzip the file. Keep in mind that throughout the course linked in the first step below, your terminal output may look slightly different to what is shown in the lessons. Anytime the course asks you to go to the Desktop, you will instead be going to the home directory which can be done by using the cd command (`cd ~`).
+
+</div>
+
+<div class="lesson-note lesson-note--warning" markdown=1>
+
+Many of these resources assume you're using a Mac or Linux environment. If you did our previous installation lesson, you should already have Linux installed in dual-boot or a virtual machine. Or, you might be using macOS. If you don't have macOS, or any official Ubuntu flavor installed, please return to the [Installations lesson](https://www.theodinproject.com/lessons/foundations-installations).
+
+</div>
+
+1. Visit [The Unix Shell](https://swcarpentry.github.io/shell-novice/) course designed by the Software Carpentry Foundation. There you will find a full complement of lessons on using the CLI, but for now just focus on completing the following lessons:
+
+   - [Download files](https://swcarpentry.github.io/shell-novice/#download-files) - only follow the instructions in this section, you don't need to install any software and can move onto the next bullet point in this list.
+   - [Introducing the Shell](https://swcarpentry.github.io/shell-novice/01-intro.html)
+   - [Navigating Files and Directories](https://swcarpentry.github.io/shell-novice/02-filedir.html)
+   - [Working With Files and Directories](https://swcarpentry.github.io/shell-novice/03-create.html)
+   - [Pipes and Filters](https://swcarpentry.github.io/shell-novice/04-pipefilter.html)
+
+1. With your newly discovered CLI super powers, practice creating a folder and a few files using the `mkdir`, `touch`, and `cd` commands introduced in the previous step. As an example, a basic website might have a main `index.html` file, a CSS stylesheet file called `style.css`, and a folder for `images`. Think about how you could create these files with the commands and put it into practice!
+
+1. Let's practice creating files and directories and deleting them! You'll need to enter the commands for the steps below in your terminal. If you can't recall how to open a terminal, scroll up for a reminder.
+
+    1. Create a new directory in your home directory with the name `test`.
+    1. Navigate to the `test` directory.
+    1. Create a new file called `test.txt`. *Hint: use the `touch` or `echo` command.*
+    1. Open your newly created file in VSCode and make some changes, save the file, and close it.
+    1. Navigate back out of the `test` directory.
+    1. Delete the `test` directory.
+
+    That's it---you're done with practice! If you commit to doing most things from the command line from here on out, these commands will become second nature to you. Moving and copying files is much more efficiently done through the command line, even if it feels like more of a hassle at this point.
+
+</div>
 
 ### Knowledge check
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

After learning how to use the terminal you are given an assignment. One step of this assignment is to open a text file in the CLI with VSCode, though this is confusing as the assignment precedes the instructions for using the CLI in VSCode to open the file. 

## This PR

* Move "Assignment" section to be directly preceding the "Knowledge Check" section
* Fix linting standards violation 

## Issue

Closes #27941

## Pull Request Requirements

-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
