### PR TITLE
Ruby: Project: Caesar Cipher: Fix Ruby Caesar Cipher code example

### DIFF
--- a/ruby/basic_ruby_projects/project_caesar_cipher.md
+++ b/ruby/basic_ruby_projects/project_caesar_cipher.md
@@ -22,7 +22,7 @@ Harvard's CS50 class has a [video about the Caesar cipher](https://www.youtube.c
 
 ```ruby
   > caesar_cipher("What a string!", 5)
-  => "Bmfy f xywnsl!"
+  => "Rcvo v nomdib!"
 ```
 
 **Quick Tips:**

--- a/ruby/basic_ruby_projects/project_caesar_cipher.md
+++ b/ruby/basic_ruby_projects/project_caesar_cipher.md
@@ -18,11 +18,11 @@ Harvard's CS50 class has a [video about the Caesar cipher](https://www.youtube.c
 
 <div class="lesson-content__panel" markdown="1">
 
-  Implement a caesar cipher that takes in a string and the shift factor and then outputs the modified string:
+  Implement a Caesar cipher that takes in a string and the shift factor and then outputs the modified string using a right shift:
 
 ```ruby
   > caesar_cipher("What a string!", 5)
-  => "Rcvo v nomdib!"
+  => "Bmfy f xywnsl!"
 ```
 
 **Quick Tips:**
@@ -30,5 +30,6 @@ Harvard's CS50 class has a [video about the Caesar cipher](https://www.youtube.c
 - You will need to remember how to convert a string into a number.
 - Don't forget to wrap from `z` to `a`.
 - Don't forget to keep the same case.
+- The Wikipedia quote discusses a Caesar cipher using a left shift.
 
 </div>


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
There is an internal inconsistency on whether a caesar cipher should use a left shift or right shift. In the entry from Wikipedia the text and example used a left shift, while in the ruby code a right shift is used.

```ruby
  > caesar_cipher("What a string!", 5)
  => "Bmfy f xywnsl!"
```

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->

Update the project instructions to explicitly call for a right shift and note that the Wikipedia quote uses a left shift.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #29106

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
