### PR TITLE
Ruby: Linting and RuboCop: Add minor clarifications and improvements

### DIFF
--- a/ruby/object_oriented_programming_basics/linting_and_rubocop.md
+++ b/ruby/object_oriented_programming_basics/linting_and_rubocop.md
@@ -226,7 +226,7 @@ This will disable the `AbcSize` Cop from `Metrics` department between those comm
 
 Some rules are a lot more arbitrary - the Style department is going to be the prime ground for strong arguments about things that don't really matter - like double-quoting all strings vs making a distinction between plain strings and string interpolation. Perhaps you have strong feelings about quotes, so let's help you out by showing you how to show them to RuboCop.
 
-Start by creating a `.rubocop.yml` file using the command touch or nano(nano will open the text editor right away). Don't forget that it must be a dotfile, meaning it needs to have a dot before its name. Now, you need to find out what rule you want to change or disable. For the possible options always consult the documentation - not every Cop is just a simple on/off, there might be more options. As an example, we'll be changing the rules regarding strings, frozen string literals and we'll enable NewCops.
+Start by creating a `.rubocop.yml` file using the command `bundle exec rubocop --init` or manually using touch or nano (nano will open the text editor right away). Don't forget that it must be a dotfile, meaning it needs to have a dot before its name. Now, you need to find out what rule you want to change or disable. For the possible options always consult the documentation - not every Cop is just a simple on/off, there might be more options. As an example, we'll be changing the rules regarding strings, frozen string literals and we'll enable NewCops.
 
 ```yaml
 # This is .rubocop.yml in ~/
@@ -280,9 +280,9 @@ In this case, there is one assignment, eighteen branches and zero conditionals, 
 
 One way to interpret this particular score is to say that this method heavily relies on other methods to do something with data. Perhaps this process could be broken down into steps or there exists some design flaw that requires us to manipulate the data so much in this one place.
 
-<span id="cyclomatic">Cyclomatic complexity is similar to the conditional measure in ABC. It aims at providing insight into how complex a program based on how many possible paths can the program (method) can go through. As you can imagine, this refers to control flow statements like if statements, loops and logical operators like `&&` or `||`.</span>
+<span id="cyclomatic">Cyclomatic complexity is similar to the conditional measure in ABC. It aims at providing insight into program complexity based on how many possible paths the program (method) can go through. As you can imagine, this refers to control flow statements like if statements, loops and logical operators like `&&` or `||`.</span>
 
-Of course in the Ruby context, instead of loops you are most likely going to use methods like `#each` to iterate over your collections - that counts, too. Every time code execution and follow one or the other path, one gets added to the score.
+In the Ruby context, instead of loops, you are most likely going to use methods like `#each` to iterate over your collections - that counts, too. Every time code execution can follow one or the other path, one gets added to the score.
 
 <span id="perceived">Perceived complexity is very similar to cyclomatic complexity. It attempts to measure how hard it is for a human to read the code and where it diverges from cyclomatic complexity is that it uses weights for some control flow statements and counts both `if` and `else` instead of just the if statement as one branching path.
 
@@ -294,7 +294,7 @@ Of course in the Ruby context, instead of loops you are most likely going to use
 
 You've got the underlines and neatly formatted list of issues listed in the `Problems` tab. Remember that `Problems` tab is interactive - make sure to play with it!
 
-When you hover over an underlined piece of code, you will be informed of the offense and be given links to RuboCop documentation *not* the Ruby Style guide and also given shortcuts to `View Problems` and `Quickfix`:
+When you hover over an underlined piece of code, you will be informed of the offense and be given links to RuboCop documentation - *not* the Ruby Style guide - and also given shortcuts to `View Problems` and `Quickfix`:
 
 ![VSC pop-up after you hover on an offense](https://cdn.statically.io/gh/TheOdinProject/curriculum/270b3d2430621d1d768234d53588054dc4bdda13/ruby/object_oriented_programming_basics/linting_and_rubocop/imgs/rubohover.png)
 


### PR DESCRIPTION
## Because
Just some minor changes to improve consistency (e.g. `touch` or `nano`  while the `rubocop --init` was introduced in a previous paragraph).

Also some punctuation and spacing to improve readability and limit confusion.


## This PR
- adds consistency with earlier paragraph by adding the `rubocop --init` command
- rewrites a few sentences in a minor way to avoid confusion and improve readability

## Issue

## Additional Information

## Pull Request Requirements
-   [X] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [X] The `Because` section summarizes the reason for this PR
-   [X] The `This PR` section has a bullet point list describing the changes in this PR
-   [X] If this PR addresses an open issue, it is linked in the `Issue` section
-   [X] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [X] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
