### PR TITLE
JavaScript: How This Course Will Work: Change sentence formation

### DIFF
--- a/javascript/introduction/how_this_course_will_work.md
+++ b/javascript/introduction/how_this_course_will_work.md
@@ -24,7 +24,7 @@ It starts with a deep look at JavaScript code organization and basic computer sc
 
 We won't be focusing deeply on the really basic coding items, so it will move quickly. You should, however, already have completed the [Foundations course](https://www.theodinproject.com/paths/foundations/courses/foundations) -- specifically, the [JavaScript Basics section](https://www.theodinproject.com/paths/foundations/courses/foundations#javascript-basics) -- before starting this course.
 
-The last thing you'll do is a project which integrates everything you've learned so far in all the courses of this curriculum. This is the kind of project that you'll consider including in your portfolio as an example to demonstrate to prospective employers you have strong web development skills.
+The last thing you'll do is a project which integrates everything you've learned so far in all the courses of this curriculum. This is the kind of project that you'll consider including in your portfolio as an example to demonstrate your web-development skills to prospective employers.
 
 ### Format
 


### PR DESCRIPTION
## Because
Because the last sentence in the last paragraph of the [The Path](https://www.theodinproject.com/lessons/node-path-javascript-how-this-course-will-work#the-path) section of the [How this course will work](https://www.theodinproject.com/lessons/node-path-javascript-how-this-course-will-work) lesson was formatted in a way that could be hard to understand for a user. 


## This PR
-Change the sentence formation


## Issue
Closes #28194 

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
