### PR TITLE
Fixes: Wrong SQL Query's are fixed now

### DIFF
--- a/databases/databases/databases_and_sql.md
+++ b/databases/databases/databases_and_sql.md
@@ -101,7 +101,7 @@ Now we're getting into the fun stuff.  Aggregate functions like `COUNT` which re
   SELECT users.id, users.name, COUNT(posts.id) AS posts_written
   FROM users
   JOIN posts ON users.id = posts.user_id
-  GROUP BY users.id;
+  GROUP BY users.id, users.name;
 ```
 
 See [W3Schools' browser-based SQL playground](http://www.w3schools.com/sql/trysql.asp?filename=trysql_select_groupby) for an interactive visual.
@@ -112,7 +112,7 @@ The last nifty trick is if you want to only display a subset of your data.  In a
   SELECT users.id, users.name, COUNT(posts.id) AS posts_written
   FROM users
   JOIN posts ON users.id = posts.user_id
-  GROUP BY users.id
+  GROUP BY users.id, users.name
   HAVING posts_written >= 10;
 ```
 


### PR DESCRIPTION
# Description

## Fixes -  https://github.com/TheOdinProject/curriculum/issues/28798
This PR addresses issues in the SQL queries presented in the **Databases and SQL** lesson. The following corrections have been made to ensure compliance with SQL standards:

1. **Updated First Query**:
   - The `GROUP BY` clause now includes `users.name` alongside `users.id` to conform to SQL standards regarding the inclusion of non-aggregated columns in the `GROUP BY` statement.

   **Before**:
   ```sql
   SELECT users.id, users.name, COUNT(posts.id) AS posts_written
   FROM users
   JOIN posts ON users.id = posts.user_id
   GROUP BY users.id;
   ```

   **After**:
   ```sql
   SELECT users.id, users.name, COUNT(posts.id) AS posts_written
   FROM users
   JOIN posts ON users.id = posts.user_id
   GROUP BY users.id, users.name;
   ```

2. **Updated Second Query**:
   - The `HAVING` clause now uses the aggregate function directly rather than the alias `posts_written`, which ensures that the query executes correctly.
   - The `GROUP BY` clause is also updated to include `users.name`.

   **Before**:
   ```sql
   SELECT users.id, users.name, COUNT(posts.id) AS posts_written
   FROM users
   JOIN posts ON users.id = posts.user_id
   GROUP BY users.id
   HAVING posts_written >= 10;
   ```

   **After**:
   ```sql
   SELECT users.id, users.name, COUNT(posts.id) AS posts_written
   FROM users
   JOIN posts ON users.id = posts.user_id
   GROUP BY users.id, users.name
   HAVING COUNT(posts.id) >= 10;
   ```

## Impact

- **Improved Learning Experience**: Correcting these SQL queries aligns them with standard SQL practices, enhancing the educational value of the lesson.
