### PR TITLE
Javascript Course: feat: added referenced lessons url for easy navigation

### DIFF
--- a/javascript/asynchronous_javascript_and_apis/async_and_await.md
+++ b/javascript/asynchronous_javascript_and_apis/async_and_await.md
@@ -125,7 +125,7 @@ Doing this can look messy, but it is a very easy way to handle errors without ap
 
 ### Practice
 
-Remember the Giphy API practice project? (If not, you should go back and complete the API lesson). We are going to convert the promise based code into `async/await` compatible code. Here's a refresher of the code we are starting with:
+Remember the Giphy API [practice project](https://www.theodinproject.com/lessons/node-path-javascript-working-with-apis#lets-do-this)? (If not, you should go back and complete the [API lesson](https://www.theodinproject.com/lessons/node-path-javascript-working-with-apis)). We are going to convert the promise based code into `async/await` compatible code. Here's a refresher of the code we are starting with:
 
 ```javascript
 <script>


### PR DESCRIPTION

## Because
Lesson mentions reference to previous lessons. Looking up and going through past lesson isn't of much convenience . 
Adding url for the references lesson gives more clarity and provides convenience.


## This PR
- wraps the references with past lesson links for easy navigation.


## Issue



## Additional Information
I tried linting changed file however i get ``Linting: 0 files`` . I don't remember if this is how it was always 
![Img](https://github.com/user-attachments/assets/720b1d88-5256-42e6-8d7a-0445ae65dd43)



## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [X ] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [ X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [ X] The `Because` section summarizes the reason for this PR
-   [ X] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
