### PR TITLE
Fixed a small typo in In the loops section

### DIFF
--- a/archive/old_lessons/foundations/JS101/oldFundamentalsLessons/fundamentals-2.md
+++ b/archive/old_lessons/foundations/JS101/oldFundamentalsLessons/fundamentals-2.md
@@ -150,7 +150,7 @@ Now it's time for the fun stuff...  So far we haven't done much with our program
 Computers don't get tired, and they're really _really_ fast!  For that reason they are well suited to solving problems that involve doing calculations multiple times.  In some cases a computer will be able to repeat a task _thousands_ or even _millions_ of times in just a few short seconds where it might take a human many hours. \(obviously speed here depends on the complexity of the calculation and the speed of the computer itself\).  One way to make a computer do a repetitive task is using a **loop**
 
 1. Read this [MDN article](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Looping_code).  It's a longer one, but make sure you tackle the 'Active Learning' sections at the bottom of the page.  
-2. Once again, same info, slightly different context from [JavaScript.info](http://javascript.info/while-for) \(Skim the info if you think you know it all, but **don't forget the tasks at the end of the page**.  You learn best by _doing_\)
+2. Once again, same info, slightly different context from [JavaScript.info](http://javascript.info/while-for) \(Skip the info if you think you know it all, but **don't forget the tasks at the end of the page**.  You learn best by _doing_\)
 
 ### Functions
 


### PR DESCRIPTION
## Description

### Fixes - #28987 
This PR fixes a small typo in the "Loops" section of the **JS101 Foundations** lesson located in `fundamentals-2.md`. The duplicated line "Once again, same info, slightly different context from [JavaScript.info](http://javascript.info/while-for)" has been corrected by changing "skim" to "skip" for consistency with the rest of the document.

## Changes

- Updated wording from "Skim the info if you think you know it all" to "Skip the info if you think you know it all."

## Impact

- **Improved Readability**: Clarified instructions in the loops section, enhancing the learning experience for students.
