### PR TITLE
Ruby: Object Oriented Programming: Update reference to section

### DIFF
--- a/ruby/object_oriented_programming_basics/object_oriented_programming.md
+++ b/ruby/object_oriented_programming_basics/object_oriented_programming.md
@@ -21,7 +21,7 @@ This section contains a general overview of topics that you will learn in this l
 <div class="lesson-content__panel" markdown="1">
 
 1. Read the [Object Oriented Programming with Ruby](https://launchschool.com/books/oo_ruby) online book, by Launch School.
-1. Read through these reinforcing posts by Erik Trautman to help you answer the questions in the "Learning Outcomes" section:
+1. Read through these reinforcing posts by Erik Trautman to help you answer the questions in the "Knowledge check" section:
     - [Ruby Explained: Classes](http://www.eriktrautman.com/posts/ruby-explained-classes)
     - [Ruby Explained: Inheritance and Scope](http://www.eriktrautman.com/posts/ruby-explained-inheritance-and-scope)
 1. Read the article [Object Relationships in Basic Ruby](https://medium.com/@marcellamaki/object-relationships-in-basic-ruby-1af5773fff48) to see an example of how two classes can interact.


### PR DESCRIPTION
The section that is referred to was renamed, but the reference itself was not. (https://github.com/TheOdinProject/curriculum/commit/565217133b4ec0b67724d6d3126f9c41ca4ac4b2#diff-ee41d717b540478bb5bb2df6d3c0e47e26957f9e20173e81810b62c90d896d97R12)

## Because
The section title doesn't match any section title in the page anymore. It also refers to 'questions', which were not part of the 'Learning Outcomes' section from before, but are part of the current 'Knowledge check' section.

## This PR
- Fixes the title of the section being referred to.

## Issue

## Additional Information


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [X] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [X] The `Because` section summarizes the reason for this PR
-   [X] The `This PR` section has a bullet point list describing the changes in this PR
-   [X] If this PR addresses an open issue, it is linked in the `Issue` section
-   [X] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [X] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
