### PR TITLE
CONTRIBUTING.md: Mention potential multiple passes of fix script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,4 +31,6 @@ To help enforce the layout specified in our layout style guide, we use [markdown
     - Lint projects: `npm run lint:project -- "./path/to/project"`
     - Autofix projects: `npm run fix:project -- "./path/to/project"`
 
+In some cases, you may need to run a fix script more than once to catch and fix all fixable errors. This typically occurs when a line has multiple errors affecting the same parts and fix actions collide, so Markdownlint only applies some of the fixes.
+
 With either of these two methods, keep in mind that not all issues that get flagged will have an autofix available. Some rules require fixes that are more dependent on context and cannot - and should not - be automatically fixed, such as our custom rule `TOP001` for descriptive link text.


### PR DESCRIPTION
## Because

Sometimes, fixers that collide in the same or close lines result in Markdownlint only applying some of the fixes. The ignored fixers require running the fix script again to catch and fix. Currently, the curriculum repo contributing guide does not explicitly mention this can happen, even though it's a somewhat common occurrence.

## This PR

- Explicitly mentions the possibility of needing multiple passes of a fix script to catch and fix all script-fixable lint errors

## Issue

N/A

## Additional Information

N/A

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
