### PR TITLE
Async and Await: fix minor grammar

### DIFF
--- a/javascript/asynchronous_javascript_and_apis/async_and_await.md
+++ b/javascript/asynchronous_javascript_and_apis/async_and_await.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-Asynchronous code can become difficult to follow when it has a lot of things going on. `async` and `await` are two keywords that can help make asynchronous read more like synchronous code. This can help code look cleaner while keeping the benefits of asynchronous code.
+Asynchronous code can become difficult to follow when it has a lot of things going on. `async` and `await` are two keywords that can help make asynchronous code read more like synchronous code. This can help code look cleaner while keeping the benefits of asynchronous code.
 
 For example, the two code blocks below do the exact same thing. They both get information from a server, process it, and return a promise.
 


### PR DESCRIPTION
Small grammatical fix (see **)

Asynchronous code can become difficult to follow when it has a lot of things going on. async and await are two keywords that can help make asynchronous **code** read  more like synchronous code.



## Because
Grammatical error. Makes it clear we are referring to the code.

## This PR
- Add "code" after asynchronous 

## Issue
N/A

## Additional Information
NA

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
