### PR TITLE
Markdownlint: Add blacklisted exact matches to TOP001

### DIFF
--- a/markdownlint/TOP001_descriptiveLinkText/TOP001_descriptiveLinkText.js
+++ b/markdownlint/TOP001_descriptiveLinkText/TOP001_descriptiveLinkText.js
@@ -1,3 +1,27 @@
+const BLACKLISTED_LINK_TEXT = [
+  "video",
+  "videos",
+  "a video",
+  "playlist",
+  "a playlist",
+  "article",
+  "articles",
+  "an article",
+  "doc",
+  "docs",
+  "the docs",
+  "their docs",
+  "documentation",
+  "the documentation",
+  "their documentation",
+  "resource",
+  "library",
+  "page",
+  "homepage",
+  "the homepage",
+  "their homepage",
+];
+
 module.exports = {
   names: ["TOP001", "descriptive-link-text"],
   description: "Links have descriptive text labels",
@@ -18,27 +42,26 @@ module.exports = {
       .map((linkToken) => childrenOfTokensWithLinks.indexOf(linkToken));
 
     linkOpenTokenIndices.forEach((linkOpenIndex) => {
-      const tokensAfterLinkOpen =
-        childrenOfTokensWithLinks.slice(linkOpenIndex);
+      const tokensAfterLinkOpen = childrenOfTokensWithLinks.slice(linkOpenIndex);
       const linkContentTokens = tokensAfterLinkOpen.slice(
         1,
         tokensAfterLinkOpen.findIndex((token) => token.type === "link_close")
       );
       const linkContentString = linkContentTokens
-        .map((token) =>
-          token.type === "code_inline" ? `\`${token.content}\`` : token.content
-        )
+        .map((token) => (token.type === "code_inline" ? `\`${token.content}\`` : token.content))
         .join("");
 
       // https://regexr.com/7sdtj to test the following regex against the link text itself
-      const isInvalid = /.*?(?<!(\w|`))(this|here)(?!(\w|`)).*?/i.test(
-        linkContentString
-      );
-      if (isInvalid) {
+      const containsThisOrHere = /.*?(?<!(\w|`))(this|here)(?!(\w|`)).*?/i.test(linkContentString);
+      const isBlacklistedLinkText = BLACKLISTED_LINK_TEXT.includes(linkContentString.toLowerCase());
+
+      if (containsThisOrHere || isBlacklistedLinkText) {
         const linkUrl = tokensAfterLinkOpen[0].attrs[0][1];
         onError({
           lineNumber: tokensAfterLinkOpen[0].lineNumber,
-					detail: `Expected text to not include the words "this" or "here". Use a more descriptive text that clearly conveys the purpose or content of the link.`,
+          detail: containsThisOrHere
+            ? `Expected text to not include the words "this" or "here". Use a more descriptive text that clearly conveys the purpose or content of the link.`
+            : `"${linkContentString}" is not sufficiently descriptive by itself. Use a more descriptive text that clearly conveys the purpose or content of the link.`,
           context: `[${linkContentString}](${linkUrl})`,
         });
       }

--- a/markdownlint/TOP001_descriptiveLinkText/tests/TOP001_test.md
+++ b/markdownlint/TOP001_descriptiveLinkText/tests/TOP001_test.md
@@ -10,21 +10,33 @@ This section contains a general overview of topics that you will learn in this l
 
 ### The following links should NOT be flagged
 
-[Some descriptive link text](someURL1)
-[He replied](someURL2)
-[With is](someURL3)
-[Where](someURL4)
-[Heresy](someURL5)
+[Some descriptive link text](someURL)
+[He replied](someURL)
+[With is](someURL)
+[Where](someURL)
+[Heresy](someURL)
+[Some text with the word video](someURL)
+[Some text with the words documentation, an article, docs, the docs, page, a video, articles, resource, their docs](someURL)
 
 ### The following links SHOULD be flagged
 
-[this](someURL6)
-[This video](someURL7)
-[here](someURL8)
-[Click here](someURL9)
-[This other thing](someURL10)
-[This blog post about flex-grow will be flagged as a false positive, but could still be updated](someURL11)
-[This will get caught](someURL12) and so will [this as separate matches](someURL13)
+[this](someURL)
+[This video](someURL)
+[video](someURL)
+[videos](someURL)
+[a video](someURL)
+[docs](someURL)
+[the documentation](someURL)
+[their documentation](someURL)
+[page](someURL)
+[their homepage](someURL)
+[playlist](someURL)
+[a playlist](someURL)
+[here](someURL)
+[Click here](someURL)
+[This other thing](someURL)
+[This blog post about flex-grow will be flagged as a false positive, but could still be updated](someURL)
+[This will get caught](someURL) and so will [this as separate matches](someURL)
 
 ### Assignment
 

--- a/markdownlint/docs/TOP001.md
+++ b/markdownlint/docs/TOP001.md
@@ -4,7 +4,12 @@ Tags: `accessibility`, `links`
 
 Aliases: `descriptive-link-text`
 
-This rule is triggered when a link has a text label that uses the words "this" or "here", for example:
+This rule is triggered when a link has a text label that meets one of the following criteria:
+
+- Uses the words "this" or "here"
+- Exactly matches one of our blacklisted link texts (commonly used text labels that are insufficiently descriptive)
+
+Example of links that have text labels that include "this" or "here":
 
 ```markdown
 You can read more about variables in JavaScript [here](https://example.com).
@@ -18,7 +23,7 @@ You can read more about [variables in JavaScript](https://example.com).
 [An in-depth article about closures in JavaScript](https://example.com) provides more information.
 ```
 
-Note that this rule only flags text labels containing the words "this" or "here", even if the text is somewhat descriptive:
+Note that even if the text is somewhat descriptive, this rule will still flag occurrences of "this" or "here":
 
 ```markdown
 [Here is a comprehensive guide to understanding closures](https://example.com).
@@ -36,6 +41,20 @@ Additionally, consider including relevant keywords in the link text to provide m
 For more information, refer to the [official documentation on closures in JavaScript](https://example.com).
 ```
 
+This rule is also triggered if the entire link text exactly matches any of our blacklisted texts, which consists of commonly used text labels that are not sufficiently descriptive while not containing "this" or "here". Examples include (but are not limited to) "video", "article", "an article", "docs", "the docs", "documentation", and "homepage":
+
+```markdown
+For more information, watch this [video](https://example.com) about the CSS box model.
+You can read more about it in the [documentation](https://example.com).
+```
+
+The above links can be rephrased to be sufficiently descriptive by themselves:
+
+```markdown
+For more information, watch this [video about the CSS box model](https://example.com).
+You can read more about it in the [Proc class documentation](https://example.com).
+```
+
 ## Rationale
 
- Descriptive link text improves accessibility by providing clear and meaningful context about the link's destination. Links with text labels using the words "this" or "here" tend to be less descriptive and may not effectively convey the purpose of the link to users, especially those using assistive technologies. By using specific and relevant keywords in the link text, you can enhance the user experience and make it easier for users to understand the context and purpose of the link.
+Descriptive link text improves accessibility by providing clear and meaningful context about the link's destination. Links with text labels using the words "this" or "here" tend to be less descriptive and may not effectively convey the purpose of the link to users, especially those using assistive technologies. Similarly, text labels like "video", "article" or "docs" act in the same way for users of assistive technologies, requiring knowledge of the surrounding non-link text for context. By using specific and relevant keywords in the link text, you can enhance the user experience and make it easier for users to understand the context and purpose of the link.


### PR DESCRIPTION
## Because

While flagging "this" and "here" in link text labels has been working well, it's still common that "fixed" or even new links come with labels like "video" or "article", which are insufficiently descriptive.

While we can't catch everything (context-dependent), we can blacklist some of the most common phrases which can aid maintainers as well as potentially educate more contributors if they flag that error. These must only flag for exact matches, not just if the link text includes it somewhere ("video" should flag but not "video about binary search trees").

## This PR

- Adds array of blacklisted link text labels to TOP001 custom rule, and flags on a blacklist error (with blacklist-specific error message).
- Adds examples of blacklisted text labels to TOP001 test file.
  - Amended placeholder link hrefs as duplicates are fine (and no need to adjust numbers)
- Updates TOP001 doc file with new flag criteria and examples.

## Issue

N/A

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
