### PR TITLE
Hash Map Lesson: Clarify fullness 

### DIFF
--- a/javascript/computer_science/hash_map_data_structure.md
+++ b/javascript/computer_science/hash_map_data_structure.md
@@ -174,9 +174,11 @@ Remember we don't want collisions. In a perfect world each bucket will either ha
 
 To deal with this, our hash map class needs to keep track of two new fields, the `capacity` and the `load factor`.
 
-- The `capacity` is the total number of buckets we currently have. Keeping track of this will let us know if our map has reached a certain threshold aka `load factor`,
+- The `capacity` is the total number of buckets we currently have.
 
-- The `load factor` is a number that we can assign our hash map to at the start. It's the factor that will determine when it is a good time to grow our buckets. For example, a load factor of `0.75` means our hash map will need to grow its buckets when the capacity reaches 75% full. Setting it too low will consume too much memory by having too many empty buckets, while setting it too high will allow our buckets to have many collisions before we grow them. Hash map implementations across various languages use a load factor between `0.75` and `1`.
+- The `load factor` is a number that we assign our hash map to at the start. It's the factor that will determine when it is a good time to grow our buckets. Hash map implementations across various languages use a load factor between `0.75` and `1`.
+
+The product of these two numbers gives us a number, and we know it's time to grow when there are more entries in the hash map than that number. For example, if there are `16` buckets, and the load factor is `0.8`, then we need to grow the buckets when there are more than `16 * 0.8 = 12.8` entries - which happens on the 13th entry. Setting it too low will consume too much memory by having too many empty buckets, while setting it too high will allow our buckets to have many collisions before we grow them.
 
 ### Computation complexity
 

--- a/ruby/computer_science/hash_map_data_structure.md
+++ b/ruby/computer_science/hash_map_data_structure.md
@@ -164,9 +164,11 @@ Remember we don't want collisions. In a perfect world each bucket will either ha
 
 To deal with this, our hash map class needs to keep track of two new fields, the `capacity` and the `load factor`.
 
-- The `capacity` is the total number of buckets we currently have. Keeping track of this will let us know if our map has reached a certain threshold aka `load factor`,
+- The `capacity` is the total number of buckets we currently have.
 
-- The `load factor` is a number that we can assign our hash map to at the start. It's the factor that will determine when it is a good time to grow our buckets. For example, a load factor of `0.75` means our hash map will need to grow its buckets when the capacity reaches 75% full. Setting it too low will consume too much memory by having too many empty buckets, while setting it too high will allow our buckets to have many collisions before we grow them. Hash map implementations across various languages use a load factor between `0.75` and `1`.
+- The `load factor` is a number that we assign our hash map to at the start. It's the factor that will determine when it is a good time to grow our buckets. Hash map implementations across various languages use a load factor between `0.75` and `1`.
+
+The product of these two numbers gives us a number, and we know it's time to grow when there are more entries in the hash map than that number. For example, if there are `16` buckets, and the load factor is `0.8`, then we need to grow the buckets when there are more than `16 * 0.8 = 12.8` entries - which happens on the 13th entry. Setting it too low will consume too much memory by having too many empty buckets, while setting it too high will allow our buckets to have many collisions before we grow them.
 
 ### Computation complexity
 

--- a/ruby/computer_science/hash_map_data_structure.md
+++ b/ruby/computer_science/hash_map_data_structure.md
@@ -27,7 +27,9 @@ There is a key difference between hashing and ciphering (encryption): reversibil
 Hashing is a one-way process. Using the above example, you can make a hash code from a name, but you cannot take a hash code and revert it back to a name. If you have a name `"Carlos"`, we can hash it to `"C"`. But it's impossible to reverse it from `"C"` back to its original form. You cannot know if it's `"Carlos"`, maybe it's `"Carla"` or `"Carrot"`. We don't know.
 
 <div class="lesson-note lesson-note--tip" markdown="1">
+
 Hashing is very good for security. Given a password, you can save the hash of that password rather than the password's plain text. If someone steals your hashes, they cannot know the original passwords since they are unable to reverse the hash back to the password.
+
 </div>
 
 #### Use cases
@@ -133,7 +135,9 @@ end
 With our new method we will have different hash codes for the names `"Sara"` and `"raSa"`. This is because even if both names have the same letters, some of the letters appear in different locations. The hash code started to change because we are multiplying the old hash with every new iteration and then adding the letter code.
 
 <div class="lesson-note lesson-note--tip" markdown="1">
+
   Notice the usage of a prime number. We could have chosen any number we wanted, but prime numbers are preferable. Multiplying by a prime number will reduce the likelihood of hash codes being evenly divisible by the bucket length, which helps minimize the occurrence of collisions.
+
 </div>
 
 Even though we reworked our hash method to avoid the `"Sara"/"raSa"` collision, there is always the possibility for collisions. Since we have a finite number of buckets, there is no way to eliminate collisions entirely. Let's try to minimize them.
@@ -149,7 +153,9 @@ You probably understand by this point why we must write a good hashing method wh
 Let's talk about the growth of our buckets. We don't have infinite memory, so we can't have the infinite number of buckets. We need to start somewhere, but starting too big is also a waste of memory if we're only going to have a hash map with a single value in it. So to deal with this issue, we should start with a small array for our buckets. We'll use an array size `16`.
 
 <div class="lesson-note lesson-note--tip" markdown="1">
+
   Most programming languages start with the default size of `16` because it's a power of 2, which helps with some techniques for performance that require bit manipulation for indexes.
+
 </div>
 
 How are we going to insert into those buckets when our hash method generates big numbers like `20353924`? We make use of the modulo `%` operation `given any number modulo by 16 we will get a number between 0 and 15`.
@@ -187,13 +193,13 @@ The growth of our hash map has the complexity of `O(n)` at all times.
 <div class="lesson-content__panel" markdown="1">
 
 - Read [What are Hash Functions and How to choose a good Hash Function](https://www.geeksforgeeks.org/what-are-hash-functions-and-how-to-choose-a-good-hash-function) for a more technical overview of a hash function.
-- Watch [This Video](https://www.youtube.com/watch?v=btT4bCOvqjs) from CS50 that explains the concept of hash maps using buckets.
+- Watch this video from CS50 that [explains the concept of hash maps using buckets](https://www.youtube.com/watch?v=btT4bCOvqjs).
 
 </div>
 
 ### Knowledge check
 
-This section contains questions for you to check your understanding of this lesson on your own. If you’re having trouble answering a question, click it and review the material it links to.
+The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
 
 - [What does it mean to hash?](#what-is-a-hash-code)
 - [What are buckets?](#buckets)
@@ -204,5 +210,5 @@ This section contains questions for you to check your understanding of this less
 
 This section contains helpful links to related content. It isn't required, so consider it supplemental.
 
-- [This discussion goes through the usages of prime numbers](https://stackoverflow.com/questions/299304/why-does-javas-hashcode-in-string-use-31-as-a-multiplier/299748)
+- This discussion goes through the [usage of prime numbers](https://stackoverflow.com/questions/299304/why-does-javas-hashcode-in-string-use-31-as-a-multiplier/299748)
 - The [pigeonhole principle](https://en.wikipedia.org/wiki/Pigeonhole_principle) mathematically guarantees collisions when there are more nodes than boxes.


### PR DESCRIPTION
## Because
The lesson said 75% full without specifying whether that counted the number of entries, or the number of buckets with 1 or more entries.


## This PR
- Edits the paragraph on growing the buckets on both ruby and JS lessons


## Issue
Closes #28119


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
