### PR TITLE
GH Markdownlint Workflows: Fix path filtering

### DIFF
--- a/.github/workflows/markdownlint-lessons.yml
+++ b/.github/workflows/markdownlint-lessons.yml
@@ -3,11 +3,12 @@ on:
     pull_request:
         paths:
             - '**.md'
-            - '!./*.md'
-            - '!**/project*.md'
-            - '!./archive/**.md'
-            - '!./templates/**.md'
-            - '!./markdownlint/docs/**.md'
+            - '!*'
+            - '!**/project*'
+            - '!archive/**'
+            - '!templates/**'
+            - '!markdownlint/docs/**'
+            - '!.github/**'
 
 jobs:
     lesson_lint:
@@ -20,12 +21,12 @@ jobs:
             with:
               files: |
                 **.md
-                !./*.md
-                !README.md
-                !**/project*.md
-                !./archive/**.md
-                !./templates/**.md
-                !./markdownlint/docs/**.md
+                !*
+                !**/project*
+                !archive/**
+                !templates/**
+                !markdownlint/docs/**
+                !.github/**
               separator: ','
           - uses: DavidAnson/markdownlint-cli2-action@v14
             with:

--- a/.github/workflows/markdownlint-projects.yml
+++ b/.github/workflows/markdownlint-projects.yml
@@ -3,10 +3,11 @@ on:
   pull_request:
     paths:
         - '**/project*.md'
-        - '!./*.md'
-        - '!./archive/**.md'
-        - '!./templates/**.md'
-        - '!./markdownlint/docs/**.md'
+        - '!*'
+        - '!archive/**'
+        - '!templates/**'
+        - '!markdownlint/docs/**'
+        - '!.github/**'
 
 jobs:
     project_lint:
@@ -19,11 +20,11 @@ jobs:
             with:
               files: |
                 **/project*.md
-                !./*.md
-                !README.md
-                !./archive/**.md
-                !./templates/**.md
-                !./markdownlint/docs/**.md
+                !*
+                !archive/**
+                !templates/**
+                !markdownlint/docs/**
+                !.github/**
               separator: ','
           - uses: DavidAnson/markdownlint-cli2-action@v14
             with:


### PR DESCRIPTION
## Because

`./LAYOUT_STYLE_GUIDE.md` triggered the lesson markdownlint workflow in #28756 despite it being filtered out by `'!./*.md'` in the workflow file. From testing, it seems that `./` isn't recognised in `on.pull_request.paths` for some reason (I think it reads the `.` literally as opposed to "current directory"?). Removing `./` fixes the behaviour.

## This PR

- Removes leading `./` from path filtering in markdownlint workflows
- Removes redundant trailing `.md` in negation patterns (only `.md` files get matched already)
- Negates `.github` directory

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
N/A

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
