### PR TITLE
Rails - Advanced Forms and Active Record: Update wording and section numbers indicated in the assignment

### DIFF
--- a/ruby_on_rails/advanced_forms_and_activerecord/active_record_queries.md
+++ b/ruby_on_rails/advanced_forms_and_activerecord/active_record_queries.md
@@ -224,15 +224,15 @@ This was a lot of material, but you should have a healthy appreciation for the b
 
 1. Read the first 6 sections of the [Rails Guide on Active Record Querying](http://guides.rubyonrails.org/active_record_querying.html) for a more basic overview of query functions. Don't worry too much about batching and `#find_each`.
 1. Read section 20 of the same Rails guide for a brief look at [using `exists?`, `any?` and `many?`](https://guides.rubyonrails.org/active_record_querying.html#existence-of-objects).
-1. Read sections 7, 8 and 21 of the same Rails guide for an understanding of [aggregate functions and the calculations you can run on them](https://guides.rubyonrails.org/active_record_querying.html#grouping).
-1. Skim sections 9-12 of the same Rails guide on [overriding conditions](https://guides.rubyonrails.org/active_record_querying.html#overriding-conditions).
+1. Read sections 7 and 21 to learn about [grouping and aggregate functions](https://guides.rubyonrails.org/active_record_querying.html#grouping).
+1. Skim section 8 to learn about [overriding conditions](https://guides.rubyonrails.org/active_record_querying.html#overriding-conditions).
 1. Read section 12 of the same Rails guide to see how Rails lets you play with [joining tables together](https://guides.rubyonrails.org/active_record_querying.html#joining-tables).
 1. Read section 18 of the same Rails guide for a quick look at [the helpful `find_or_create_by` methods](https://guides.rubyonrails.org/active_record_querying.html#find-or-build-a-new-object).
 
 #### Advanced querying
 
 1. Read section 14 in the [Rails Guide on Querying](https://guides.rubyonrails.org/active_record_querying.html#scopes) for a look at scopes. Again, you don't necessarily need to memorize all the details of scopes, but you should understand the concept and when it might be useful.
-1. Read section 19 of the same Rails guide for a look at [using SQL directly to query](http://guides.rubyonrails.org/active_record_querying.html#finding-by-sql).
+1. Read section 19 “Finding by SQL” of the same Rails guide for a look at [using SQL directly to query](http://guides.rubyonrails.org/active_record_querying.html#finding-by-sql).
 
 </div>
 

--- a/ruby_on_rails/rails_sprinkles/js_bundling.md
+++ b/ruby_on_rails/rails_sprinkles/js_bundling.md
@@ -165,7 +165,7 @@ yarn add @hotwired/stimulus
 
 Now when we run `yarn run build` we should get the proper outcome! You should also be able to run `bin/dev` and see the Rails splash page at `http://localhost:3000`.
 
-Now that we have walked through how to install a Rails app with import maps let's make our life a little bit easier and set it up with jsbundling-rails! Go ahead and enter the below command.
+Now that we have walked through how to install the jsbundling-rails gem in a Rails app that was created with import maps let's make our life a little bit easier and set it up right from the beginning! Go ahead and enter the below command.
 
 ```bash
 rails new myapp -j <replace the text and <> with your bundler choice>


### PR DESCRIPTION
## Because
The section numbers in bullet point 3 and 4 of "Querying basics" did partially not match with the ones in the Rails Guide.

Bullet point 2 of "Advanced querying" raised doubts about whether the correct section number is indicated.


## This PR
- Section numbers and wording in bullet point 3 and 4 in "Querying basics" of the assignment instruction were updated
- The wording of bullet point 2 in "Advanced querying" was slightly modified to signal clearly that section 19 is the one TOP students should read.


## Issue
Closes [#29073](https://github.com/TheOdinProject/curriculum/issues/29073)

## Pull Request Requirements
-   [x ] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [ x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x ] The `Because` section summarizes the reason for this PR
-   [ x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
