### PR TITLE
Git Basics lesson: Add link to Git Exercises in Additional Resources

### DIFF
--- a/git/foundations_git/git_basics.md
+++ b/git/foundations_git/git_basics.md
@@ -176,4 +176,4 @@ The following questions are an opportunity to reflect on key topics in this less
 
 This section contains helpful links to related content. It isn't required, so consider it supplemental.
 
-- It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.
+- You can practice what you have learned with the exercises available on [Git Exercises - W3Schools](https://www.w3schools.com/git/git_exercises.asp).


### PR DESCRIPTION
## Because
To provide users with a practical way to reinforce what they've learned in the course through interactive exercises.

## This PR
Adds a link to the Git exercises on W3Schools in the additional resources section.

## Issue

## Additional Information
Link added: [Git Exercises - W3Schools](https://www.w3schools.com/git/git_exercises.asp).
The exercises on this page allow users to practice Git commands and concepts in an interactive environment.

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
