### PR TITLE
README.md: Follow layout style guide for markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,17 @@ Our community can be found on the [TOP Discord server](https://discord.gg/fbFCkY
 The Odin Project depends on open-source contributions to improve, grow, and thrive. We welcome contributors of all experience levels and backgrounds to help maintain this awesome curriculum and community. If you would like to contribute to our curriculum, be sure to thoroughly read our [contributing guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md).
 
 Some of the things you can do to contribute to our curriculum include:
-* Correct typos and other grammar errors.
-* Rewrite parts of existing lessons to make them clearer and easier to understand.
-* Fix broken links.
-* Add new resource links you think would make a lesson better.
-* Work on entirely new lessons after getting approval.
+
+- Correct typos and other grammar errors.
+- Rewrite parts of existing lessons to make them clearer and easier to understand.
+- Fix broken links.
+- Add new resource links you think would make a lesson better.
+- Work on entirely new lessons after getting approval.
 
 **Happy Coding!**
 
-\* See [license.md](https://github.com/TheOdinProject/curriculum/blob/main/license.md) for usage details.
+See [license.md](https://github.com/TheOdinProject/curriculum/blob/main/license.md) for usage details.
 
 ___
-Created by [Erik Trautman](http://www.github.com/eriktrautman)
+
+Created by [Erik Trautman](http://www.github.com/eriktrautman).


### PR DESCRIPTION
## Because

Our README.md wasn't using our layout style guide's markdown style.

## This PR

- Fixes README.md's markdown style to match our layout style guide.

## Issue

N/A

## Additional Information

N/A

## Pull Request Requirements

-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
