### PR TITLE
NodeJS Deployment lesson: remove adaptable.io

### DIFF
--- a/nodeJS/express/deployment.md
+++ b/nodeJS/express/deployment.md
@@ -116,29 +116,6 @@ Can deploy both servers and databases.
 
 ---
 
-#### Adaptable.io
-
-Can deploy servers with or without a database attached (cannot deploy standalone databases).
-
-- Like Railway, has a convenient deployment process. You link to your project's GitHub repo.
-- Free plan does not limit the number of applications you can deploy.
-- Also has fixed and usage-based payment plans.
-
-##### Adaptable.io: Free Plan
-
-- No limits on the number of applications you can deploy on the free plan.
-- Monthly performance allowance is more than sufficient for course/personal projects (approximately 25,000 API requests per month).
-- Applications are put to sleep when inactive but wake up speed is quicker than Render.
-- Requires a credit card.
-
-##### Adaptable.io: Links
-
-- [Adaptable.io homepage](https://adaptable.io/)
-- [Adaptable.io documentation](https://adaptable.io/docs/what-is-adaptable)
-- [Guide: Official getting started with deploying an Express app on Adaptable guide](https://adaptable.io/docs/app-guides/deploy-express-app)
-
----
-
 #### Render
 
 Can deploy both servers and databases.


### PR DESCRIPTION
## Because
Adaptable.io removed it's free tier. 

## This PR
* Removes Adaptable.io from [list of recommended PaaSes in the deployment lesson of NodeJS course](https://www.theodinproject.com/lessons/node-path-nodejs-deployment#our-recommended-paas-services)


## Issue
Closes #28784 ([link here](https://github.com/TheOdinProject/curriculum/issues/28784))

## Additional Information
I had been using Adaptable.io as my PaaS. But when they added a monthly subscription I found it unreasonable to pay monthly for my portfolio sites which practically get no traffic. 

My free solution was a combination of Render for the server (it lets you deploy unlimited "web services") and Neon for the database (where I can deploy unlimited databases). There are limits on the compute in the free tiers, but I do not worry about those (because my sites get no traffic yet). There also limits on features, but I've managed to work around them.

So, I am sure Adaptable should not be recommended anymore.