### PR TITLE
Fix typos in PostgreSQL installation instructions

### DIFF
--- a/nodeJS/express/installing_postgresql.md
+++ b/nodeJS/express/installing_postgresql.md
@@ -135,7 +135,7 @@ You'll be prompted to enter a password and to verify it. Once you are done, the 
 GRANT ALL PRIVILEGES ON DATABASE <role_database_name> TO <role_name>;
 ```
 
-Remember that you should change the `<role_database_name>` and `<role_name>` (they should be both the same)! If you see `GRANT` in response to the command, then you can type `\q` to exit the prompt.
+Remember that you should change the `<role_database_name>` and `<role_name>` (they should both be the same)! If you see `GRANT` in response to the command, then you can type `\q` to exit the prompt.
 
 #### 3.5 Saving access information in the environment
 
@@ -259,7 +259,7 @@ You'll be prompted to enter a password and to verify it. Once you are done, the 
 GRANT ALL PRIVILEGES ON DATABASE <role_database_name> TO <role_name>;
 ```
 
-Remember that you should change the `<role_database_name>` and `<role_name>` (they should both the same)! If you see `GRANT` in response to the command, then you can type `\q` to exit the prompt.
+Remember that you should change the `<role_database_name>` and `<role_name>` (they should both be the same)! If you see `GRANT` in response to the command, then you can type `\q` to exit the prompt.
 
 #### 3.4 Saving access information in the environment
 

--- a/ruby_on_rails/advanced_forms_and_activerecord/installing_psql.md
+++ b/ruby_on_rails/advanced_forms_and_activerecord/installing_psql.md
@@ -159,7 +159,7 @@ You'll be prompted to enter a password and to verify it. Once you are done, the 
 GRANT ALL PRIVILEGES ON DATABASE <role_database_name> TO <role_name>;
 ```
 
-Remember that you should change the `<role_database_name>` and `<role_name>` (they should both the same)! If you see `GRANT` in response to the command, then you can type `\q` to exit the prompt.
+Remember that you should change the `<role_database_name>` and `<role_name>` (they should both be the same)! If you see `GRANT` in response to the command, then you can type `\q` to exit the prompt.
 
 #### 3.5 Saving access information in the environment
 
@@ -283,7 +283,7 @@ You'll be prompted to enter a password and to verify it. Once you are done, the 
 GRANT ALL PRIVILEGES ON DATABASE <role_database_name> TO <role_name>;
 ```
 
-Remember that you should change the `<role_database_name>` and `<role_name>` (they should both the same)! If you see `GRANT` in response to the command, then you can type `\q` to exit the prompt.
+Remember that you should change the `<role_database_name>` and `<role_name>` (they should both be the same)! If you see `GRANT` in response to the command, then you can type `\q` to exit the prompt.
 
 #### 3.4 Saving access information in the environment
 


### PR DESCRIPTION
## Because
There were minor wording inconsistencies in the `Installing PostgreSQL` section of both the Ruby on Rails and Node.js lessons.


## This PR
- In the Ruby on Rails lesson, changed `they should both the same` to `they should both be the same`
- In the Node.js lesson, changed `they should be both the same` to `they should both be the same`


## Issue
Closes #28676


## Additional Information
nil


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
