### PR TITLE
Join the Odin Community: Add missing LO/KC sections and fix google bot command

### DIFF
--- a/foundations/introduction/join_the_odin_community.md
+++ b/foundations/introduction/join_the_odin_community.md
@@ -119,7 +119,7 @@ If the question needs to have live code to fully understand or debug, ask them t
 
 Learning how to research these questions is a very important skill for developers, so we need to empower them to find their own answer. When we answer these questions, it hinders their personal growth and makes them codependent on our community.
 
-Instead of answering these questions, politely ask them to google their question or use our bot command `/google` with the search terms.
+Instead of answering these questions, politely ask them to google their question or use our bot command `/search google` with the search terms.
 
 #### 9. Do not answer questions covered in our curriculum.
 

--- a/foundations/introduction/join_the_odin_community.md
+++ b/foundations/introduction/join_the_odin_community.md
@@ -173,7 +173,7 @@ Sometimes there are misunderstandings and interactions go poorly. You are a volu
 
 1. First, [create a free GitHub account](https://github.com/join). As you will discover, GitHub is an integral part of the development workflow.
 
-1. Now, sign in to [our Discord server](https://discord.gg/theodinproject). Pop in and say hello! We've created an introductions room which is a great place to introduce yourself and we're always happy to welcome new community members. We have chat rooms for every development topic covered in our curriculum. Log into the chat and start exploring!
+1. Now, sign in to [our Discord server](https://discord.gg/fbFCkYabZB). Pop in and say hello! We've created an introductions room which is a great place to introduce yourself and we're always happy to welcome new community members. We have chat rooms for every development topic covered in our curriculum. Log into the chat and start exploring!
 
    - **Link your GitHub to your Discord profile:** Go to `Discord Settings > Connections`, then click the GitHub icon. In the new tab that opens click "Allow Access", then back in Discord make sure "Display on profile" is toggled on. This will allow others to see what you're working on and vice versa!
 
@@ -188,6 +188,14 @@ Sometimes there are misunderstandings and interactions go poorly. You are a volu
    - **Don't disappear right after asking for help on code:** If you're posting a question, make sure you have time to stick around and discuss it with those trying to help!
 
 </div>
+
+### Knowledge check
+
+The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
+
+- [How do you join The Odin Project's Discord server?](https://discord.gg/fbFCkYabZB)
+- [What makes a good question that's easier for others to help with?](#asking-for-help)
+- [How can you more effectively help others with their coding problems?](#how-to-help-others-solve-coding-problems)
 
 ### Additional resources
 

--- a/foundations/introduction/join_the_odin_community.md
+++ b/foundations/introduction/join_the_odin_community.md
@@ -2,6 +2,14 @@
 
 Working and collaborating with other people is an important part of working as a web developer. Therefore, we at The Odin Project encourage you to participate in our online chat community, which we'll talk more about below. By joining the community, you can grow alongside other Odinites and help each other learn web development. While you're at it, you can check out [our Facebook page](https://www.facebook.com/theodinproject/), [follow us on X](https://x.com/TheOdinProject) and catch up on [our Instagram page](https://www.instagram.com/theodinproject/). Use #TheOdinProject to share your Odin Project progress, updates, thoughts and to see what other Odin students are up to!
 
+### Lesson overview
+
+This section contains a general overview of topics that you will learn in this lesson.
+
+- Learn about The Odin's community and how to join it.
+- Explain how to ask good and detailed questions.
+- Explain good practices for helping others with their questions.
+
 ### Why a community is awesome for you
 
 Learning web development will be a long and arduous journey, but you can make the marathon a lot more fun by getting involved in our Discord community. No matter what pace you are doing our curriculum, there will always be people a few steps ahead of you that are willing to help. Furthermore, helping others that are a few steps behind you is a great way to deepen your own understanding and make your learning stick.

--- a/foundations/introduction/join_the_odin_community.md
+++ b/foundations/introduction/join_the_odin_community.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-Working and collaborating with other people is an important part of working as a web developer. Therefore, we at The Odin Project encourage you to participate in our online chat community, which we'll talk more about below. By joining the community, you can grow alongside other Odinites and help each other learn web development. While you're at it, you can check out our [Facebook page](https://www.facebook.com/theodinproject/), [follow us on X](https://x.com/TheOdinProject) and catch up on [Instagram](https://www.instagram.com/theodinproject/). Use #TheOdinProject to share your Odin Project progress, updates, thoughts and to see what other Odin students are up to!
+Working and collaborating with other people is an important part of working as a web developer. Therefore, we at The Odin Project encourage you to participate in our online chat community, which we'll talk more about below. By joining the community, you can grow alongside other Odinites and help each other learn web development. While you're at it, you can check out [our Facebook page](https://www.facebook.com/theodinproject/), [follow us on X](https://x.com/TheOdinProject) and catch up on [our Instagram page](https://www.instagram.com/theodinproject/). Use #TheOdinProject to share your Odin Project progress, updates, thoughts and to see what other Odin students are up to!
 
 ### Why a community is awesome for you
 
@@ -56,7 +56,7 @@ In the chat rooms, code can be displayed differently from normal sentences by us
 
 \`Your Code\`
 
-**For multiple lines of code:** use three backticks _on a separate line_ above and below your code.
+**For multiple lines of code:** use three backticks *on a separate line* above and below your code.
 
 \`\`\`
 
@@ -64,9 +64,9 @@ Your Multiple Lines of Code
 
 \`\`\`
 
-You can also use _code highlighting_ to add color to your multi-line code by specifying the language:
+You can also use *code highlighting* to add color to your multi-line code by specifying the language:
 
-\`\`\`**js** or **javascript**
+\`\`\`**js** or **JavaScript**
 
 Your Multiple Lines of Colorful Code
 
@@ -83,45 +83,45 @@ Your Multiple Lines of Colorful Code
 
 Not only is it important to know how to ask an effective question, but it is also important to know how to help others effectively. Please take a moment to review these guidelines so that you will have proper expectations of the help you will receive in our Discord community. In addition, come back and review these guidelines when you are ready to start helping others.
 
-#### 1. Instead of answering the question, guide them to the answer.
+#### 1. Instead of answering the question, guide them to the answer
 
 Unless the problem is a simple typo or syntax error, it is more beneficial to guide them to find their own answer. This approach will teach good debugging skills and will increase their ability to solve future problems.
 
 Start by asking probing questions, such as "What have you already tried?", “What do you expect this function to do?”, or “What do you think that error means?”.
 
-#### 2. Help only when you are certain of the answer.
+#### 2. Help only when you are certain of the answer
 
 If you are not 100% certain of the answer, you may end up doing more harm than good, so please let someone else answer it.
 
 Do not worry about how long someone has to wait for an answer. The right answer is worth the wait.
 
-#### 3. Help only when no one else is currently helping.
+#### 3. Help only when no one else is currently helping
 
 If somebody is already getting help, do not jump in the middle of the conversation. We know you mean well, but it is overwhelming for the person receiving help to follow multiple conversations.
 
-#### 4. Help only when you have plenty of time.
+#### 4. Help only when you have plenty of time
 
 If you do not have much time to help, please let someone else answer the question.
 
-#### 5. Adjust your expectations to their level.
+#### 5. Adjust your expectations to their level
 
 If the question does not reveal where they are in the curriculum, ask them so that you can adjust your expectations to their knowledge level.
 
-#### 6. Ask for clarifications.
+#### 6. Ask for clarifications
 
 If the question seems confusing or ambiguous, ask for more clarity, or politely link them to our bot command `/question`, which links to the [How to be great at asking coding questions](https://medium.com/@gordon_zhu/how-to-be-great-at-asking-questions-e37be04d0603) article.
 
-#### 7. Ask for live code.
+#### 7. Ask for live code
 
 If the question needs to have live code to fully understand or debug, ask them to use [replit](https://replit.com) to provide it. If the problem is difficult to isolate, they should recreate the problem with isolated code.
 
-#### 8. Do not answer googleable questions.
+#### 8. Do not answer googleable questions
 
 Learning how to research these questions is a very important skill for developers, so we need to empower them to find their own answer. When we answer these questions, it hinders their personal growth and makes them codependent on our community.
 
 Instead of answering these questions, politely ask them to google their question or use our bot command `/search google` with the search terms.
 
-#### 9. Do not answer questions covered in our curriculum.
+#### 9. Do not answer questions covered in our curriculum
 
 If you know that the answer is provided in our curriculum, ask them where they are at in the curriculum.
 
@@ -129,48 +129,47 @@ If they have not reached that portion of the curriculum, let them know they will
 
 If they have already been through that portion of the curriculum, politely direct them to review that lesson.
 
-#### 10. Answer the question before pointing out other problems.
+#### 10. Answer the question before pointing out other problems
 
 When helping someone it can be easy to spot other problems in their code. Resolve the original question, before pointing out any other problems that need attention.
 
-#### 11. Encourage students to use a debugger.
+#### 11. Encourage students to use a debugger
 
 It is common for students to not understand the importance of using a debugger to look at the values of their variables at different points in their program. When students are getting unexpected values, politely encourage them to use a debugger with our bot command `/debug`.
 
-#### 12. Watch for students that need to take a step back.
+#### 12. Watch for students that need to take a step back
 
 It is common for students to focus too hard on a problem and not be able to clearly see everything. When this situation arises, politely encourage them to step back from the problem and take a break. Oftentimes, stepping away from a problem will help them see the bigger picture and how to solve it.
 
-#### 13. Watch for students that are in over their head.
+#### 13. Watch for students that are in over their head
 
 It is common for students to skip a lesson/project or think they know more than they actually do. When this situation arises, politely encourage them to go back and reread a section of the curriculum for more understanding.
 
-#### 14. Admit when the problem goes beyond your current knowledge.
+#### 14. Admit when the problem goes beyond your current knowledge
 
 It is common for the actual issue to go beyond the initial question. If it goes beyond your current knowledge, it is important to admit that you are unsure of the correct answer and let someone else help.
 
 After digging deeper into the problem, they might be able to continue troubleshooting on their own or they can wait for someone more experienced to help.
 
-#### 15. Be patient.
+#### 15. Be patient
 
 Helping others solve a problem is not always easy. Remember to be patient as they struggle through the problem.
 
-#### 16. Duck out of the conversation if you get frustrated.
+#### 16. Duck out of the conversation if you get frustrated
 
 Sometimes there are misunderstandings and interactions go poorly. You are a volunteer and are not obligated to help when things get out of hand. Politely duck out of the conversation and let someone else step up.
-
 
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">
 
-1. First, create a free [GitHub account](https://github.com/join). As you will discover, GitHub is an integral part of the development workflow.
+1. First, [create a free GitHub account](https://github.com/join). As you will discover, GitHub is an integral part of the development workflow.
 
-2. Now, sign in to our [Discord server](https://discord.gg/theodinproject). Pop in and say hello! We've created an introductions room which is a great place to introduce yourself and we're always happy to welcome new community members. We have chat rooms for every development topic covered in our curriculum. Log into the chat and start exploring!
+1. Now, sign in to [our Discord server](https://discord.gg/theodinproject). Pop in and say hello! We've created an introductions room which is a great place to introduce yourself and we're always happy to welcome new community members. We have chat rooms for every development topic covered in our curriculum. Log into the chat and start exploring!
 
    - **Link your GitHub to your Discord profile:** Go to `Discord Settings > Connections`, then click the GitHub icon. In the new tab that opens click "Allow Access", then back in Discord make sure "Display on profile" is toggled on. This will allow others to see what you're working on and vice versa!
 
-3. Here are some guidelines before you dive in:
+1. Here are some guidelines before you dive in:
 
    - **Read the rules and FAQ:** Please take the time to read and understand our rules and FAQ. On the left sidebar in Discord, navigate to `TOP META`-> `rules` and `faq`.
    - **Remember the human:** Behind every username there is a person with feelings! Be kind! If you don't have anything nice to say, don't say anything at all.
@@ -184,6 +183,6 @@ Sometimes there are misunderstandings and interactions go poorly. You are a volu
 
 ### Additional resources
 
-This section contains helpful links to related content. It isn’t required, so consider it supplemental.
+This section contains helpful links to related content. It isn't required, so consider it supplemental.
 
 - For more information on formatting, check out [Discord Markdown 101](https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-).


### PR DESCRIPTION
## Because

Originally just fixing the suggested bot command for google searches which is now `/search google` instead of `/google` (https://github.com/TheOdinProject/odin-bot-v2/pull/513).

Lesson was also missing LO/KC sections which were simple enough to add in to appease the linter and follow the style guide's lesson structure.

## This PR

- Updates command name for google search with Odinbot
- Adds lesson overview and knowledge check sections
- Fixes general linting errors

## Issue

N/A

## Additional Information

N/A

## Pull Request Requirements

-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
