### PR TITLE
Update intro-to-css.md

### DIFF
--- a/foundations/html_css/css-foundations/intro-to-css.md
+++ b/foundations/html_css/css-foundations/intro-to-css.md
@@ -360,20 +360,13 @@ If you need to add a *unique* style for a *single* element, this method can work
 - It can quickly become pretty messy once you start adding a *lot* of declarations to a single element, causing your HTML file to become unnecessarily bloated.
 - If you want many elements to have the same style, you would have to copy and paste the same style to each individual element, causing lots of unnecessary repetition and more bloat.
 - Any inline CSS will override the other two methods, which can cause unexpected results. (While we won't dive into it here, this can actually be taken advantage of.)
-
-### Warning
-
-<div class="lesson-note" markdown="1">
-
-Kindly complete exercises 1 to 5 within the `Foundations` folder only. Please avoid doing anything outside of this folder in the CSS exercises repository, such as `animation`, `grid`, or `flex`, as these topics will be taught later in this curriculum.
-
-</div>
-
+- 
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">
 
-1. Go to our [CSS exercises repository](https://github.com/TheOdinProject/css-exercises) and read the README. Then, once you know how to use the exercises, navigate to the `foundations` directory. Review each README file prior to completing the following exercises in order:
+1. Go to our [CSS exercises repository](https://github.com/TheOdinProject/css-exercises) and read the README.
+2. Then, once you know how to use the exercises, navigate to the [foundations](https://github.com/TheOdinProject/css-exercises/tree/main/foundations) directory. Review each README file prior to completing the following exercises in order:
 
     - `01-css-methods`
     - `02-class-id-selectors`

--- a/foundations/html_css/css-foundations/intro-to-css.md
+++ b/foundations/html_css/css-foundations/intro-to-css.md
@@ -361,6 +361,16 @@ If you need to add a *unique* style for a *single* element, this method can work
 - If you want many elements to have the same style, you would have to copy and paste the same style to each individual element, causing lots of unnecessary repetition and more bloat.
 - Any inline CSS will override the other two methods, which can cause unexpected results. (While we won't dive into it here, this can actually be taken advantage of.)
 
+
+### Warning
+
+<div class="lesson-note" markdown="1">
+
+Kindly complete exercises 1 to 5 within the `Foundations` folder only. Please avoid doing anything outside of this folder in the CSS exercises repository, such as `animation`, `grid`, or `flex`, as these topics will be taught later in this curriculum.
+
+</div>
+
+
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">

--- a/foundations/html_css/css-foundations/intro-to-css.md
+++ b/foundations/html_css/css-foundations/intro-to-css.md
@@ -360,7 +360,7 @@ If you need to add a *unique* style for a *single* element, this method can work
 - It can quickly become pretty messy once you start adding a *lot* of declarations to a single element, causing your HTML file to become unnecessarily bloated.
 - If you want many elements to have the same style, you would have to copy and paste the same style to each individual element, causing lots of unnecessary repetition and more bloat.
 - Any inline CSS will override the other two methods, which can cause unexpected results. (While we won't dive into it here, this can actually be taken advantage of.)
-- 
+
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">

--- a/foundations/html_css/css-foundations/intro-to-css.md
+++ b/foundations/html_css/css-foundations/intro-to-css.md
@@ -366,7 +366,7 @@ If you need to add a *unique* style for a *single* element, this method can work
 <div class="lesson-content__panel" markdown="1">
 
 1. Go to our [CSS exercises repository](https://github.com/TheOdinProject/css-exercises) and read the README file.
-1. Then, once you know how to use the exercises, navigate to the [foundations](https://github.com/TheOdinProject/css-exercises/tree/main/foundations) directory. Review each README file prior to completing the following exercises in order:
+1. Then, once you know how to use the exercises, navigate to the [CSS exercises repository's foundations directory](https://github.com/TheOdinProject/css-exercises/tree/main/foundations). Review each README file prior to completing the following exercises in order:
 
     - `01-css-methods`
     - `02-class-id-selectors`

--- a/foundations/html_css/css-foundations/intro-to-css.md
+++ b/foundations/html_css/css-foundations/intro-to-css.md
@@ -365,7 +365,7 @@ If you need to add a *unique* style for a *single* element, this method can work
 
 <div class="lesson-content__panel" markdown="1">
 
-1. Go to our [CSS exercises repository](https://github.com/TheOdinProject/css-exercises) and read the README.
+1. Go to our [CSS exercises repository](https://github.com/TheOdinProject/css-exercises) and read the README file.
 2. Then, once you know how to use the exercises, navigate to the [foundations](https://github.com/TheOdinProject/css-exercises/tree/main/foundations) directory. Review each README file prior to completing the following exercises in order:
 
     - `01-css-methods`

--- a/foundations/html_css/css-foundations/intro-to-css.md
+++ b/foundations/html_css/css-foundations/intro-to-css.md
@@ -361,7 +361,6 @@ If you need to add a *unique* style for a *single* element, this method can work
 - If you want many elements to have the same style, you would have to copy and paste the same style to each individual element, causing lots of unnecessary repetition and more bloat.
 - Any inline CSS will override the other two methods, which can cause unexpected results. (While we won't dive into it here, this can actually be taken advantage of.)
 
-
 ### Warning
 
 <div class="lesson-note" markdown="1">
@@ -369,7 +368,6 @@ If you need to add a *unique* style for a *single* element, this method can work
 Kindly complete exercises 1 to 5 within the `Foundations` folder only. Please avoid doing anything outside of this folder in the CSS exercises repository, such as `animation`, `grid`, or `flex`, as these topics will be taught later in this curriculum.
 
 </div>
-
 
 ### Assignment
 

--- a/foundations/html_css/css-foundations/intro-to-css.md
+++ b/foundations/html_css/css-foundations/intro-to-css.md
@@ -366,7 +366,7 @@ If you need to add a *unique* style for a *single* element, this method can work
 <div class="lesson-content__panel" markdown="1">
 
 1. Go to our [CSS exercises repository](https://github.com/TheOdinProject/css-exercises) and read the README file.
-2. Then, once you know how to use the exercises, navigate to the [foundations](https://github.com/TheOdinProject/css-exercises/tree/main/foundations) directory. Review each README file prior to completing the following exercises in order:
+1. Then, once you know how to use the exercises, navigate to the [foundations](https://github.com/TheOdinProject/css-exercises/tree/main/foundations) directory. Review each README file prior to completing the following exercises in order:
 
     - `01-css-methods`
     - `02-class-id-selectors`


### PR DESCRIPTION
A warning would be very helpful as i see people in discord everyday asking doubts about animation exercise. They solve 1to5 exercises and then in flow they start animation even when its instructed. I think a warning should make them aware to not touch anything else except foundations 1 to 5 exercises.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
