### PR TITLE
Ruby: Linting and RuboCop: Fix code blocks

### DIFF
--- a/ruby/object_oriented_programming_basics/linting_and_rubocop.md
+++ b/ruby/object_oriented_programming_basics/linting_and_rubocop.md
@@ -179,8 +179,8 @@ Since RuboCop is extensible, there exist other departments that you can use - li
 
 Usually things that are not required for app to run are given the `require: false` flag, like:
 
-```bash
-`gem 'rubocop-performance', require: false`
+```ruby
+gem 'rubocop-performance', require: false
 ```
 
 This way the Gem would be installed normally, but for your `bundle exec` ran code to make use of it, it would need to be explicitly `require`d wherever you'd need it.
@@ -189,7 +189,7 @@ This way the Gem would be installed normally, but for your `bundle exec` ran cod
 
 RuboCop is still under development, so changes and additions happen. New Cops join the precinct and they're not enabled by default - if you'd like them to be enabled by default instead of going through all of them and deciding on your own, you can use:
 
-```bash
+```yaml
 AllCops:
   NewCops: enable
 ```


### PR DESCRIPTION
## Because
There were additional back quotes and some blocks were described as `bash` instead of `ruby` or `yaml`


## This PR
- Removes unnecessary back quotes.
- Correctly describes code blocks.

## Issue

nil

## Additional Information

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
