### PR TITLE
Library: Use clearer wording for some instruction steps

### DIFF
--- a/javascript/organizing_your_javascript_code/project_library.md
+++ b/javascript/organizing_your_javascript_code/project_library.md
@@ -7,7 +7,7 @@ Let's extend the 'Book' example from the previous lesson and turn it into a smal
 <div class="lesson-content__panel" markdown="1">
 
 1. If you haven’t already, set up a Git repository for your project with skeleton HTML/CSS and JS files. From here on out, we'll assume that you have already done this.
-1. All of your book objects are going to be stored in an array, so add a function to the script (not the constructor) that can take some arguments, create a book from those arguments, and store the new book object into an array. Your code should look something like this:
+1. All of your book objects are going to be stored in an array, so you'll need a constructor for books. Then, add a separate function to the script (not inside the constructor) that can take some arguments, create a book from those arguments, and store the new book object into an array. Your code should look something like this (we're showing only a basic skeleton without function parameters):
 
    ```javascript
    const myLibrary = [];
@@ -17,7 +17,7 @@ Let's extend the 'Book' example from the previous lesson and turn it into a smal
    }
 
    function addBookToLibrary() {
-     // do stuff here
+     // take params, create a book then store it in the array
    }
    ```
 
@@ -27,7 +27,7 @@ Let's extend the 'Book' example from the previous lesson and turn it into a smal
 1. Add a button on each book's display to remove the book from the library.
    1. You will need to associate your DOM elements with the actual book objects in some way. One easy solution is giving them a data-attribute that corresponds to the index of the library array.
 1. Add a button on each book's display to change its `read` status.
-   1. To facilitate this you will want to create the function that toggles a book's `read` status on your `Book` prototype instance.
+   1. To facilitate this you will want to create `Book` prototype function that toggles a book instance's `read` status.
 
 <div class="lesson-note" markdown="1">
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

I somewhat regularly see 2 specific confusions about the Library project instructions:
1. Wording of "...add a function to the script (not the constructor)..." - since the constructor is not explicitly mentioned before yet shown in the code snippet, quite a few ESL speakers have misunderstood this and been confused as to what the quoted wording is actually referring to.
2. Sometimes I've seen people mistake the `Book.prototype.toggleRead` instruction as being an instruction to put the `read` status on the prototype then write a separate plain function that manually changes it. Or the same but with the `read` status on the instance but without a prototype method. Again, I think it's just a matter of potential ESL and wording that could be a bit clearer.


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Reworded two instruction steps with clearer wording.
- Reworded code snippet comment to reinforce new instruction wording.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
N/A

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
