### PR TITLE
Update transforms.md

### DIFF
--- a/advanced_html_css/animation/transforms.md
+++ b/advanced_html_css/animation/transforms.md
@@ -157,9 +157,9 @@ on <a href="https://codepen.io">CodePen</a>.</span>
 
 <script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
 
-If you guessed correctly, congratulations! But this is a tricky concept. MDN's transform docs state that "[composite transforms are effectively applied in order from right to left](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#values)".
+If you guessed correctly, congratulations! But this is a tricky concept. MDN's transform docs state that "[transform functions are multiplied in order from left to right](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#values)".
 
-The blue box rotates 45 degrees on the spot, then translates on the X axis by 200%, moving it directly to the right. The red box translates by 200% first, so moves to the right, but the transform origin is still where it used to be. Therefore, it rotates 45 degrees around that original point, making the red box "swing down" to end up diagonally from where it started.
+The red box rotates 45 degrees on the spot first, tilting its coordinate system. Then it translates along the rotated X axis by 200%, moving it diagonally down and to the right. The blue box translates by 200% first, so it moves directly to the right along the original X axis. After that, it rotates 45 degrees around its new position, making it “swing up” to end up diagonally from where it started.
 
 While you can generally chain multiple transforms in any order for various results, there is one exception: `perspective`. This brings us nicely to the next section where `perspective` is involved.
 


### PR DESCRIPTION
The description of order of transformations was incorrect. MDN says that composition is right to left, which is talking about the inner function g of f(g(x)) being done first. This is equivalent to transform: g() f(), so when laid out the transform actually goes from left to right when reading it. I have changed the description to describe this change too.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The description of order of transformations was incorrect. MDN says that composition is right to left, which is talking about the inner function g of f(g(x)) being done first. This is equivalent to transform: g() f(), so when laid out the transform actually goes from left to right when reading it. I have changed the description to describe this change too.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->

1.  description for blue and red squares

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [ ] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [ ] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [ ] The `Because` section summarizes the reason for this PR
-   [ ] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
