### PR TITLE
GH Workflows: Fix path filtering for projects

### DIFF
--- a/.github/workflows/markdownlint-lessons.yml
+++ b/.github/workflows/markdownlint-lessons.yml
@@ -4,7 +4,7 @@ on:
         paths:
             - '**.md'
             - '!*'
-            - '!**/project*'
+            - '!**/project_*'
             - '!archive/**'
             - '!templates/**'
             - '!markdownlint/docs/**'
@@ -22,7 +22,7 @@ jobs:
               files: |
                 **.md
                 !*
-                !**/project*
+                !**/project_*
                 !archive/**
                 !templates/**
                 !markdownlint/docs/**

--- a/.github/workflows/markdownlint-projects.yml
+++ b/.github/workflows/markdownlint-projects.yml
@@ -2,7 +2,7 @@ name: MarkDownLint
 on:
   pull_request:
     paths:
-        - '**/project*.md'
+        - '**/project_*.md'
         - '!*'
         - '!archive/**'
         - '!templates/**'
@@ -19,7 +19,7 @@ jobs:
             id: changed-files
             with:
               files: |
-                **/project*.md
+                **/project_*.md
                 !*
                 !archive/**
                 !templates/**


### PR DESCRIPTION
## Because

For some reason, #28818 triggered the wrong lint workflows. It seems the "project" in the changed file name triggered this, even though it wasn't at the start of the file name. Really not sure why it triggered that but ensuring it matches `project_*` seems to work for such a file and be more specific.

## This PR

Fixes project path filtering in both lint workflows.

## Issue

N/A

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
