### PR TITLE
Ruby on Rails Active Record Queries and Active Record Callbacks: Fix Link Text

### DIFF
--- a/ruby_on_rails/advanced_forms_and_activerecord/active_record_callbacks.md
+++ b/ruby_on_rails/advanced_forms_and_activerecord/active_record_callbacks.md
@@ -78,7 +78,7 @@ The `commit`ting of a transaction and its potential `rollback` if it fails are b
 
 <div class="lesson-content__panel" markdown="1">
   1. Read through the [Rails Guide on Callbacks](http://guides.rubyonrails.org/active_record_callbacks.html)
-  2. Read [this post from Samuel Mullen](https://samuelmullen.com/articles/guidelines-for-using-activerecord-callbacks) on guidelines for using callbacks.
+  2. Read this post from Samuel Mullen on [guidelines for using callbacks](https://samuelmullen.com/articles/guidelines-for-using-activerecord-callbacks).
 </div>
 
 ### Conclusion

--- a/ruby_on_rails/advanced_forms_and_activerecord/active_record_queries.md
+++ b/ruby_on_rails/advanced_forms_and_activerecord/active_record_queries.md
@@ -219,16 +219,16 @@ Sometimes, you just can't get ActiveRecord to do what you want it to. In that ca
 ### Querying basics
 
 1. Read the first 6 sections of the [Rails Guide on Active Record Querying](http://guides.rubyonrails.org/active_record_querying.html) for a more basic overview of query functions. Don't worry too much about batching and `#find_each`.
-2. Read section 20 of the [same Rails Guide](https://guides.rubyonrails.org/active_record_querying.html#existence-of-objects) for a brief look at using `exists?`, `any?` and `many?`.
-3. Read sections 7, 8 and 21 of the [same Rails Guide](https://guides.rubyonrails.org/active_record_querying.html#group) for an understanding of aggregate functions and the calculations you can run on them.
-4. Skim sections 9-12 of the [same Rails Guide](https://guides.rubyonrails.org/active_record_querying.html#overriding-conditions). 
-5. Read section 12 of the [same Rails Guide](https://guides.rubyonrails.org/active_record_querying.html#joining-tables) to see how Rails lets you play with joining tables together.
-6. Read section 18 of the [same Rails Guide](https://guides.rubyonrails.org/active_record_querying.html#find-or-build-a-new-object) for a quick look at the helpful `find_or_create_by` methods.
+2. Read section 20 of the same Rails guide for a brief look at [using `exists?`, `any?` and `many?`](https://guides.rubyonrails.org/active_record_querying.html#existence-of-objects).
+3. Read sections 7, 8 and 21 of the same Rails guide for an understanding of [aggregate functions and the calculations you can run on them](https://guides.rubyonrails.org/active_record_querying.html#group).
+4. Skim sections 9-12 of the same Rails guide on [overriding conditions](https://guides.rubyonrails.org/active_record_querying.html#overriding-conditions). 
+5. Read section 12 of the same Rails guide to see how Rails lets you play with [joining tables together](https://guides.rubyonrails.org/active_record_querying.html#joining-tables).
+6. Read section 18 of the same Rails guide for a quick look at [the helpful `find_or_create_by` methods](https://guides.rubyonrails.org/active_record_querying.html#find-or-build-a-new-object).
 
 ### Advanced querying
 
 1. Read section 14 in the [Rails Guide on Querying](https://guides.rubyonrails.org/active_record_querying.html#scopes) for a look at scopes. Again, you don't necessarily need to memorize all the details of scopes, but you should understand the concept and when it might be useful.
-2. Read section 19 of the [same Rails Guide](http://guides.rubyonrails.org/active_record_querying.html#finding-by-sql) for a look at using SQL directly.
+2. Read section 19 of the same Rails guide for a look at [using SQL directly to query](http://guides.rubyonrails.org/active_record_querying.html#finding-by-sql).
 </div>
 
 ### Conclusion


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
Link text was not descriptive enough for accessibility guidelines.


## This PR
- changed link text in Active Record Queries lesson as per the suggested link text changes spreadsheet
- changed link text in Active Record Callbacks lesson as per the suggested link text changes spreadsheet

## Issue
Related to #28290

## Additional Information
N/A

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
