### PR TITLE
ES6 Modules: Add warning about opening directly in browser

### DIFF
--- a/javascript/organizing_your_javascript_code/es6_modules.md
+++ b/javascript/organizing_your_javascript_code/es6_modules.md
@@ -214,7 +214,7 @@ two.js <-------------- one.js <-------------- three.js
 
 Note that we only needed the one script tag, as the browser will handle the additional file dependencies for us. We also did not need to add the `defer` attribute, as `type="module"` will automatically defer script execution for us.
 
-If you had coded along with the IIFE example at the start of the lesson, try rewriting the JavaScript to use `import` and `export`, and link only the entry point as a module script. Due to browser security reasons, ES6 modules cannot be loaded if you open the HTML file directly in the browser, so make sure you use Visual Studio Code's [Live Server extension](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer) if you aren't already.
+If you had coded along with the IIFE example at the start of the lesson, try rewriting the JavaScript to use `import` and `export`, and link only the entry point as a module script. Due to browser security reasons, ES6 modules cannot be loaded if you open the HTML file directly in the browser, so make sure you use Visual Studio Code's [Live Preview extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.live-server) if you aren't already.
 
 ### CommonJS
 

--- a/javascript/organizing_your_javascript_code/es6_modules.md
+++ b/javascript/organizing_your_javascript_code/es6_modules.md
@@ -216,6 +216,16 @@ Note that we only needed the one script tag, as the browser will handle the addi
 
 If you had coded along with the IIFE example at the start of the lesson, try rewriting the JavaScript to use `import` and `export`, and link only the entry point as a module script.
 
+<div class="lesson-note lesson-note--warning" markdown="1">
+
+#### Opening ES6 modules locally in the browser
+
+Due to security restrictions with the `file://` protocol, if you try to open an HTML file with module scripts directly in the browser (e.g. running `google-chrome index.html` in the terminal or similar), you will be greeted with a CORS error.
+
+ES6 modules need to be served via a server. For now, if you haven't been using it already, you should use Visual Studio Code's [Live Server extension](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer).
+
+</div>
+
 ### CommonJS
 
 Along the way, you may have bumped into something called CommonJS (CJS), which uses syntax like `require` and `module.exports` instead of `import` and `export`. You may remember seeing this in our JavaScript exercises in the Foundations course (you've come a long way)! This is a module system that was designed for use with Node.js that works a little differently than ESM, and is not something that browsers will be able to understand.

--- a/javascript/organizing_your_javascript_code/es6_modules.md
+++ b/javascript/organizing_your_javascript_code/es6_modules.md
@@ -214,17 +214,7 @@ two.js <-------------- one.js <-------------- three.js
 
 Note that we only needed the one script tag, as the browser will handle the additional file dependencies for us. We also did not need to add the `defer` attribute, as `type="module"` will automatically defer script execution for us.
 
-If you had coded along with the IIFE example at the start of the lesson, try rewriting the JavaScript to use `import` and `export`, and link only the entry point as a module script.
-
-<div class="lesson-note lesson-note--warning" markdown="1">
-
-#### Opening ES6 modules locally in the browser
-
-Due to security restrictions with the `file://` protocol, if you try to open an HTML file with module scripts directly in the browser (e.g. running `google-chrome index.html` in the terminal or similar), you will be greeted with a CORS error.
-
-ES6 modules need to be served via a server. For now, if you haven't been using it already, you should use Visual Studio Code's [Live Server extension](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer).
-
-</div>
+If you had coded along with the IIFE example at the start of the lesson, try rewriting the JavaScript to use `import` and `export`, and link only the entry point as a module script. Due to browser security reasons, ES6 modules cannot be loaded if you open the HTML file directly in the browser, so make sure you use Visual Studio Code's [Live Server extension](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer) if you aren't already.
 
 ### CommonJS
 


### PR DESCRIPTION
## Because

ES6 modules require a dev server to be opened (as opposed to opening directly in the browser under `file://`) due to CORS. I had assumed we directly assigned people to use the Live Preview extension in VSC in an earlier lesson but they're actually just tips, so not everyone would have been using it ([user on Discord confused by CORS error due to opening via terminal](https://discord.com/channels/505093832157691914/513125308757442562/1281357219656630303)).

A quick note can be added that live server is necessary for now. Later, webpack-dev-server will be introduced.

## This PR

- Adds warning box for opening ES6 modules, advising use of Live Preview instead


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
N/A

## Additional Information

Changed from Live Server to Live Preview due to #28801 

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
