### PR TITLE
Fundamentals--JavaScriptBasics--javascript_developer_tools - Fixed Mac Dev Tool Shortcut

### DIFF
--- a/foundations/javascript_basics/javascript_developer_tools.md
+++ b/foundations/javascript_basics/javascript_developer_tools.md
@@ -25,7 +25,7 @@ There are three ways to open the Chrome DevTools menu:
 
 1. From the `Chrome Menu` > `More Tools` > `Developer Tools`
 1. Right-click anywhere on a webpage and select `Inspect`
-1. Use the keyboard shortcut <kbd>F12</kbd> or <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd> (Mac: <kbd>Opt</kbd> + <kbd>Cmd</kbd> + <kbd>C</kbd>)
+1. Use the keyboard shortcut <kbd>F12</kbd> or <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd> (Mac: <kbd>Opt</kbd> + <kbd>Cmd</kbd> + <kbd>J</kbd>)
 
 ### Assignment
 


### PR DESCRIPTION
## Because
The shortcut listed for Mac was Incorrect so I fixed it.

## This PR
cmd+ctrl+C was incorrect, updated to cmd+ctrl+J

## Issue
New

## Additional Information


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
