### PR TITLE
deployment: update Fly.io pricing info

### DIFF
--- a/nodeJS/express_and_mongoose/deployment.md
+++ b/nodeJS/express_and_mongoose/deployment.md
@@ -106,14 +106,6 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - The longevity of your free trial credit depends on how many resources you consume. More complex apps with more traffic may consume all free resources within a month, whereas simpler apps may last longer.
 - Requires a credit card
 
-##### Fly.io: Legacy Hobby Plan
-
-- If you were on the free Hobby plan at the time that the paid Hobby plan became the default for new users, your plan is now called the Legacy Hobby plan
-- You can host three apps for free before you need to start paying.
-- Requires a credit card.
-- Fly.io waives monthly invoices that total less than $5 USD. So, although it may look like
-  you are being charged, it's very unlikely that you will exceed $5 and actually have to pay.
-
 ##### Fly.io: Links
 
 - [Fly.io's homepage](https://fly.io/)

--- a/nodeJS/express_and_mongoose/deployment.md
+++ b/nodeJS/express_and_mongoose/deployment.md
@@ -96,15 +96,15 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 #### Fly.io
 
 - Fly.io uses a convenient CLI tool for deployment.
-- Pay for what you use with very reasonable rates. Each app should cost around $4 per month.
+- All plans include [free allowances](https://fly.io/docs/about/pricing/#free-allowances), additional resources are billed based on usage with very reasonable rates. Each app should cost around $4 per month.
 - $20 a month should be enough to host eight apps (including three apps for free).
 - Fly.io charges $0.15/GB of RootFS for machines stopped for 30 days.
 
 ##### Fly.io: Hobby Plan
 
-- New customers get a one-time $5 free trial credit to test Fly.io at no cost. After the credit has been used, you will be be automatically placed on the $5/month Hobby plan subscription
+- New customers get a one-time $5 free trial credit to test Fly.io at no cost. The free credit will only start being used after the free allowances are exceeded. After the credit has been used, you will be be automatically placed on the $5/month Hobby plan subscription.
 - The longevity of your free trial credit depends on how many resources you consume. More complex apps with more traffic may consume all free resources within a month, whereas simpler apps may last longer.
-- Requires a credit card
+- Requires a credit card.
 
 ##### Fly.io: Links
 

--- a/nodeJS/express_and_mongoose/deployment.md
+++ b/nodeJS/express_and_mongoose/deployment.md
@@ -100,8 +100,15 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - $20 a month should be enough to host eight apps (including three apps for free).
 - Fly.io charges $0.15/GB of RootFS for machines stopped for 30 days.
 
-##### Fly.io: Free Plan
+##### Fly.io: Hobby Plan
 
+- New customers get a one-time $5 free trial credit to test Fly.io at no cost. After the credit has been used, you will be be automatically placed on the $5/month Hobby plan subscription
+- The longevity of your free trial credit depends on how many resources you consume. More complex apps with more traffic may consume all free resources within a month, whereas simpler apps may last longer.
+- Requires a credit card
+
+##### Fly.io: Legacy Hobby Plan
+
+- If you were on the free Hobby plan at the time that the paid Hobby plan became the default for new users, your plan is now called the Legacy Hobby plan
 - You can host three apps for free before you need to start paying.
 - Requires a credit card.
 - Fly.io waives monthly invoices that total less than $5 USD. So, although it may look like
@@ -124,7 +131,7 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 ##### Railway.app: Free Plan
 
 - You get a free one-time grant of $5 on their free trial, and the applications are never put to sleep when inactive.
-- However, the longevity of your free allowance depends on how many resources you consume. More complex apps with more traffic may consume all free resources within a month, whereas simpler apps may last longer.
+- The longevity of your free allowance depends on how many resources you consume. More complex apps with more traffic may consume all free resources within a month, whereas simpler apps may last longer.
 
 ##### Railway.app: Links
 
@@ -241,7 +248,7 @@ This will be where the Git skills you've been learning will start to really pay 
 
 <div class="lesson-content__panel" markdown="1">
 
-1. Deploy your [Mini Message Board project](https://www.theodinproject.com/lessons/nodejs-mini-message-board) to one of the hosting providers we've mentioned. If you need help deciding which one to use, we recommend Fly.io. The important thing to take away from this first deployment is getting experience deploying. Don't worry if you don't understand everything that's happening. That will come with time.
+1. Deploy your [Mini Message Board project](https://www.theodinproject.com/lessons/nodejs-mini-message-board) to one of the hosting providers we've mentioned. Any of the free options will work for curriculum purposes, so it doesn't matter which you pick for your projects. The important thing to take away from this first deployment is getting experience deploying. Don't worry if you don't understand everything that's happening. That will come with time.
    - Use one of the linked deploy guides for your PaaS provider to help you through the process.
    - If you're having trouble deploying, check out the [Debugging and Troubleshooting Deployments](#debugging-and-troubleshooting-deployments) section for some tips.
    - If for some reason the deployment is still too difficult, and you just can't seem to get it to work, move onto the next project and come back once you've deployed your MDN project. The steps in their tutorial hold your hand a bit more through the process and will give you the confidence you need to deploy this project.

--- a/ruby_on_rails/rails_basics/deployment.md
+++ b/ruby_on_rails/rails_basics/deployment.md
@@ -93,15 +93,15 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 #### Fly.io
 
 - Fly.io uses a CLI tool for deployment.
-- Pay for what you use with very reasonable rates. Each app should cost around $4 per month.
+- All plans include [free allowances](https://fly.io/docs/about/pricing/#free-allowances), additional resources are billed based on usage with very reasonable rates. Each app should cost around $4 per month.
 - $20 a month should be enough to host eight apps (including three apps for free).
 - Fly.io charges $0.15/GB of RootFS for machines stopped for 30 days.
 
 ##### Fly.io: Hobby Plan
 
-- New customers get a one-time $5 free trial credit to test Fly.io at no cost. After the credit has been used, you will be be automatically placed on the $5/month Hobby plan subscription
+- New customers get a one-time $5 free trial credit to test Fly.io at no cost. The free credit will only start being used after the free allowances are exceeded. After the credit has been used, you will be be automatically placed on the $5/month Hobby plan subscription.
 - The longevity of your free trial credit depends on how many resources you consume. More complex apps with more traffic may consume all free resources within a month, whereas simpler apps may last longer.
-- Requires a credit card
+- Requires a credit card.
 
 ##### Fly.io: Links
 

--- a/ruby_on_rails/rails_basics/deployment.md
+++ b/ruby_on_rails/rails_basics/deployment.md
@@ -103,14 +103,6 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - The longevity of your free trial credit depends on how many resources you consume. More complex apps with more traffic may consume all free resources within a month, whereas simpler apps may last longer.
 - Requires a credit card
 
-##### Fly.io: Legacy Hobby Plan
-
-- If you were on the free Hobby plan at the time that the paid Hobby plan became the default for new users, your plan is now called the Legacy Hobby plan
-- You can host three apps for free before you need to start paying.
-- Requires a credit card.
-- Fly.io waives monthly invoices that total less than $5 USD. So, although it may look like
-  you are being charged, it's very unlikely that you will exceed $5 and actually have to pay.
-
 ##### Fly.io: Links
 
 - [Homepage](https://fly.io/)

--- a/ruby_on_rails/rails_basics/deployment.md
+++ b/ruby_on_rails/rails_basics/deployment.md
@@ -97,8 +97,15 @@ Whatever your circumstances, we've got you covered. Here are the PaaS providers 
 - $20 a month should be enough to host eight apps (including three apps for free).
 - Fly.io charges $0.15/GB of RootFS for machines stopped for 30 days.
 
-##### Fly.io: Free Plan
+##### Fly.io: Hobby Plan
 
+- New customers get a one-time $5 free trial credit to test Fly.io at no cost. After the credit has been used, you will be be automatically placed on the $5/month Hobby plan subscription
+- The longevity of your free trial credit depends on how many resources you consume. More complex apps with more traffic may consume all free resources within a month, whereas simpler apps may last longer.
+- Requires a credit card
+
+##### Fly.io: Legacy Hobby Plan
+
+- If you were on the free Hobby plan at the time that the paid Hobby plan became the default for new users, your plan is now called the Legacy Hobby plan
 - You can host three apps for free before you need to start paying.
 - Requires a credit card.
 - Fly.io waives monthly invoices that total less than $5 USD. So, although it may look like
@@ -224,7 +231,7 @@ This will be where the Git skills you've been learning will start to really pay 
 
 <div class="lesson-content__panel" markdown="1">
 
-1. Deploy your [Blog App project](https://www.theodinproject.com/lessons/ruby-on-rails-blog-app) to one of the hosting providers we've mentioned. If you need help deciding which one to use, we recommend Fly.io. The important thing to take away from this first deployment is getting experience deploying. Don't worry if you don't understand everything that's happening. That will come with time.
+1. Deploy your [Blog App project](https://www.theodinproject.com/lessons/ruby-on-rails-blog-app) to one of the hosting providers we've mentioned. Any of the free options will work for curriculum purposes, so it doesn't matter which you pick for your projects. The important thing to take away from this first deployment is getting experience deploying. Don't worry if you don't understand everything that's happening. That will come with time.
    - Use one of the linked deploy guides for your PaaS provider to help you through the process.
    - If you're having trouble deploying, check out the [Debugging and Troubleshooting Deployments](#debugging-and-troubleshooting-deployments) section for some tips.
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
- Fly.io pricing information was outdated

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Updates Fly.io pricing information
- Changes The Odin Project's recommendation to use Fly.io over other PaaS options to be more neutral

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #27895

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->

I left in the previous pricing information with some extra context, I figured the curriculum would primarily be viewed by new users, but in case someone did have a Fly.io account prior to these changes visited this page, the now "Legacy Hobby Plan" would apply to them. Let me know if this should just be removed instead.

After a brief discussion with @MaoShizhong on the issue, I have changed The Odin Project's recommendation to use Fly.io to be more neutral. Prior to this change, Fly.io seems to have been the only truly free deployment option (or at least had the possibility to be free so long as usage was under $5/month) which I believe warranted the recommendation. Now that it's not free and similar to other PaaS plans, I don't believe it necessarily stands above the rest anymore. Let me know if this should be reverted. (https://github.com/TheOdinProject/curriculum/issues/27895#issuecomment-2125921852)

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
