### PR TITLE
intermediate_html_css/intermediate_css_concepts/default_styles.md: Fixes markdown syntax for code element

### DIFF
--- a/intermediate_html_css/intermediate_css_concepts/default_styles.md
+++ b/intermediate_html_css/intermediate_css_concepts/default_styles.md
@@ -11,7 +11,7 @@ This section contains a general overview of topics that you will learn in this l
 
 ### What are default styles and where do they come from?
 
-As you have worked on projects, you likely observed default styles applied to certain elements, such as larger and bolder headings on `h1` elements, and blue, underlined links on `a' elements. There is also a good chance you struggled with things like default margins and padding. These styles are part of the user-agent stylesheets, ensuring basic styling for webpages without CSS. Each browser has its own set of user-agent stylesheets so the default styles do vary slightly between browsers.
+As you have worked on projects, you likely observed default styles applied to certain elements, such as larger and bolder headings on `h1` elements, and blue, underlined links on `a` elements. There is also a good chance you struggled with things like default margins and padding. These styles are part of the user-agent stylesheets, ensuring basic styling for webpages without CSS. Each browser has its own set of user-agent stylesheets so the default styles do vary slightly between browsers.
 
 ### What if I don't like the defaults?
 


### PR DESCRIPTION
## Because

Makrdown for the code syntax is broken because it doesn't have the closing backtick. Instead, it has a quotation mark.

## This PR
This PR is fixing the markdown syntax.

**From**: \`a'
**To**: \`a\`

## Issue

No issue exists.

## Additional Information

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
