### PR TITLE
CONTRIBUTING.md: Specify npm script execution location

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,11 @@ To help enforce the layout specified in our layout style guide, we use [markdown
     - Lint projects: `npm run lint:project -- "./path/to/project"`
     - Autofix projects: `npm run fix:project -- "./path/to/project"`
 
-You *must* run these npm scripts in the root of the curriculum repo (the same location as this file and `package.json`). If you navigate to a different directory and run a script on files there, it will not pick up the right configuration files and rules.
+> [!IMPORTANT]
+> You *must* run these npm scripts in the root of the curriculum repo (the same location as this file and `package.json`). If you navigate to a different directory and run a script on files there, it will not pick up the right configuration files and rules.
 
-In some cases, you may need to run a fix script more than once to catch and fix all fixable errors. This typically occurs when a line has multiple errors affecting the same parts and fix actions collide, so Markdownlint only applies some of the fixes.
+> [!TIP]
+> In some cases, you may need to run a fix script more than once to catch and fix all fixable errors. This typically occurs when a line has multiple errors affecting the same parts and fix actions collide, so Markdownlint only applies some of the fixes.
 
-With either of these two methods, keep in mind that not all issues that get flagged will have an autofix available. Some rules require fixes that are more dependent on context and cannot - and should not - be automatically fixed, such as our custom rule `TOP001` for descriptive link text.
+> [!NOTE]
+>With either of these two methods, keep in mind that not all issues that get flagged will have an autofix available. Some rules require fixes that are more dependent on context and cannot - and should not - be automatically fixed, such as our custom rule `TOP001` for descriptive link text.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,8 @@ To help enforce the layout specified in our layout style guide, we use [markdown
     - Lint projects: `npm run lint:project -- "./path/to/project"`
     - Autofix projects: `npm run fix:project -- "./path/to/project"`
 
+You *must* run these npm scripts in the root of the curriculum repo (the same location as this file and `package.json`). If you navigate to a different directory and run a script on files there, it will not pick up the right configuration files and rules.
+
 In some cases, you may need to run a fix script more than once to catch and fix all fixable errors. This typically occurs when a line has multiple errors affecting the same parts and fix actions collide, so Markdownlint only applies some of the fixes.
 
 With either of these two methods, keep in mind that not all issues that get flagged will have an autofix available. Some rules require fixes that are more dependent on context and cannot - and should not - be automatically fixed, such as our custom rule `TOP001` for descriptive link text.


### PR DESCRIPTION
## Because

The local linting instructions don't actually specify that the scripts must be run in the curriculum repo root, else it won't pick up the right config files. People less familiar much of this may not realise this is the case. We've had several cases where people have navigated to a lesson file's subdirectory then run a script there, received 0 errors, pushed, then got confused why GH actions was reporting lint errors.

## This PR

- Add explicit instruction to run npm scripts in the repo root.
- Convert last sections to use GitHub alert boxes for visibility.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
N/A

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
