### PR TITLE
Rails Advanced Forms: Fix code block languages

### DIFF
--- a/ruby_on_rails/advanced_forms_and_activerecord/forms_advanced.md
+++ b/ruby_on_rails/advanced_forms_and_activerecord/forms_advanced.md
@@ -32,7 +32,7 @@ Let's say you want to build a New Post form for your blog but you want to be abl
 
 The bare HTML way is to build a bunch of `<option>` tags (inside your `<select>` tag).  You could easily create these in your ERB code by just iterating over some collection, for instance if you'd like to select a post to view from a list of them.
 
-```html
+```erb
   # app/views/posts/new.html.erb
   ...
   <select name="user_id">
@@ -57,7 +57,9 @@ But Rails provides some less verbose ways of doing the same thing, namely using 
     @post = Post.new
   end
   ...
+```
 
+```erb
   # app/views/posts/new.html.erb
   ...
   <%= select_tag(:author_id, options_for_select(@user_options)) %>
@@ -68,7 +70,7 @@ So just pass `#select_tag` the name it should use for your chosen value and the 
 
 <span id='select-helper'>If you want to avoid the whole `options_for_select` thing altogether and your form is designed to build a model instance (e.g. a Post object), just use the more generic `#select` helper in your view:</span>
 
-```ruby
+```erb
   # app/views/posts/new.html.erb
   ...
   <%= select(:post, :author_id, @user_options) %>
@@ -81,7 +83,7 @@ The `:author_id` input to the `#select` helper above represents not just what th
 
 If you have a `#form_with` form scoped under the `f` variable, you don't need to pass the `:post` symbol above (it gets it from `f`), so could instead use:
 
-```ruby
+```erb
   # app/views/posts/new.html.erb
   ...
     <%= f.select(:author_id, @user_options) %>
@@ -119,18 +121,18 @@ We'll do a broad overview of the process here:
 
 There are a couple new aspects to this process.  You saw `#fields_for` in the [Basic Forms lesson](/paths/full-stack-ruby-on-rails/courses/ruby-on-rails/lessons/form-basics) but it probably has new meaning to you now.  It's basically how you create a form within a form (which should make sense since it's actually used behind the scenes by `#form_with`).  In this example, we might create three "sub-forms" for ShippingAddress objects by using our association, e.g.
 
-```ruby
-  <%= form_with model: @user do |f| %>
+```erb
+<%= form_with model: @user do |f| %>
     ...
     <% 3.times do %>
-      <%= f.fields_for @user.shipping_addresses.build do |sub_form| %>
+    <%= f.fields_for @user.shipping_addresses.build do |sub_form| %>
         ...
         <%= sub_form.text_field :zip_code %>
         ...
-      <% end %>
+    <% end %>
     <% end %>
     <%= f.submit %>
-  <% end %>
+<% end %>
 ```
 
 Note that we could (and should) also have built the new shipping_address objects in the controller instead of the view; it's just for demonstration purposes here.


### PR DESCRIPTION
## Because

Some code blocks were using the wrong language, leading to incorrect syntax highlighting.

## This PR

- Applies correct language to appropriate code blocks.
- Splits a code block containing two languages into individual code blocks with their respective languages.


## Issue

N/A

## Additional Information

N/A


## Pull Request Requirements

-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
