### PR TITLE
foundations-variables-and-operators: Change link at line 167

### DIFF
--- a/foundations/javascript_basics/variables_and_operators.md
+++ b/foundations/javascript_basics/variables_and_operators.md
@@ -164,7 +164,7 @@ The following questions are an opportunity to reflect on key topics in this less
 - [What rules should you follow when naming variables?](https://javascript.info/variables#variable-naming)
 - [What happens when you add numbers and strings together?](https://javascript.info/operators#string-concatenation-with-binary)
 - [How does the Modulo (%), or Remainder, operator work?](https://javascript.info/operators#remainder)
-- [Explain the difference between `==` and `===`.](https://www.w3schools.com/js/js_operators.asp)
+- [Explain the difference between `==` and `===`.]([https://www.w3schools.com/js/js_operators.asp](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Math#comparison_operators))
 - [When would you receive a `NaN` result?](https://www.w3schools.com/js/js_numbers.asp)
 - [How do you increment and decrement a number?](https://javascript.info/operators#increment-decrement)
 - [Explain the difference between prefixing and postfixing increment/decrement operators.](https://javascript.info/operators#increment-decrement)

--- a/foundations/javascript_basics/variables_and_operators.md
+++ b/foundations/javascript_basics/variables_and_operators.md
@@ -164,7 +164,7 @@ The following questions are an opportunity to reflect on key topics in this less
 - [What rules should you follow when naming variables?](https://javascript.info/variables#variable-naming)
 - [What happens when you add numbers and strings together?](https://javascript.info/operators#string-concatenation-with-binary)
 - [How does the Modulo (%), or Remainder, operator work?](https://javascript.info/operators#remainder)
-- [Explain the difference between `==` and `===`.]([https://www.w3schools.com/js/js_operators.asp](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Math#comparison_operators))
+- [Explain the difference between `==` and `===`.](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Math#comparison_operators)
 - [When would you receive a `NaN` result?](https://www.w3schools.com/js/js_numbers.asp)
 - [How do you increment and decrement a number?](https://javascript.info/operators#increment-decrement)
 - [Explain the difference between prefixing and postfixing increment/decrement operators.](https://javascript.info/operators#increment-decrement)


### PR DESCRIPTION
## Because
The current link (W3Schools) to the answer of the question "Explain the difference between == and ===." does not explain it as good as the one I linked it to (MDN Docs).

## This PR
* changes the link to the question in the 'Knowledge Check' section
* is better at helping others in understanding the concept of the question


## Pull Request Requirements

-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
