### PR TITLE
remove link that returns 503

### DIFF
--- a/getting_hired/preparing_for_job_search/project_portfolio.md
+++ b/getting_hired/preparing_for_job_search/project_portfolio.md
@@ -37,5 +37,4 @@ A list of portfolios of professional developers. Students should analyze these s
   * [Tiago Sá's Portfolio](https://i-am-tiago.com/)
   * [Patrick David](https://bepatrickdavid.com/)
   * [Luis Krötz](https://luiskr.com/)
-  * [Leonid Kostetckyi](https://lk.emotion-agency.com/)
 </details>


### PR DESCRIPTION
## Because
Whilst browsing the example designs for a personal website I came across one of the domains linked return a 503 service unavailable.


## This PR

- Removed link to unreachable site.

## Issue
No current issue identified.

## Additional Information
N/A


## Pull Request Requirements
-   [X] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [X] The `Because` section summarizes the reason for this PR
-   [X] The `This PR` section has a bullet point list describing the changes in this PR
-   [X] If this PR addresses an open issue, it is linked in the `Issue` section
-   [X] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [X] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
