### PR TITLE
foundations-intro-to-css: Add missing exercise 06 to assignment list

### DIFF
--- a/foundations/html_css/css-foundations/intro-to-css.md
+++ b/foundations/html_css/css-foundations/intro-to-css.md
@@ -373,6 +373,7 @@ If you need to add a *unique* style for a *single* element, this method can work
     - `03-group-selectors`
     - `04-chain-selectors`
     - `05-descendant-combinator`
+    - `06-cascade-fix`
 
     Note: Solutions for these exercises can be found in the `solution` folder of each exercise.
 


### PR DESCRIPTION
Add 06-cascade-fix to assignment list

## Because
Assignment list is missing task 06-cascade-fix. It says inside the task that it is the final exercise but according to the list at foundations-intro-to-css, number 5 is the final one. Just added the last one to make it more clear that there is a number 6 as well.


## This PR
- Added the missing final exercise (number 6) to the assignment list

## Issue

## Additional Information

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
