### PR TITLE
JavaScript Course JSON lesson: Add one YouTube resource

### DIFF
--- a/javascript/organizing_your_javascript_code/json.md
+++ b/javascript/organizing_your_javascript_code/json.md
@@ -18,4 +18,4 @@ Fortunately, there isn't much to learn here. We're only including a lesson on it
 
 This section contains helpful links to related content. It isn't required, so consider it supplemental.
 
-- It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.
+- Web Dev Simplified explains [JSON in ten minutes](https://www.youtube.com/watch?v=iiADhChRriM).


### PR DESCRIPTION
Add one YouTube link titled "Learn JSON in 10 Minutes" as an additional resource for the JavaScript Course JSON lesson.

## Because
- It adds an additional resource about JSON explained by Web Dev Simplified in ten minutes.

## This PR
- One YouTube resource "Learn JSON in 10 Minutes" by Web Dev Simplified.

## Issue
- Lack of additional resources.

## Additional Information

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)