### PR TITLE
Admin Dashboard: Remove step on color palettes

### DIFF
--- a/intermediate_html_css/grid/project_admin_dashboard.md
+++ b/intermediate_html_css/grid/project_admin_dashboard.md
@@ -30,7 +30,6 @@ Now that you've had plenty of practice using Grid, we are going to build a full 
 #### Step 4: Gather assets
 
 1. Once you have your grid layout complete you can either recreate the dashboard example above or style your own design.
-1. Check out some [color palettes](https://tailwindcss.com/docs/customizing-colors) if you'd like.
 1. All of the icons and more can be downloaded as SVGs from [Material Design Icons](https://pictogrammers.com/library/mdi/).
 1. Choose your own fonts! The design example uses `Roboto`, which is available with Google fonts. (You may want to review the [More Text Styles Lesson](https://www.theodinproject.com/lessons/intermediate-html-and-css-more-text-styles) for information about how to include external fonts in your projects).
 

--- a/intermediate_html_css/grid/project_admin_dashboard.md
+++ b/intermediate_html_css/grid/project_admin_dashboard.md
@@ -30,7 +30,7 @@ Now that you've had plenty of practice using Grid, we are going to build a full 
 #### Step 4: Gather assets
 
 1. Once you have your grid layout complete you can either recreate the dashboard example above or style your own design.
-1. Check out some color palettes from [Tailwind](https://tailwindcss.com/docs/customizing-colors).
+1. Check out some [color palettes](https://tailwindcss.com/docs/customizing-colors) if you'd like.
 1. All of the icons and more can be downloaded as SVGs from [Material Design Icons](https://pictogrammers.com/library/mdi/).
 1. Choose your own fonts! The design example uses `Roboto`, which is available with Google fonts. (You may want to review the [More Text Styles Lesson](https://www.theodinproject.com/lessons/intermediate-html-and-css-more-text-styles) for information about how to include external fonts in your projects).
 


### PR DESCRIPTION
## Because

As per the comments below, removed the color palettes step entirely as not vital for the project.

~~The current link text for the Tailwind colour palettes page just says "Tailwind", which can be made more descriptive since it links to a specific page within that site. Over the months there have also been a few questions implying people think they need to use Tailwind for this, and I suspect omitting "Tailwind" from the link text may get the point across that it's just some colour palette suggestions?~~


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Removes color palette step

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
N/A

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
