### PR TITLE
Include warning about Prisma not supporting identity columns

### DIFF
--- a/nodeJS/orms/prisma_orm.md
+++ b/nodeJS/orms/prisma_orm.md
@@ -118,6 +118,14 @@ You might have a complex query that you just are unable to get right via the Pri
 
 Prisma migrate is a tool that helps you perform database migrations. You won't be using it a whole ton in the curriculum, but it's good to be aware of it. When you decide to change the schema in any way, you run a Prisma migration to apply the schema changes to the database. These changes are tracked in a `migrations` folder in your codebase.
 
+<div class="lesson-note" markdown="1">
+
+#### ORM Limitations
+
+In the [Using Postgres](https://www.theodinproject.com/lessons/nodejs-using-postgresql) lesson, we learned about Identity columns. Postgres recommends the use of Identity columns, as they comply with the SQL standard. Prisma, however, does not support these columns, and will create Postgres specific [Serial Types](https://www.postgresql.org/docs/16/datatype-numeric.html#DATATYPE-SERIAL) instead. This most likely will not affect your projects, but it can be important to keep in mind. For a short description on the difference between Serial and Identity, see this [Stackoverflow answer](https://stackoverflow.com/a/55300741/1882858).
+
+</div>
+
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">

--- a/nodeJS/orms/prisma_orm.md
+++ b/nodeJS/orms/prisma_orm.md
@@ -118,11 +118,11 @@ You might have a complex query that you just are unable to get right via the Pri
 
 Prisma migrate is a tool that helps you perform database migrations. You won't be using it a whole ton in the curriculum, but it's good to be aware of it. When you decide to change the schema in any way, you run a Prisma migration to apply the schema changes to the database. These changes are tracked in a `migrations` folder in your codebase.
 
-<div class="lesson-note" markdown="1">
+<div class="lesson-note lesson-note--warning" markdown="1">
 
-#### ORM Limitations
+#### Prisma ORM limitations
 
-In the [Using Postgres](https://www.theodinproject.com/lessons/nodejs-using-postgresql) lesson, we learned about Identity columns. Postgres recommends the use of Identity columns, as they comply with the SQL standard. Prisma, however, does not support these columns, and will create Postgres specific [Serial Types](https://www.postgresql.org/docs/16/datatype-numeric.html#DATATYPE-SERIAL) instead. This most likely will not affect your projects, but it can be important to keep in mind. For a short description on the difference between Serial and Identity, see this [Stackoverflow answer](https://stackoverflow.com/a/55300741/1882858).
+In the [Using PostgreSQL lesson](https://www.theodinproject.com/lessons/nodejs-using-postgresql), we learned about Identity columns. PostgreSQL recommends the use of Identity columns, as they comply with the SQL standard. Prisma ORM, however, does not support these columns, and will create PostgreSQL specific [Serial Types](https://www.postgresql.org/docs/16/datatype-numeric.html#DATATYPE-SERIAL) instead. This most likely will not affect your projects, but it can be important to keep in mind. See this Stackoverflow answer for a short description on the [difference between Serial and Identity](https://stackoverflow.com/a/55300741/1882858).
 
 </div>
 


### PR DESCRIPTION
## Because
Prisma does not support identity columns, which is both the SQL standard and the recommended way to create auto-incrementing columns in Postgres. This pull request lets readers know this and gives a short explanation as to the difference between serial types and identity columns via a stackoverflow answer and Postgres' documentation.


## This PR
- A short paragraph explaining the difference between the two columns and Prisma's lack of support was included above the assignment. 


## Issue
Closes #28583

## Additional Information
I thought about placing this in the Prisma Schema section, but the Migration files themselves detail how Prisma creates tables.


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
