### PR TITLE
Easy Fix: add Linux/Windows shortcut to emmet.md

### DIFF
--- a/intermediate_html_css/intermediate_html_concepts/emmet.md
+++ b/intermediate_html_css/intermediate_html_concepts/emmet.md
@@ -24,7 +24,7 @@ Pressing <kbd>Enter</kbd> should generate the following text:
 We have just used one of many Emmet abbreviations. There are lots of useful Emmet abbreviations that you should check out, like [Wrap with Abbreviation](https://docs.emmet.io/actions/wrap-with-abbreviation/) and [Remove Tag](https://docs.emmet.io/actions/remove-tag/). Definitely go through those before moving forward.
 
 Considering how useful these two are, we will be setting up VS Code shortcuts for them.
-Start off by opening the keyboard shortcuts window. You can do so by clicking the cog icon on the bottom left and selecting keyboard shortcuts, or by pressing <kbd>Cmd</kbd> + <kbd>K</kbd> followed by <kbd>Cmd</kbd> + <kbd>S</kbd>.
+Start off by opening the keyboard shortcuts window. You can do so by clicking the cog icon on the bottom left and selecting keyboard shortcuts, or by pressing <kbd>Cmd</kbd> + <kbd>K</kbd> followed by <kbd>Cmd</kbd> + <kbd>S</kbd> on Mac, or <kbd>Ctrl</kbd> + <kbd>K</kbd> followed by <kbd>Ctrl</kbd> + <kbd>S</kbd> on Windows/Linux.
 
 ![Setting up VS code shortcuts](https://cdn.statically.io/gh/TheOdinProject/curriculum/1953c1f219a8b321e7ecef9ebcb92834f50ffb9f/html_css/intermediate_html/emmet/imgs/02.png)
 


### PR DESCRIPTION
## Because
Correcting keyboard shortcut to include Linux and Windows in emmet.md. The lesson currently lists `cmd+k and cmd+s`, which covers only Mac users. 


## This PR
Updated the Emmet lesson for Windows and Linux users by adding the keyboard shortcuts  `ctrl+k ctrl+s` in addition to current `cmd+k cmd+s`.


## Issue
Closes [#28966](https://github.com/TheOdinProject/curriculum/issues/28966) 


## Additional Information
N/A
