### PR TITLE
More Testing: Update Link Text 

### DIFF
--- a/javascript/testing_javascript/more_testing.md
+++ b/javascript/testing_javascript/more_testing.md
@@ -56,7 +56,7 @@ In this example, the only thing we really need to test is the `evaluateGuess` fu
 
 If we had written this program with TDD it is very likely that it would have looked more like the second example to begin with.  Test driven development encourages better program architecture because it encourages you to write _Pure Functions_.
 
-- Read [this quick article](https://medium.com/@jamesjefferyuk/javascript-what-are-pure-functions-4d4d5392d49c) about the value of 'Pure Functions'.
+- Read this quick article about [the value of "pure functions"](https://medium.com/@jamesjefferyuk/javascript-what-are-pure-functions-4d4d5392d49c).
 
 ### Mocking
 
@@ -65,11 +65,14 @@ There are two solutions to the 'tightly coupled code' problem.  The first, and b
 ### Assignment 
 
 <div class="lesson-content__panel" markdown="1">
-1. If you haven't already, watch the 'mocking' videos from [this series](https://www.youtube.com/watch?v=3PjdxjWK0F0).
-2. Too much mocking can be a bad thing.  It _is_ sometimes necessary, but if you have to set up an elaborate system of mocks to test any bit of your code, that means your code is too tightly coupled.  [This article](https://medium.com/javascript-scene/mocking-is-a-code-smell-944a70c90a6a) might be a little extreme, but it contains several really good points about program architecture and testing.
-3. Now that you have some practice and context for TDD, [this section](https://jestjs.io/docs/setup-teardown) of the Jest docs will probably make good sense to you.
-4. Jest includes some _really_ handy mocking functions.  Read about them in the [official docs](https://jestjs.io/docs/mock-functions).
-5. Watch [this amazing video](https://www.youtube.com/watch?v=URSWYvyc42M) that covers _what_ to test in your codebase.  The video is specifically about testing the Ruby language, but that doesn't matter _at all_.  The concepts here ring true in any language, and luckily Ruby is a clear enough language that you will be able to follow along just fine.
+
+1. If you haven’t already, watch [FunFunFunction's "Mocking Basics" video](https://www.youtube.com/watch?v=3PjdxjWK0F0).
+2. Too much mocking can be a bad thing.  It _is_ sometimes necessary, but if you have to set up an elaborate system of mocks to test any bit of your code, that means your code is too tightly coupled.  While it is quite in-depth, the following article contains several really good points about [program architecture and testing](https://medium.com/javascript-scene/mocking-is-a-code-smell-944a70c90a6a).
+3. Now that you have some practice and context for TDD, the [Jest docs section on "Setup and Teardown"](https://jestjs.io/docs/setup-teardown) will probably make good sense to you.
+4. Read about [Jest's really handy mocking functions](https://jestjs.io/docs/mock-functions).
+5. Watch this amazing video that covers [what to test in your codebase](https://www.youtube.com/watch?v=URSWYvyc42M).
+
+  The video is specifically about testing the Ruby language, but that doesn't matter _at all_.  The concepts here ring true in any language, and luckily Ruby is a clear enough language that you will be able to follow along just fine.
 </div>
 
 ### Knowledge check 

--- a/javascript/testing_javascript/testing_basics.md
+++ b/javascript/testing_javascript/testing_basics.md
@@ -20,7 +20,7 @@ This section contains a general overview of topics that you will learn in this l
 
 1. Read about the [basic process and the benefits of TDD](https://web.archive.org/web/20211123190134/http://godswillokwara.com/index.php/2016/09/09/the-importance-of-test-driven-development/).
 1. Watch at least the first 3 videos of [the Unit Testing in JavaScript video series](https://www.youtube.com/playlist?list=PL0zVEGEvSaeF_zoW9o66wa_UCNE3a7BEr). The first video focuses heavily on the WHY, while the next two go into more depth about the process.  We will cover the rest of the videos in our [More Testing](https://www.theodinproject.com/lessons/node-path-javascript-more-testing) lesson.
-1. Read and follow the [Getting Started](https://jestjs.io/docs/getting-started) tutorial on the main Jest website. For the upcoming testing practice and project, you only need to follow the instructions for installing jest.
+1. Follow along to [Jest's Getting Started tutorial](https://jestjs.io/docs/getting-started). For the upcoming testing practice and project, you only need to follow the instructions for installing jest.
 1. Read and follow the [Using Matchers](https://jestjs.io/docs/using-matchers) document on the main Jest website.  This one demonstrates some of the other useful functions you can use in your tests.
 1. This article explains more about [the why/how and value behind TDD](https://jrsinclair.com/articles/2016/one-weird-trick-that-will-change-the-way-you-code-forever-javascript-tdd/) and also includes some great examples of how to apply it.
 


### PR DESCRIPTION
## Because
Update the link text to be more concise. 

## This PR
**Pure Functions Section**
- Replace article link text on line 59

**Assignment Section**
- Replace link text on line 68(now line 69), adding a single blank line before the line
- Replace link text on lines 69, 70,  71 (now lines 70, 71, and 72, respectively) 
- Replace link text on line 72(now line 73) , adding a single blank line after the line 


## Issue
Related to #27819 

## Additional Information

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
