### PR TITLE
Qualifying Job Leads: Fix link typo

### DIFF
--- a/getting_hired/applying_and_interviewing/qualify_leads.md
+++ b/getting_hired/applying_and_interviewing/qualify_leads.md
@@ -4,7 +4,7 @@ You should have the criteria that you use to evaluate a job already figured out 
 
 Next, make a column for the percentage likelihood of getting the job with a reasonable effort. Multiply this with the value of the job based on the previous step, sort by this new "expected value", and you should have an indication of which jobs are most worth your time.
 
-If the job happens to be with one of the many companies like Revature that offer to train you for free before contracting you out, read this [Hire Beware blog post about some warning signs for less-than-ideal opportunites](https://github.com/TheOdinProject/blog/blob/main/hire-beware.md). Part of the reason for qualifying the leads is to make sure you don't get sucked into a process and waste a bunch of time applying to jobs that you wouldn't actually take anyway. That's surprisingly easy. You'll still be able to send out "practice" applications, but at least now you know which companies are worth sending those out to.
+If the job happens to be with one of the many companies like Revature that offer to train you for free before contracting you out, read this [Hire Beware blog post about some warning signs for less-than-ideal opportunities](https://github.com/TheOdinProject/blog/blob/main/hire-beware.md). Part of the reason for qualifying the leads is to make sure you don't get sucked into a process and waste a bunch of time applying to jobs that you wouldn't actually take anyway. That's surprisingly easy. You'll still be able to send out "practice" applications, but at least now you know which companies are worth sending those out to.
 
 Some other criteria to think about in the "nice-to-have" column:
 


### PR DESCRIPTION
## Because
The word "opportunities" was written incorrectly in the link of the third paragraph in the [Qualifying Job Leads](https://www.theodinproject.com/lessons/node-path-getting-hired-qualifying-job-leads) lesson.


## This PR
-change "opportunites" into "opportunities"


## Issue
Closes #28098 


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
