### PR TITLE
Project: Rock Paper Scissors: Change wording of JS link check step

### DIFF
--- a/foundations/javascript_basics/project_rock_paper_scissors.md
+++ b/foundations/javascript_basics/project_rock_paper_scissors.md
@@ -26,7 +26,7 @@ Remember to commit early and often! To refresh your memory, check out the [commi
 
 1. Create a new Git repository for your project.
 1. Create a blank HTML document with a script tag.
-1. Check if the webpage includes JavaScript:
+1. Check if JavaScript is linked correctly:
    - Write `console.log("Hello World")` in JavaScript.
    - Check if "Hello World" is logged in the browser console once you open your webpage.
 


### PR DESCRIPTION
## Because
The third bullet point in the first step in the Assignment section of the [Project: Rock Paper Scissors](https://www.theodinproject.com/lessons/foundations-rock-paper-scissors) lesson, was worded in a way that could lead to confusion: "Check if the webpage includes JavaScript", whilst the user is actually supposed to check if they've linked their JavaScript correctly.


## This PR

- Remove the previous step description, and add new description


## Issue

Closes #28083 


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
