### PR TITLE
Commit Messages Lesson: Minor grammar change in commit message recommendation

### DIFF
--- a/git/foundations_git/commit_messages.md
+++ b/git/foundations_git/commit_messages.md
@@ -42,7 +42,7 @@ This is the change I made to the codebase.
 
 <div class="lesson-note lesson-note--tip" markdown=1>
 
-GitHub has a 72-character limit so we recommend keeping your commits' subject to within this amount.
+GitHub has a 72-character limit, so we recommend keeping your commit's subject within this amount.
 
 </div>
 

--- a/git/foundations_git/commit_messages.md
+++ b/git/foundations_git/commit_messages.md
@@ -42,7 +42,7 @@ This is the change I made to the codebase.
 
 <div class="lesson-note lesson-note--tip" markdown=1>
 
-GitHub has a 72-character limit, so we recommend keeping your commit's subject within this amount.
+GitHub has a 72-character limit, so we recommend keeping your commits' subjects within this amount.
 
 </div>
 


### PR DESCRIPTION
## Because
The sentence "GitHub has a 72-character limit so we recommend keeping your commits' subject to within this amount." is not correct because the apostrophe after "commits" is in the wrong place.

## This PR
- Has changed the above sentence to "GitHub has a 72-character limit, so we recommend keeping your commit's subject within this amount."

## Issue
Currently no open issue.

## Additional Information
This change relates to a minor grammatical error.


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
