### PR TITLE
project_sql_zoo.md: update sqlzoo link

### DIFF
--- a/databases/databases/project_sql_zoo.md
+++ b/databases/databases/project_sql_zoo.md
@@ -6,7 +6,7 @@ SQL Zoo is one of the few resources online that actually lets you build and run 
 
 <div class="lesson-content__panel" markdown="1">
 
-  1. Go to [SQL Zoo](https://sqlzoo.net/) and do Tutorials 0-9 listed under the "Tutorial Section" and the quizzes listed at the end of each.  The first tutorial is called "SELECT basics".
+  1. Go to [SQL Zoo](https://sqlzoo.net/w/index.php?title=SQL_Tutorial&redirect=no) and do Tutorials 0-9 listed under the "Tutorial Section" and the quizzes listed at the end of each.  The first tutorial is called "SELECT basics".
       - Make sure the dropdown on the upper right of the main page for "Engine" says "MySQL" (the default).  Large results will be cut off and not all rows or columns shown, so the "answers" may not look 100% correct.
   1. Before you move on, we would like your feedback - please fill out this [feedback form for the SQL course](https://docs.google.com/forms/d/e/1FAIpQLSenvMG6WFbOOEap_biQOwqfbH-j-xsf5Eyv4ir2Rx5FsYSecQ/viewform?usp=sf_link). Getting user (you) feedback is important so we can continue to improve the curriculum and get an idea of your experience.
 


### PR DESCRIPTION
Change sqlzoo link so it doesn't use default redirect behaviour

## Because
#29163 - Link was taking users to a blank page. After some investigation, I found the issue to be related to redirects not being followed by the browser. I checked Firefox (not following), Chrome (following after disabling cache), and Edge (not following). Checking sqlzoo's web page revealed a permanent link that takes users to the latest revision of the site via a URL param.

This works on their page as it will follow in step due to being server-rendered. But, using the link in the markdown would quickly become stale (due to having the revision built into the link).

Instead, I found that the permanent link does not need a revision to be passed. Using the link this way allows users to navigate to the page as expected on all browsers.

`https://sqlzoo.net/w/index.php?title=SQL_Tutorial&redirect=no`


## This PR
* Change link to use URL param that turns off redirect behaviour

## Issue
Closes #29163 


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
