### PR TITLE
Working with Remotes lesson: Reword a knowledge check item

### DIFF
--- a/git/intermediate_git/working_with_remotes.md
+++ b/git/intermediate_git/working_with_remotes.md
@@ -89,7 +89,7 @@ Let's review the dangers we've addressed so far. I know, I know, it's scary stuf
 
 The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
 
-- [What is a safe way to push history changes to a remote repository?](#force-with-lease)
+- [What is a safe way to forcefully push history changes to a remote repository?](#force-with-lease)
 - [What are the dangers of history-changing operations?](#dangers)
 - [What are best practices of history-changing operations?](#best-practices)
 


### PR DESCRIPTION
## Because

The current wording is ambiguous. The question could be correctly answered by both `git push` and `git push --force-with-lease`, the latter being the answer that we're actually looking for.


## This PR

- Adds a single word to a 'knowledge check' item.


## Issue


## Additional Information


## Pull Request Requirements
-   [X] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [X] The `Because` section summarizes the reason for this PR
-   [X] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [X] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [X] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
