### PR TITLE
Fix: Keys in React: Add missing word

### DIFF
--- a/react/getting_started_with_react/keys_in_react.md
+++ b/react/getting_started_with_react/keys_in_react.md
@@ -22,7 +22,7 @@ If the list were to change, one of two things *should* happen:
 
 Assuming we want to hunt down that one specific item that was changed and NOT re-render the entire list. We need something to track that specific item. We can track down a specific item by using a `key`.
 
-When the list is updated for whatever reason, (either from a server or a user interaction), React matches the `keys` of each of the previous list to the updated list. If there were any changes, React will only update the items that have changed.
+When the list is updated for whatever reason, (either from a server or a user interaction), React matches the `keys` of each of the previous list items to the updated list. If there were any changes, React will only update the items that have changed.
 
 As long as `keys` remain consistent and unique, React can handle the DOM effectively and efficiently.
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
- "the `keys` of each of the previous list to the updated list" doesn't make sense

## This PR
- changes it to "the `keys` of each of the previous list items to the updated list"

## Additional Information
See https://discord.com/channels/505093832157691914/664184123061174274/1277311492714266718 for discussion

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
