### PR TITLE
[Foundations] Variables and Operators: Fix typo

### DIFF
--- a/foundations/javascript_basics/variables_and_operators.md
+++ b/foundations/javascript_basics/variables_and_operators.md
@@ -47,7 +47,7 @@ Save and open this file up in a web browser and then open up the browser's conso
 1. Click on "Inspect" or "Inspect Element" to open the Developer Tools.
 1. Find and select the "Console" tab, where you should see the output of our `console.log` statement.
 
-**Tip:** You can use [Live Preview extension in Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.live-server) to automatically update the browser when you save your file instead of having to manually refresh the page to see any changes when you edit your code. Try edit the text to say something different!
+**Tip:** You can use [Live Preview extension in Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.live-server) to automatically update the browser when you save your file instead of having to manually refresh the page to see any changes when you edit your code. Try editing the text to say something different!
 
 `console.log()` is the command to print something to the developer console in your browser. You can use this to print the results from any of the following articles and exercises to the console. We encourage you to code along with all of the examples in this and future lessons.
 


### PR DESCRIPTION
## Because
Fixes a typo. "Try edit the text" doesn't make sense in English. It should be "Try editing the text" or "Try to edit the text". It immediately threw me off, and would for others too, especially those not as well acquainted with English.

## This PR
- Simply rewords a string

## Issue
This PR does not close an open issue, it just addresses an unnoticed/unreported typo.

## Additional Information
N/A

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
