### PR TITLE
Ruby: Project Management: Change method name in description

### DIFF
--- a/ruby/object_oriented_programming_basics/managing_ruby_projects.md
+++ b/ruby/object_oriented_programming_basics/managing_ruby_projects.md
@@ -236,7 +236,7 @@ puts NotSoGreen.food_opinion('Cereal')
 puts Scheals.food_opinion('Marmite')
 #=> Marmite is awful!
 puts food_opinion('Cereal')
-#=> Errors out - there's no longer a free floating foo method to use.
+#=> Errors out - there's no longer a free floating food_opinion method to use.
 ```
 
 ### Gems and you


### PR DESCRIPTION
## Because
The description refers to the above-mentioned method as 'foo', while the example uses a method called 'food_opinion'. Probably wasn't changed when changing the example to something more descriptive.

## This PR
- Fixes the method name in the description

## Issue

## Additional Information

## Pull Request Requirements
-   [X] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [X] The `Because` section summarizes the reason for this PR
-   [X] The `This PR` section has a bullet point list describing the changes in this PR
-   [X] If this PR addresses an open issue, it is linked in the `Issue` section
-   [X] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [X] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
