### PR TITLE
CONTRIBUTING.md: Amend linting note about npm script file path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,10 @@ To help enforce the layout specified in our layout style guide, we use [markdown
     - Autofix projects: `npm run fix:project -- "./path/to/project"`
 
 > [!IMPORTANT]
-> You *must* run these npm scripts in the root of the curriculum repo (the same location as this file and `package.json`). If you navigate to a different directory and run a script on files there, it will not pick up the right configuration files and rules.
+> npm scripts always run from the root of the curriculum repo (the same location as this file and `package.json`). Therefore, you *must* provide the full lesson/project file path relative to the repo root, even if your terminal is inside a subdirectory (such as the same directory as the lesson file).
 
 > [!TIP]
 > In some cases, you may need to run a fix script more than once to catch and fix all fixable errors. This typically occurs when a line has multiple errors affecting the same parts and fix actions collide, so Markdownlint only applies some of the fixes.
 
 > [!NOTE]
->With either of these two methods, keep in mind that not all issues that get flagged will have an autofix available. Some rules require fixes that are more dependent on context and cannot - and should not - be automatically fixed, such as our custom rule `TOP001` for descriptive link text.
+> With either of these two methods, keep in mind that not all issues that get flagged will have an autofix available. Some rules require fixes that are more dependent on context and cannot - and should not - be automatically fixed, such as our custom rule `TOP001` for descriptive link text.


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

Currently, the linting guide has a note about running the `npm run lint/fix:*` scripts in the repo root else it won't find the correct config files. This is technically incorrect (which is my own mistake!) because [npm scripts always run from the package root](https://docs.npmjs.com/cli/v10/commands/npm-run-script#:~:text=Scripts%20are%20run%20from%20the%20root%20of%20the%20package%20folder%2C%20regardless%20of%20what%20the%20current%20working%20directory%20is%20when%20npm%20run%20is%20called.). Linting issues when users' terminals are in a subdirectory actually come from the file path, which they're often writing relative to their terminal location and not the package root, and has nothing to do with their current terminal location.

i.e. they can be inside `./javascript/testing_javascript` and as long as they run with a path relative to root, they'll be fine e.g. `npm run lint:lesson -- ./javascript/testing_javascript/test_basics.md`

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Fixes linting warning to be about file path and not terminal cwd


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
N/A

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
