### PR TITLE
Ruby: Update link texts to clearly describe it's content

### DIFF
--- a/ruby/basic_ruby/nested_collections.md
+++ b/ruby/basic_ruby/nested_collections.md
@@ -335,7 +335,7 @@ Amazing! We have found a great solution to returning an array that only contains
 
 1. Read more about [using a hash with a nested array](https://web.archive.org/web/20220525215038/https://learn.co/lessons/nested-hash-iteration).
 1. This Stack Overflow answer explains more about [using arrays with a nested hash](https://stackoverflow.com/questions/50529389/manipulating-output-from-an-array-of-nested-hashes-in-ruby).
-1. Complete the nested collections exercises from the [ruby-exercises repo](https://github.com/TheOdinProject/ruby-exercises)
+1. Complete the nested collections exercises from the [ruby-exercises repo](https://github.com/TheOdinProject/ruby-exercises).
 
 </div>
 

--- a/ruby/basic_ruby/nested_collections.md
+++ b/ruby/basic_ruby/nested_collections.md
@@ -1,4 +1,5 @@
 ### Introduction
+
 This lesson is going to build on your knowledge of arrays and hashes. As you have seen, arrays and hashes are great ways to store data. However, sometimes the data is more complex and needs more structure than a basic array or hash offers.
 
 Let's take a look at how you can use nested arrays and nested hashes to store more complex data.
@@ -17,6 +18,7 @@ This section contains a general overview of topics that you will learn in this l
 - Explain how to iterate over a nested array and hash.
 
 ### Nested arrays
+
 Arrays can contain any type of data, including other arrays. An array that contains other arrays is called a nested array, or a multidimensional array.
 
 Nested arrays can be useful to store groups of similar data or positional data. The following nested array of test scores is storing groups of similar data and the teacher mailboxes is storing groups of positional data.
@@ -37,6 +39,7 @@ teacher_mailboxes = [
 ```
 
 ### Accessing elements
+
 You already know that every element in an array has an index. Accessing a specific element within a nested array is done by calling `array[x][y]`, where `x` is the index of the nested element and `y` is the index inside of the nested element.
 
 ```ruby
@@ -78,6 +81,7 @@ teacher_mailboxes.dig(0, 4)
 ```
 
 ### Creating a new nested array
+
 Now that you have seen how to access values inside a nested array, we need to take a step back to look at creating a new nested array. In a previous lesson you were taught to create a new array, by calling the Array.new method with up to 2 optional arguments (initial size and default value), like `Array.new(3)` or `Array.new(3, 7)`. However, there is one major "gotcha" that is important to point out. According to the [Array class documentation](https://docs.ruby-lang.org/en/3.3/Array.html), the second optional argument for `Array.new` (the default value), should only be used with an immutable (unable to be changed) object such as a number, boolean value, or symbol. Using a string, array, hash, or other mutable object may result in confusing behavior because each default value in the array will actually be a *reference to* the same default value. Therefore, any change to **one** of the elements will change **all** of the elements in the array.
 
 To create an immutable array of mutable objects (string, array, hash, etc), you will need to pass the default value for `Array.new` via a block, using curly braces, instead of the second optional argument. The code in the block gets evaluated for every slot in the array, creating multiple objects to initialize the array with, rather than references to the same object.
@@ -109,6 +113,7 @@ immutable
 Changing the value of the first element in the first nested array does not cause the value to change in any other nested array.
 
 ### Adding and removing elements
+
 You can add another element to the end of nested array using the `#push` method or the shovel operator `<<`. If you want to add an element to a specific nested array, you will need to specify the index of the nested array.
 
 ```ruby
@@ -132,6 +137,7 @@ test_scores
 ```
 
 ### Iterating over a nested array
+
 Let's break down how to iterate over a nested array using the `#each_with_index` method. You might find it helpful to think of a nested array as having rows and columns. Each row is the nested element and each column is the index of the nested element. When we iterate over the teacher_mailboxes example, each element will be one row.
 
 ```ruby
@@ -212,6 +218,7 @@ end
 The results are different, because now it is determining if **all** of the nested arrays contain **any** number over 80. This returns true, because each of the nested arrays have at least one number over 80.
 
 ### Nested hashes
+
 The hashes that you've seen so far have single key/value pairs. However, just like arrays, they can be nested, or multidimensional. Nested hashes are a very common way to store complex associated data.
 
 ```ruby
@@ -223,6 +230,7 @@ vehicles = {
 ```
 
 ### Accessing data
+
 Accessing a specific element in a nested hash is very similar to a nested array. It is done by calling `hash[:x][:y]`, where `:x` is the key of the hash and `:y` is the key of the nested hash.
 
 ```ruby
@@ -248,6 +256,7 @@ vehicles.dig(:alice, :color)
 ```
 
 ### Adding and removing data
+
 You can add more nested hashes, just like a regular hash. Let's say Dave just bought a new vehicle and we want to add it to the list.
 
 ```ruby
@@ -285,6 +294,7 @@ vehicles
 ```
 
 ### Methods
+
 There are many helpful methods to use with nested hashes. Once you know what data you need from a nested hash, you might find that browsing through the documentation and experimenting with them in IRB is the best way for you to understand how they work.
 
 Let's look at an example using the vehicles nested hash. Let's say that we want to know who owns vehicles that are from 2020 or newer. At first glance in the documentation, it looks like `#select` would be a great method to use.
@@ -320,32 +330,34 @@ vehicles.filter_map { |name, data| name if data[:year] >= 2020 }
 Amazing! We have found a great solution to returning an array that only contains the names of the owners of vehicles from 2020 or newer! Plus, we got experience using other methods that you will probably use in the future. We have found some really useful methods by exploring the documentation when we have a specific use case in mind.
 
 ### Assignment
+
 <div class="lesson-content__panel" markdown="1">
 
 1. Read more about [using a hash with a nested array](https://web.archive.org/web/20220525215038/https://learn.co/lessons/nested-hash-iteration).
-2. This Stack Overflow answer explains more about [using arrays with a nested hash](https://stackoverflow.com/questions/50529389/manipulating-output-from-an-array-of-nested-hashes-in-ruby).
-3. Complete the nested collections exercises from the [ruby-exercises repo](https://github.com/TheOdinProject/ruby-exercises)
+1. This Stack Overflow answer explains more about [using arrays with a nested hash](https://stackoverflow.com/questions/50529389/manipulating-output-from-an-array-of-nested-hashes-in-ruby).
+1. Complete the nested collections exercises from the [ruby-exercises repo](https://github.com/TheOdinProject/ruby-exercises)
 
 </div>
 
 ### Knowledge check
-This section contains questions for you to check your understanding of this lesson. If you're having trouble answering the questions below on your own, review the material above to find the answer.
 
-- <a class='knowledge-check-link' href='#nested-arrays'>What is a nested array? What data is useful to store in a nested array?</a>
-- <a class='knowledge-check-link' href='#nested-hashes'>What is a nested hash? What data is useful to store in a nested hash?</a>
-- <a class='knowledge-check-link' href='#accessing-elements'>How do you access elements in a nested array?</a>
-- <a class='knowledge-check-link' href='#accessing-data'>How do you access data in a nested hash?</a>
-- <a class='knowledge-check-link' href='#dig-method'>Why is the `#dig` method useful?</a>
-- <a class='knowledge-check-link' href='#adding-and-removing-elements'>How do you add elements to a nested array?</a>
-- <a class='knowledge-check-link' href='#adding-and-removing-data'>How do you add data to a nested hash?</a>
-- <a class='knowledge-check-link' href='#remove-elements-nested-array'>How do you delete elements from a nested array?</a>
-- <a class='knowledge-check-link' href='#deleting-data-nested-hash'>How do you delete data in a nested hash?</a>
-- <a class='knowledge-check-link' href='#create-immutable-nested-arrays'>How do you create a new nested array that is not mutable?</a>
-- <a class='knowledge-check-link' href='#iterating-over-a-nested-array'>How do you iterate over a nested array?</a>
-- <a class='knowledge-check-link' href='#methods'>How do you iterate over a nested hash?</a>
+The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
+
+- [What is a nested array? What data is useful to store in a nested array?](#nested-arrays)
+- [What is a nested hash? What data is useful to store in a nested hash?](#nested-hashes)
+- [How do you access elements in a nested array?](#accessing-elements)
+- [How do you access data in a nested hash?](#accessing-data)
+- [Why is the `#dig` method useful?](#dig-method)
+- [How do you add elements to a nested array?](#adding-and-removing-elements)
+- [How do you add data to a nested hash?](#adding-and-removing-data)
+- [How do you delete elements from a nested array?](#remove-elements-nested-array)
+- [How do you delete data in a nested hash?](#deleting-data-nested-hash)
+- [How do you create a new nested array that is not mutable?](#create-immutable-nested-arrays)
+- [How do you iterate over a nested array?](#iterating-over-a-nested-array)
+- [How do you iterate over a nested hash?](#methods)
 
 ### Additional resources
 
 This section contains helpful links to related content. It isn't required, so consider it supplemental.
 
--   It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.
+- It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.

--- a/ruby/basic_ruby/nested_collections.md
+++ b/ruby/basic_ruby/nested_collections.md
@@ -324,7 +324,7 @@ Amazing! We have found a great solution to returning an array that only contains
 
 1. Read more about [using a hash with a nested array](https://web.archive.org/web/20220525215038/https://learn.co/lessons/nested-hash-iteration).
 2. This Stack Overflow answer explains more about [using arrays with a nested hash](https://stackoverflow.com/questions/50529389/manipulating-output-from-an-array-of-nested-hashes-in-ruby).
-3. Complete the nested collections exercises
+3. Complete the nested collections exercises from the [ruby-exercises repo](https://github.com/TheOdinProject/ruby-exercises)
 
 </div>
 

--- a/ruby/basic_ruby/nested_collections.md
+++ b/ruby/basic_ruby/nested_collections.md
@@ -78,7 +78,7 @@ teacher_mailboxes.dig(0, 4)
 ```
 
 ### Creating a new nested array
-Now that you have seen how to access values inside a nested array, we need to take a step back to look at creating a new nested array. In a previous lesson you were taught to create a new array, by calling the Array.new method with up to 2 optional arguments (initial size and default value), like `Array.new(3)` or `Array.new(3, 7)`. However, there is one major "gotcha" that is important to point out. According to the [documentation](https://docs.ruby-lang.org/en/3.3/Array.html) the second optional argument, for the default value, should only be used with an immutable (unable to be changed) object such as a number, boolean value, or symbol. Using a string, array, hash, or other mutable object may result in confusing behavior because each default value in the array will actually be a *reference to* the same default value. Therefore, any change to **one** of the elements will change **all** of the elements in the array.
+Now that you have seen how to access values inside a nested array, we need to take a step back to look at creating a new nested array. In a previous lesson you were taught to create a new array, by calling the Array.new method with up to 2 optional arguments (initial size and default value), like `Array.new(3)` or `Array.new(3, 7)`. However, there is one major "gotcha" that is important to point out. According to the [Array class documentation](https://docs.ruby-lang.org/en/3.3/Array.html), the second optional argument for `Array.new` (the default value), should only be used with an immutable (unable to be changed) object such as a number, boolean value, or symbol. Using a string, array, hash, or other mutable object may result in confusing behavior because each default value in the array will actually be a *reference to* the same default value. Therefore, any change to **one** of the elements will change **all** of the elements in the array.
 
 To create an immutable array of mutable objects (string, array, hash, etc), you will need to pass the default value for `Array.new` via a block, using curly braces, instead of the second optional argument. The code in the block gets evaluated for every slot in the array, creating multiple objects to initialize the array with, rather than references to the same object.
 
@@ -322,9 +322,9 @@ Amazing! We have found a great solution to returning an array that only contains
 ### Assignment
 <div class="lesson-content__panel" markdown="1">
 
-1. To learn more about using a hash with a nested array, read [this article](https://web.archive.org/web/20220525215038/https://learn.co/lessons/nested-hash-iteration) from Learn.co.
-2. To learn more about using an array with a nested hash, read [the answer to this post](https://stackoverflow.com/questions/50529389/manipulating-output-from-an-array-of-nested-hashes-in-ruby) on Stack Overflow.
-3. Complete the [nested collections](https://github.com/TheOdinProject/ruby-exercises/tree/main/ruby_basics) exercises from the [ruby-exercises repo](https://github.com/TheOdinProject/ruby-exercises) that you previously cloned.
+1. Read more about [using a hash with a nested array](https://web.archive.org/web/20220525215038/https://learn.co/lessons/nested-hash-iteration).
+2. This Stack Overflow answer explains more about [using arrays with a nested hash](https://stackoverflow.com/questions/50529389/manipulating-output-from-an-array-of-nested-hashes-in-ruby).
+3. Complete the nested collections exercises
 
 </div>
 

--- a/ruby/basic_ruby_projects/project_caesar_cipher.md
+++ b/ruby/basic_ruby_projects/project_caesar_cipher.md
@@ -17,6 +17,7 @@ From Wikipedia:
 Harvard's CS50 class has a [video about the Caesar cipher](https://www.youtube.com/watch?v=36xNpbosfTY).
 
 <div class="lesson-content__panel" markdown="1">
+
   Implement a caesar cipher that takes in a string and the shift factor and then outputs the modified string:
 
 ```ruby
@@ -29,4 +30,5 @@ Harvard's CS50 class has a [video about the Caesar cipher](https://www.youtube.c
 - You will need to remember how to convert a string into a number.
 - Don't forget to wrap from `z` to `a`.
 - Don't forget to keep the same case.
+
 </div>

--- a/ruby/basic_ruby_projects/project_caesar_cipher.md
+++ b/ruby/basic_ruby_projects/project_caesar_cipher.md
@@ -14,7 +14,7 @@ From Wikipedia:
 
 > In cryptography, a Caesar cipher, also known as Caesar's cipher, the shift cipher, Caesar's code or Caesar shift, is one of the simplest and most widely known encryption techniques. It is a type of substitution cipher in which each letter in the plaintext is replaced by a letter some fixed number of positions down the alphabet. For example, with a left shift of 3, D would be replaced by A, E would become B, and so on. The method is named after Julius Caesar, who used it in his private correspondence.
 
-There's a video about it [from Harvard's CS50 class](https://www.youtube.com/watch?v=36xNpbosfTY).
+Harvard's CS50 class has a [video about the Caesar cipher](https://www.youtube.com/watch?v=36xNpbosfTY).
 
 <div class="lesson-content__panel" markdown="1">
   Implement a caesar cipher that takes in a string and the shift factor and then outputs the modified string:


### PR DESCRIPTION
## Because
Update the link texts to clearly describe the content it leads to, following the accessibility guidelines outlined in the issue.


## This PR
- Update link texts to the sections [Nested Collections](https://www.theodinproject.com/lessons/ruby-nested-collections) && [Project: Caesar Cipher](https://www.theodinproject.com/lessons/ruby-caesar-cipher) as per the given [spreadsheet](https://docs.google.com/spreadsheets/d/1rM9tjPIFZbKoMfd6OlLnjOhddBe2bivllY8_Bg5aGqY/edit?usp=sharing)


## Issue
Related to https://github.com/TheOdinProject/curriculum/issues/28290


## Additional Information
none


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
