### PR TITLE
Ruby on Rails section: remove note about installing responders gem

### DIFF
--- a/ruby_on_rails/forms_and_authentication/project_members_only.md
+++ b/ruby_on_rails/forms_and_authentication/project_members_only.md
@@ -22,12 +22,6 @@ If you'd like to challenge yourself, don't even follow the steps below, just go 
 1. Create your new `members-only` Rails app and GitHub repo.  Update your README.
 1. Add devise to your Gemfile and install it in your app using set up instructions on the [Devise README](https://github.com/heartcombo/devise).
 
-<div class="lesson-note lesson-note--tip" markdown="1">
-
-You'll need to install the [Responders gem](https://github.com/heartcombo/responders) to [get Devise to play nicely with Turbo Drive](https://github.com/heartcombo/devise#hotwireturbo). Make sure that in addition to adding the gem to your Gemfile that you also run the install generator. You’ll also need to specify delete requests on your links/buttons for signing the user out. More detailed information can be found in [Devise’s Guide for Hotwire Turbo Integration](https://github.com/heartcombo/devise/wiki/How-To:-Upgrade-to-Devise-4.9.0-%5BHotwire-Turbo-integration%5D).
-
-</div>
-
 #### Authentication and posts
 
 Let's build those secrets!  We'll need to make sure only signed in users can see the author of each post.  We're not going to worry about editing or deleting posts.


### PR DESCRIPTION
We can use Devise without Responders gem

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
This pull request removes the note about installing responders gem, as we can use devise without it. 

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Removes note about installing responders gem

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #29347 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
