### PR TITLE
Importmap: Fix fenced code block languages and linting

### DIFF
--- a/ruby_on_rails/assets_and_navigation/importmap.md
+++ b/ruby_on_rails/assets_and_navigation/importmap.md
@@ -40,7 +40,7 @@ The `importmap-rails` gem provides an API for mapping the "bare module specifier
 
 Example
 
-```Ruby
+```ruby
 # config/importmap.rb
 pin "react", to: "https://ga.jspm.io/npm:react@18.2.0/index.js"
 ```
@@ -68,7 +68,7 @@ Pinning "scheduler" to vendor/javascript/scheduler.js via download from https://
 
 This will produce pins in your `config/importmap.rb` like this:
 
-```Ruby
+```ruby
 pin "react" # @18.2.0
 pin "react-dom" # @18.2.0
 pin "scheduler" # @0.23.0
@@ -78,7 +78,7 @@ The packages are downloaded to `vendor/javascript`, which you can check into you
 
 Now you can import them in your JavaScript code.
 
-```JS
+```javascript
 import React from "react"
 import ReactDOM from "react-dom"
 ```
@@ -94,11 +94,13 @@ Unpinning and removing "react"
 
 To avoid having the browser load one file after another before it can get to the deepest nested import, `importmap-rails` uses [modulepreload](https://developers.google.com/web/updates/2017/12/modulepreload) by default. If you don't want to preload a dependency, add `preload: false` to the pin.
 
-```Ruby
+```ruby
 # config/importmap.rb
 pin "@github/hotkey", to: "@github--hotkey.js" # file lives in vendor/javascript/@github--hotkey.js
 pin "md5", preload: false # file lives in vendor/javascript/md5.js
+```
 
+```erb
 # app/views/layouts/application.html.erb
 <%= javascript_importmap_tags %>
 

--- a/ruby_on_rails/assets_and_navigation/importmap.md
+++ b/ruby_on_rails/assets_and_navigation/importmap.md
@@ -123,6 +123,7 @@ All of the above may have you wondering why you'd use importmaps all things cons
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">
+
 Since Rails 7 is relatively new there aren't a ton of resources available yet. That being said here are some that are worth taking a look at:
 
 1. First things first. [Briefly look over the `importmap-rails` gem README on GitHub](https://github.com/rails/importmap-rails). This has A LOT of the information here plus more. Straight from the horse's mouth.
@@ -135,9 +136,9 @@ Since Rails 7 is relatively new there aren't a ton of resources available yet. T
 
 The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
 
-- <a class="knowledge-check-link" href="#import-maps-with-npm-packages">Can you use import maps with npm packages?</a>
-- <a class="knowledge-check-link" href="#downloading-vendor-files">How do you download vendor files using import maps?</a>
-- <a class="knowledge-check-link" href="#preloading-pinned-modules">How can you preload pinned modules?</a>
+- [Can you use import maps with npm packages?](#import-maps-with-npm-packages)
+- [How do you download vendor files using import maps?](#downloading-vendor-files)
+- [How can you preload pinned modules?](#preloading-pinned-modules)
 
 ### Additional resources
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->

There were several linting issues that could be autofixed, and one code block that contained two different languages would've flagged errors if it wasn't split into the appropriate separate blocks.


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Splits a `ruby` code block into `ruby` and `erb`, which would be more appropriate
- Fixes fenced code block language names to be the lowercase full names as per the TOP006 lint rule
- Runs the autofixer to address remaining lint errors

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
