### PR TITLE
Project Etch-a-Sketch: Clarify Extra credit instructions

### DIFF
--- a/foundations/javascript_basics/project_etch_a_sketch.md
+++ b/foundations/javascript_basics/project_etch_a_sketch.md
@@ -41,7 +41,7 @@ Don't forget to commit early and often! You can reference the [Commit Messages l
 Transform the behavior of a square when interacting with the mouse by introducing a series of modifications.
 
 1. Rather than squares being the same color throughout the grid, randomize the squares' RGB values with each interaction.
-1. Additionally, implement a progressive darkening effect where each interaction darkens the square by 10%. The objective is to achieve a completely black square in only ten interactions.
+1. Additionally, implement a progressive darkening effect where each interaction darkens the square by 10%. The goal is to achieve a fully black (or completely colored) square in only ten interactions.
     - **Hint**: The opacity CSS property is useful here. To learn how to use it, check this [MDN docs article about the opacity CSS property](https://developer.mozilla.org/en-US/docs/Web/CSS/opacity).
 
 You can choose to do either one or both of these challenges, it's up to you.


### PR DESCRIPTION
## Because
Provide clear instructions for the second extra credit, ensuring the goal is well understood.

## This PR
- Add a clarification to the second extra credit, specifying that the goal is for the squares to either become completely black or have their color opacity fully increased.

## Additional Information
https://discord.com/channels/505093832157691914/513125308757442562/1216771257874251847

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
