### PR TITLE
Remove DOM Enlightenment from the additional resources for the DOM Manipulation and Events lesson

### DIFF
--- a/foundations/javascript_basics/DOM_manipulation_and_events.md
+++ b/foundations/javascript_basics/DOM_manipulation_and_events.md
@@ -464,7 +464,6 @@ This section contains helpful links to related content. It isn't required, so co
 
 - [Eloquent JS - DOM](http://eloquentjavascript.net/13_dom.html)
 - [Eloquent JS - Handling Events](http://eloquentjavascript.net/14_event.html)
-- [DOM Enlightenment](http://domenlightenment.com/)
 - [Plain JavaScript](https://plainjs.com/javascript/) is a reference of JavaScript code snippets and explanations involving the DOM, as well as other aspects of JS. If you've already learned jQuery, it will help you figure out how to do things without it.
 - This [W3Schools](https://www.w3schools.com/js/js_htmldom.asp) article offers easy-to-understand lessons on the DOM.
 - [JS DOM Crash Course](https://www.youtube.com/watch?v=0ik6X4DJKCc&list=PLillGF-RfqbYE6Ik_EuXA2iZFcE082B3s) is an extensive and well explained 4 part video series on the DOM by Traversy Media.


### PR DESCRIPTION
## Because
The original link no longer works as the domain has expired. There is a backup available on web archive, but this resource may no longer be required since there's plenty of other resources listed in the additional resources section of that lesson. 

## This PR
- Removes DOM Enlightenment from the additional resources list for the DOM Manipulation and Events lesson

## Issue
Closes #28996

## Additional Information

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
