### PR TITLE
React Conclusion: Fix "Using a backend" typo 

### DIFF
--- a/react/conclusion/conclusion_full_stack_javascript.md
+++ b/react/conclusion/conclusion_full_stack_javascript.md
@@ -20,7 +20,7 @@ As you've seen, you can get your apps to do a lot of pretty cool things already,
 
 While Local Storage is great, it's not ideal: it only stores data on the computer from which the user is accessing the page. This approach does not allow for the app to 'remember' anything when the same user tries to access it again from a different device. For that, you're going to need a real backend, which you'll learn all about next in our [NodeJS](https://www.theodinproject.com/paths/full-stack-javascript/courses/nodejs) course. With Node, we'll be able to add a bunch of cool features to your apps like user authentication, data persistence, and more.
 
-You have very come far and you should be proud of yourself for getting to this point.
+You have come very far and you should be proud of yourself for getting to this point.
 
 ### Contribute
 

--- a/react/conclusion/conclusion_ruby_on_rails.md
+++ b/react/conclusion/conclusion_ruby_on_rails.md
@@ -12,7 +12,7 @@ You can also keep up with the future of React by following the [React RFC GitHub
 
 You're at a point in your React journey where you can begin learning about design patterns and architecture. [patterns.dev](https://www.patterns.dev/) is an exceptional resource that will help you build better React apps by leveraging powerful patterns. They are worth a bookmark!
 
-You have very come far and you should be proud of yourself for getting to this point.
+You have come very far and you should be proud of yourself for getting to this point.
 
 Before you move onto the next section. Fill out this [React course feedback survey](https://docs.google.com/forms/d/e/1FAIpQLSdj_tNMp0LEz3ZLPqYcF67V11tX_CCJP3CTictPZzZ6XQm2Gw/viewform?usp=sf_link) to add your input and experience with the section. This helps us improve the section as well as the overall course and is greatly appreciated.
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
This PR fixes a typo in the React Conclusion files in both paths.

## This PR
- corrects the typo in "Using a backend" section on the Conclusion files;

## Issue
Closes #28554

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
