### PR TITLE
JS Linting: Add ESLint v9/flatconfig support warning and eslint-config-prettier mention

### DIFF
--- a/javascript/javascript_in_the_real_world/linting.md
+++ b/javascript/javascript_in_the_real_world/linting.md
@@ -40,6 +40,18 @@ The current version of the extension (2.4.4) will only pick up the workspace fol
 
 </div>
 
+<div class="lesson-note lesson-note--warning" markdown="1">
+
+#### ESLint v9 and flat config support
+
+The above ESLint doc links take you to the docs for v9, which was released in April 2024. v9 came with a lot of big changes, including forcing all ESLint config files to use the "flat config" format (`eslint.config.(m|c)js`).
+
+Because of these changes, some community plugins like [eslint-config-airbnb-base](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base) (which makes ESLint use airbnb's ruleset) have not yet been able to release a version that supports v9 or flat config.
+
+For the time being, if you wish to use airbnb's style guide with ESLint, you will need to use [ESLint's v8.57 version of the docs](https://eslint.org/docs/v8.x/use/getting-started) and make sure you use one of the older [eslintrc configuration file formats](https://eslint.org/docs/v8.x/use/configure/configuration-files), **not** the newer flat config format.
+
+</div>
+
 ### Prettier
 
 Prettier is *awesome*. It is similar to a linter, but serves a slightly different function. Prettier will take your JS code and then automatically format it according to a set of rules. Unlike a linter, it's not looking for style errors, but specifically targeting the layout of your code and making intelligent decisions about things like spaces, indentation levels and line-breaks.
@@ -52,7 +64,11 @@ Using prettier makes coding faster and easier! You don't have to worry about nai
 
 ### Using ESLint and Prettier
 
-We **highly** recommend that you install ESlint and Prettier and use them for all future projects. It will make your code easier to read, both for yourself and for anyone else looking at it. There is no special setup needed apart from installing both of them.
+We **highly** recommend that you install ESlint and Prettier and use them for all future projects. It will make your code easier to read, both for yourself and for anyone else looking at it.
+
+For most people using the default ESLint ruleset, there will be no special setup needed apart from installing both of them.
+
+Some community plugins, such as [eslint-config-airbnb-base](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base), turn on some stylistic rules that may clash with what Prettier formats. If you wish to use a plugin like `eslint-config-airbnb-base` and Prettier together, you will also need to install [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) which will turn off any of the ESLint rules that clash with Prettier. If you are using the default ESLint ruleset, you will not need this.
 
 ### Template repositories
 


### PR DESCRIPTION
## Because
#27939 updated our Linting lesson in light of the recent ESLint v9 release and its breaking changes.

Since then, we've had a few people who wanted to use the airbnb ESLint plugin but ran into issues as it does not yet support v9 and flat config.

Since this has been somewhat common, it's worth adding a temporary note about using v8.57 and eslintrc if someone wanted to use something like the airbnb plugin (but if not, they can stick with the v9 docs). This note can be removed once airbnb release support for v9 and flat config.

Since this note was added, it also means it'd be sensible to add `eslint-config-prettier` back in specifically if someone wanted to use the airbnb plugin, as that plugin turns on rules that clash with Prettier. It was removed in #27939 because the default ESLint ruleset does not include any rules that clash with Prettier.


## This PR
- Adds warning about ESLint v9/flat config and airbnb plugin support
- Brings back mention of `eslint-config-prettier`, this time clarifying it's only relevant if using the airbnb plugin with ESLint.


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
N/A

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
