### PR TITLE
HTML Foundations Update: Clarify GitHub account requirements for publishing private repos

### DIFF
--- a/foundations/html_css/html-foundations/project-recipes.md
+++ b/foundations/html_css/html-foundations/project-recipes.md
@@ -103,7 +103,7 @@ GitHub allows you to publish web projects directly from a GitHub repository. Doi
 
 <div class="lesson-note">
 
-A GitHub paid account is required to publish a private repository.
+A GitHub paid account is required to publish web projects from a private repository. Free accounts can only publish from public repositories.
 
 </div>
 


### PR DESCRIPTION
## Because
This PR updates and clarifies the information about GitHub account requirements for publishing web projects. It addresses potentially misleading information in the current content regarding the need for a paid GitHub account.

## This PR
- Updates the note about GitHub account requirements in the relevant lesson file
- Clarifies the distinction between free and paid accounts regarding publishing from private repositories
- Ensures the information is accurate and up-to-date with GitHub's current policies

## Additional Information
This PR is a revised version of a [previously closed PR](#28982). It incorporates feedback from maintainers to provide more accurate information about GitHub Pages publishing requirements.

[Previous PR](https://github.com/TheOdinProject/curriculum/pull/28982)



## Pull Request Requirements
- [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [ ] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
- [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)