### PR TITLE
HashMap Data Structure lesson: fixed explanation on sets

### DIFF
--- a/javascript/computer_science/hash_map_data_structure.md
+++ b/javascript/computer_science/hash_map_data_structure.md
@@ -92,7 +92,7 @@ Buckets are storage that we need to store our elements. Simply, it's an array. F
 1. Find the bucket at index `385`.
 1. Store the key value pair in that bucket. In this case, the key would be "Fred" and the value would be "Smith".
 
-What if the bucket at index `385` already contains an item with the same key "Fred"? We check if it's the same item by comparing the keys, then we overwrite the value with our new value. This is how we can only have unique values inside a `Set`. A `Set` is similar to a hash map but the key difference (pun intended) is that a `Set` will have nodes with only keys and no values.
+What if the bucket at index `385` already contains an item with the same key "Fred"? We check if it's the same item by comparing the keys, then we overwrite the value with our new value. This is how we can only have unique values inside a `Set`. A `Set` is similar to a hash map but the key difference (pun intended) is that a `Set` will have nodes with only values and no keys.
 
 This is an oversimplified explanation; we'll discuss more internal mechanics later in the lesson.
 

--- a/ruby/computer_science/hash_map_data_structure.md
+++ b/ruby/computer_science/hash_map_data_structure.md
@@ -103,7 +103,7 @@ Maybe you are wondering, why are we comparing the keys if we already found the i
 
 This is it, making this will result in a hash table with `has?`, `set` and `get`.
 
-What if we found the hash code, but also the key value is the same as what we already have in the bucket. We check if it's the same item by comparing the keys, then we overwrite the value with our new value. This is how we can only have unique values inside a `Set`. A `Set` is similar to a hash map but the key difference (pun intended) is that a `Set` will have nodes with only keys and no values.
+What if we found the hash code, but also the key value is the same as what we already have in the bucket. We check if it's the same item by comparing the keys, then we overwrite the value with our new value. This is how we can only have unique values inside a `Set`. A `Set` is similar to a hash map but the key difference (pun intended) is that a `Set` will have nodes with only values and no keys.
 
 #### Insertion order is not maintained
 


### PR DESCRIPTION
Sets contain only values and not keys.

## Because
In the lesson on HashMap Data Structure for both JS and Ruby paths, the following is stated: `A Set is similar to a hash map but the key difference (pun intended) is that a Set will have nodes with only keys and no values.`

This is not correct because a set contains only values, not keys.

## This PR
- In `curriculum/javascript/computer_science/hash_map_data_structure.md`, `A Set is similar to a hash map but the key difference (pun intended) is that a Set will have nodes with only keys and no values.` is changed to `A Set is similar to a hash map but the key difference (pun intended) is that a Set will have nodes with only values and no keys.`.
- In `curriculum/ruby/computer_science/hash_map_data_structure.md`, `A Set is similar to a hash map but the key difference (pun intended) is that a Set will have nodes with only keys and no values.` is changed to `A Set is similar to a hash map but the key difference (pun intended) is that a Set will have nodes with only values and no keys.`.

## Issue
Closes #28853

## Additional Information
N/A

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
