### PR TITLE
Webpack: Note about restarting webpack-dev-server on config change

### DIFF
--- a/javascript/organizing_your_javascript_code/webpack.md
+++ b/javascript/organizing_your_javascript_code/webpack.md
@@ -408,6 +408,10 @@ Secondly, by default, `webpack-dev-server` will only auto-restart when it detect
 
 Once set up, `npx webpack serve` will host our web page on `http://localhost:8080/`, which we can open in our browser and start working!
 
+<div class="lesson-note">
+Note that the webpack-dev-server reads your webpack configuration <em>once</em> when you start it. If you change the webpack config file while the dev server is running, it will not reflect those config changes. Use <kbd>Ctrl</kbd> + <kbd>C</kbd> to restart it to apply the new config.  
+</div>
+
 ### Rounding up
 
 Yes, yes, this all might seem like a lot. You've gone from just having some basic HTML, CSS and JS files, and not needing much else to suddenly needing this loader, that plugin, this configuration file, etc. In the real world, as apps get more complex, we need tools that can improve our development experience while optimizing things in production. Even though we're not using all of the features available to us right now, a general understanding of what these sorts of tools are doing for us is valuable. Later in the curriculum, you will use different tools that abstract a lot of these underlying mechanisms away from us. Using them and having no clue what they're actually doing for you can make things harder for you when you eventually encounter a situation that actually needs some kind of manual configuration.

--- a/javascript/organizing_your_javascript_code/webpack.md
+++ b/javascript/organizing_your_javascript_code/webpack.md
@@ -410,7 +410,7 @@ Once set up, `npx webpack serve` will host our web page on `http://localhost:808
 
 <div class="lesson-note">
   
-Note that the webpack-dev-server reads your webpack configuration <em>once</em> when you start it. If you change the webpack config file while the dev server is running, it will not reflect those config changes. Use <kbd>Ctrl</kbd> + <kbd>C</kbd> to restart it to apply the new config.  
+Note that the webpack-dev-server only reads your webpack configuration when you start it. If you change the webpack config file while the dev server is running, it will not reflect those config changes. Use <kbd>Ctrl</kbd> + <kbd>C</kbd> in the terminal to kill it then rerun `npx webpack serve` to apply the new config.  
 
 </div>
 

--- a/javascript/organizing_your_javascript_code/webpack.md
+++ b/javascript/organizing_your_javascript_code/webpack.md
@@ -409,7 +409,7 @@ Secondly, by default, `webpack-dev-server` will only auto-restart when it detect
 Once set up, `npx webpack serve` will host our web page on `http://localhost:8080/`, which we can open in our browser and start working!
 
 <div class="lesson-note" markdown="1">
-  
+
 Note that the webpack-dev-server only reads your webpack configuration when you start it. If you change the webpack config file while the dev server is running, it will not reflect those config changes. Use <kbd>Ctrl</kbd> + <kbd>C</kbd> in the terminal to kill it then rerun `npx webpack serve` to apply the new config.  
 
 </div>

--- a/javascript/organizing_your_javascript_code/webpack.md
+++ b/javascript/organizing_your_javascript_code/webpack.md
@@ -409,7 +409,9 @@ Secondly, by default, `webpack-dev-server` will only auto-restart when it detect
 Once set up, `npx webpack serve` will host our web page on `http://localhost:8080/`, which we can open in our browser and start working!
 
 <div class="lesson-note">
+  
 Note that the webpack-dev-server reads your webpack configuration <em>once</em> when you start it. If you change the webpack config file while the dev server is running, it will not reflect those config changes. Use <kbd>Ctrl</kbd> + <kbd>C</kbd> to restart it to apply the new config.  
+
 </div>
 
 ### Rounding up

--- a/javascript/organizing_your_javascript_code/webpack.md
+++ b/javascript/organizing_your_javascript_code/webpack.md
@@ -408,7 +408,7 @@ Secondly, by default, `webpack-dev-server` will only auto-restart when it detect
 
 Once set up, `npx webpack serve` will host our web page on `http://localhost:8080/`, which we can open in our browser and start working!
 
-<div class="lesson-note">
+<div class="lesson-note" markdown="1">
   
 Note that the webpack-dev-server only reads your webpack configuration when you start it. If you change the webpack config file while the dev server is running, it will not reflect those config changes. Use <kbd>Ctrl</kbd> + <kbd>C</kbd> in the terminal to kill it then rerun `npx webpack serve` to apply the new config.  
 


### PR DESCRIPTION
## Because
It's easy to not know / forget that dev server doesn't automatically reload to reflect webpack conifg changes.


## This PR
- Adds note box at the end of the [webpack-dev-server part of the Webpack lesson](https://www.theodinproject.com/lessons/javascript-webpack#webpack-dev-server)
  - Note warns reader to restart their dev server with Ctrl + C after changing webpack config

## Issue
Closes #28766 

## Additional Information
N/A

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
