### PR TITLE
Setting up Git lesson: Add optional configuration steps for signed commits

### DIFF
--- a/foundations/installations/setting_up_git.md
+++ b/foundations/installations/setting_up_git.md
@@ -222,6 +222,15 @@ Follow the [GitHub directions for testing your SSH connection](https://docs.gith
 
 You should see this response in your terminal: **Hi username! You've successfully authenticated, but GitHub does not provide shell access.** Don't let GitHub's lack of providing shell access trouble you. If you see this message, you've successfully added your SSH key and you can move on. If the output doesn't correctly match up, then try going through these steps again or come to [the Discord chat](https://discord.gg/fbFCkYabZB) to ask for help.
 
+#### Step 2.6 (Optional)
+
+If you are using VScode and you want your commits to be signed (`-S`) while committing from the UI.
+Open Settings `Ctrl`+`,` by default, and search for “gpg”, check the “Enables commit signing with GPG” box.
+Alternatively you can add this line to your settings.json:
+```json
+"git.enableCommitSigning": true
+```
+
 ### Step 3: Let us know how it went!
 
 You've completed the basic installations section, good job! As you progress through the Paths there will be other tools to install, so keep an eye out!

--- a/foundations/installations/setting_up_git.md
+++ b/foundations/installations/setting_up_git.md
@@ -225,7 +225,9 @@ You should see this response in your terminal: **Hi username! You've successfull
 #### Step 2.6 (Optional)
 
 If you are using VScode and you want your commits to be signed (`-S`) while committing from the UI.
-Open Settings `Ctrl`+`,` by default, and search for “gpg”, check the “Enables commit signing with GPG” box.
+- Open Settings `Ctrl`+`,` by default
+- Search for “gpg”, check the “Enables commit signing with GPG” box.
+
 Alternatively you can add this line to your settings.json:
 ```json
 "git.enableCommitSigning": true


### PR DESCRIPTION
## Because
If you are committing from VScode UI, your commits would not be sign unless you add the configuration steps mentioned below. Regardless of the TOP focus for using git in the terminal, this should be mentioned. Won't hurt nobody.

## This PR
- Add configuration steps for adding `"git.enableCommitSigning": true` into VScode settings

## Pull Request Requirements

-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
