### PR TITLE
GH Workflows: Include dash delimiter for projects

### DIFF
--- a/.github/workflows/markdownlint-lessons.yml
+++ b/.github/workflows/markdownlint-lessons.yml
@@ -5,6 +5,7 @@ on:
             - '**.md'
             - '!*'
             - '!**/project_*'
+            - '!**/project-*'
             - '!archive/**'
             - '!templates/**'
             - '!markdownlint/docs/**'
@@ -23,6 +24,7 @@ jobs:
                 **.md
                 !*
                 !**/project_*
+                !**/project-*
                 !archive/**
                 !templates/**
                 !markdownlint/docs/**

--- a/.github/workflows/markdownlint-projects.yml
+++ b/.github/workflows/markdownlint-projects.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
         - '**/project_*.md'
+        - '**/project-*.md'
         - '!*'
         - '!archive/**'
         - '!templates/**'
@@ -20,6 +21,7 @@ jobs:
             with:
               files: |
                 **/project_*.md
+                **/project-*.md
                 !*
                 !archive/**
                 !templates/**


### PR DESCRIPTION
## Because

In #28843, the project lint workflow needed to include `_` in the path filtering as for some reason it was matching false positives without it (still not entirely sure why). But it seems not all lesson files use snake case - some use kebab case (like the lesson files in `foundations/html_css`) and so cause projects to trigger the lesson lint workflow instead (seen in #28983).

It's less disruptive to just include `-` in the project workflow path filtering than unify the file name casing (which would require changes to the website repo lessons list too).

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Includes `project-` in the project linting workflow path filtering

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
