### PR TITLE
Form Validation with JavaScript: Change Zip Code to Postal Code (TheOdinProject#29201)

### DIFF
--- a/javascript/javascript_in_the_real_world/form_validation_with_javascript.md
+++ b/javascript/javascript_in_the_real_world/form_validation_with_javascript.md
@@ -28,7 +28,7 @@ Go back to your 'Library' project and add validation to that form! Don't let you
 
 #### A little more practice
 
-Build a browser form which collects Email, Country, Zip Code, Password and Password Confirmation fields.  It should use live inline validation to inform the user whether a field is properly filled in or not.  That means highlighting a field red and providing a helpful error message until it has been filled in properly.
+Build a browser form which collects Email, Country, Postal Code, Password and Password Confirmation fields.  It should use live inline validation to inform the user whether a field is properly filled in or not.  That means highlighting a field red and providing a helpful error message until it has been filled in properly.
 
 The form doesn't need to actually submit, but you should give an error message if the button is pushed with any active errors or unfilled required fields. For the sake of this lesson, make sure the `<form>` element has the [`novalidate` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#novalidate) which will allow you to do **all** of your validation in your JavaScript files. You can still use different `<input>` types, but you will need to use JavaScript to check and report their validity. If all is well and the form is "submitted", give the user a high five.
 


### PR DESCRIPTION
## Because
Per Issue #29201, a form that requires Country and Zip Code does not make sense, as ZIP codes are for United States addresses only. Postal Code is a more general term that is understood and applicable in many countries.

## This PR
* Changes "Zip Code" to "Postal Code" in the first sentence in the "A Little More Practice" section of the Form Validation with JavaScript lesson.

## Issue
Closes #29201

## Additional Information
This is one of several possible fixes to the issue where Country and Zip Code don't make sense together. If anyone prefers keeping Zip Code and changing something else, let's discuss.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
