### PR TITLE
Markdownlint: Fix TOP003 error reporting with empty default content sections

### DIFF
--- a/markdownlint/TOP003_defaultSectionContent/TOP003_defaultSectionContent.js
+++ b/markdownlint/TOP003_defaultSectionContent/TOP003_defaultSectionContent.js
@@ -26,14 +26,14 @@ function getListSectionErrors(sectionTokens, section) {
   const listSectionErrors = [];
   const listItemsName = `${section}${section.endsWith("s") ? "" : "s"}`;
   const tokensAfterHeading = sectionTokens.slice(
-    sectionTokens.findIndex((token) => token.type === "heading_close") + 1,
+    sectionTokens.findIndex((token) => token.type === "heading_close") + 1
   );
 
   const listItemTokens = tokensAfterHeading.filter(
-    (token) => token.type === "list_item_open",
+    (token) => token.type === "list_item_open"
   );
   const nestedListItemTokens = listItemTokens.filter(
-    (token) => token.level > 1,
+    (token) => token.level > 1
   );
   nestedListItemTokens.forEach((nestedListItemToken) => {
     listSectionErrors.push(
@@ -41,8 +41,8 @@ function getListSectionErrors(sectionTokens, section) {
       // will resolve the issue. There may be entire list items that need to be removed as well.
       createErrorObject(
         nestedListItemToken.lineNumber,
-        `The ${section} section must not contain nested lists.`,
-      ),
+        `The ${section} section must not contain nested lists.`
+      )
     );
   });
 
@@ -50,7 +50,7 @@ function getListSectionErrors(sectionTokens, section) {
   // the fact that whitespaces won't precede the token marker, e.g. "1.", in the token object
   const orderedListItemRegex = /^\d+\.\s*/;
   const orderedListItemTokens = listItemTokens.filter((token) =>
-    orderedListItemRegex.test(token.line),
+    orderedListItemRegex.test(token.line)
   );
   orderedListItemTokens.forEach((orderedListItemToken) => {
     listSectionErrors.push(
@@ -62,13 +62,13 @@ function getListSectionErrors(sectionTokens, section) {
           deleteCount:
             orderedListItemToken.line.match(orderedListItemRegex)[0].length,
           insertText: "- ",
-        },
-      ),
+        }
+      )
     );
   });
 
   const defaultContentOpenTokenIndex = tokensAfterHeading.findIndex(
-    (token) => token.line === listSectionsDefaultContent[section],
+    (token) => token.line === listSectionsDefaultContent[section]
   );
 
   if (defaultContentOpenTokenIndex > 0) {
@@ -77,8 +77,8 @@ function getListSectionErrors(sectionTokens, section) {
     listSectionErrors.push(
       createErrorObject(
         defaultContentToken.lineNumber,
-        `Expected default section content to come immediately after the ${section} heading.`,
-      ),
+        `Expected default section content to come immediately after the ${section} heading.`
+      )
     );
   }
   if (defaultContentOpenTokenIndex === -1) {
@@ -97,18 +97,18 @@ function getListSectionErrors(sectionTokens, section) {
         lineNumber: tokensAfterHeading[0].lineNumber,
         deleteCount: tokensAfterHeading[0].line.length,
         insertText: replacementText,
-      }),
+      })
     );
   }
 
   const tokensAfterFirstContent = tokensAfterHeading.slice(
     tokensAfterHeading.findIndex(
       (token, _index, arr) =>
-        token.type === arr[0].type.replace("_open", "_close"),
-    ) + 1,
+        token.type === arr[0].type.replace("_open", "_close")
+    ) + 1
   );
   const bulletListOpenTokenIndex = sectionTokens.findIndex(
-    (token) => token.type === "bullet_list_open",
+    (token) => token.type === "bullet_list_open"
   );
   if (
     (defaultContentOpenTokenIndex === 0 && !tokensAfterFirstContent.length) ||
@@ -134,8 +134,8 @@ function getListSectionErrors(sectionTokens, section) {
               insertText:
                 "\n- It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.",
             }
-          : {},
-      ),
+          : {}
+      )
     );
   }
 
@@ -151,13 +151,13 @@ function getListSectionErrors(sectionTokens, section) {
         {
           lineNumber: tokensAfterFirstContent[0].lineNumber,
           deleteCount: WHOLE_LINE,
-        },
-      ),
+        }
+      )
     );
   }
 
   const lastBulletListCloseIndex = sectionTokens.findLastIndex(
-    (token) => token.type === "bullet_list_close",
+    (token) => token.type === "bullet_list_close"
   );
 
   if (
@@ -165,7 +165,7 @@ function getListSectionErrors(sectionTokens, section) {
     lastBulletListCloseIndex !== sectionTokens.length - 1
   ) {
     const tokensAfterBulletListClose = sectionTokens.slice(
-      lastBulletListCloseIndex + 1,
+      lastBulletListCloseIndex + 1
     );
 
     listSectionErrors.push(
@@ -175,8 +175,8 @@ function getListSectionErrors(sectionTokens, section) {
         {
           lineNumber: tokensAfterBulletListClose[0].lineNumber,
           deleteCount: WHOLE_LINE,
-        },
-      ),
+        }
+      )
     );
   }
 
@@ -186,19 +186,19 @@ function getListSectionErrors(sectionTokens, section) {
 function getAssignmentSectionErrors(sectionTokens) {
   const assignmentErrors = [];
   const divBlockTokens = sectionTokens.filter(
-    (token) => token.type === "html_block" && token.content.startsWith("<div"),
+    (token) => token.type === "html_block" && token.content.startsWith("<div")
   );
   const hasAssignmentDiv = divBlockTokens.some(
     (token) =>
       token.content.includes(`class="lesson-content__panel"`) &&
-      token.content.includes(`markdown="1"`),
+      token.content.includes(`markdown="1"`)
   );
   if (!divBlockTokens || !hasAssignmentDiv) {
     assignmentErrors.push(
       createErrorObject(
         sectionTokens[0].lineNumber,
-        `Assignment sections must include an HTML div element with class="lesson-content__panel" and markdown="1" attributes`,
-      ),
+        `Assignment sections must include an HTML div element with class="lesson-content__panel" and markdown="1" attributes`
+      )
     );
   }
 
@@ -211,7 +211,7 @@ module.exports = {
   tags: ["content"],
   parser: "markdownit",
   information: new URL(
-    "https://github.com/TheOdinProject/curriculum/blob/main/markdownlint/docs/TOP003.md",
+    "https://github.com/TheOdinProject/curriculum/blob/main/markdownlint/docs/TOP003.md"
   ),
   function: function TOP003(params, onError) {
     const { tokens } = params.parsers.markdownit;
@@ -233,7 +233,7 @@ module.exports = {
 
         const tokensBetweenHeadings = tokens.slice(
           tokenIndexValue,
-          tokenIndicesArr[arrIndex + 1],
+          tokenIndicesArr[arrIndex + 1]
         );
         const isSectionEmpty =
           tokensBetweenHeadings.at(-1).type === "heading_close";
@@ -243,7 +243,7 @@ module.exports = {
             createErrorObject(
               tokensBetweenHeadings[0].lineNumber,
               `The ${headingContent} section cannot be empty`,
-            ),
+            )
           );
         } else {
           switch (headingContent) {
@@ -251,17 +251,17 @@ module.exports = {
             case sectionsWithDefaultContent.knowledgeCheck:
             case sectionsWithDefaultContent.additionalResources:
               totalErrors.push(
-                ...getListSectionErrors(tokensBetweenHeadings, headingContent),
+                ...getListSectionErrors(tokensBetweenHeadings, headingContent)
               );
               break;
             case sectionsWithDefaultContent.assignment:
               totalErrors.push(
-                ...getAssignmentSectionErrors(tokensBetweenHeadings),
+                ...getAssignmentSectionErrors(tokensBetweenHeadings)
               );
               break;
           }
         }
-      },
+      }
     );
 
     totalErrors.forEach((error) => {

--- a/markdownlint/TOP003_defaultSectionContent/TOP003_defaultSectionContent.js
+++ b/markdownlint/TOP003_defaultSectionContent/TOP003_defaultSectionContent.js
@@ -26,14 +26,14 @@ function getListSectionErrors(sectionTokens, section) {
   const listSectionErrors = [];
   const listItemsName = `${section}${section.endsWith("s") ? "" : "s"}`;
   const tokensAfterHeading = sectionTokens.slice(
-    sectionTokens.findIndex((token) => token.type === "heading_close") + 1
+    sectionTokens.findIndex((token) => token.type === "heading_close") + 1,
   );
 
   const listItemTokens = tokensAfterHeading.filter(
-    (token) => token.type === "list_item_open"
+    (token) => token.type === "list_item_open",
   );
   const nestedListItemTokens = listItemTokens.filter(
-    (token) => token.level > 1
+    (token) => token.level > 1,
   );
   nestedListItemTokens.forEach((nestedListItemToken) => {
     listSectionErrors.push(
@@ -41,8 +41,8 @@ function getListSectionErrors(sectionTokens, section) {
       // will resolve the issue. There may be entire list items that need to be removed as well.
       createErrorObject(
         nestedListItemToken.lineNumber,
-        `The ${section} section must not contain nested lists.`
-      )
+        `The ${section} section must not contain nested lists.`,
+      ),
     );
   });
 
@@ -50,7 +50,7 @@ function getListSectionErrors(sectionTokens, section) {
   // the fact that whitespaces won't precede the token marker, e.g. "1.", in the token object
   const orderedListItemRegex = /^\d+\.\s*/;
   const orderedListItemTokens = listItemTokens.filter((token) =>
-    orderedListItemRegex.test(token.line)
+    orderedListItemRegex.test(token.line),
   );
   orderedListItemTokens.forEach((orderedListItemToken) => {
     listSectionErrors.push(
@@ -62,13 +62,13 @@ function getListSectionErrors(sectionTokens, section) {
           deleteCount:
             orderedListItemToken.line.match(orderedListItemRegex)[0].length,
           insertText: "- ",
-        }
-      )
+        },
+      ),
     );
   });
 
   const defaultContentOpenTokenIndex = tokensAfterHeading.findIndex(
-    (token) => token.line === listSectionsDefaultContent[section]
+    (token) => token.line === listSectionsDefaultContent[section],
   );
 
   if (defaultContentOpenTokenIndex > 0) {
@@ -77,8 +77,8 @@ function getListSectionErrors(sectionTokens, section) {
     listSectionErrors.push(
       createErrorObject(
         defaultContentToken.lineNumber,
-        `Expected default section content to come immediately after the ${section} heading.`
-      )
+        `Expected default section content to come immediately after the ${section} heading.`,
+      ),
     );
   }
   if (defaultContentOpenTokenIndex === -1) {
@@ -97,18 +97,18 @@ function getListSectionErrors(sectionTokens, section) {
         lineNumber: tokensAfterHeading[0].lineNumber,
         deleteCount: tokensAfterHeading[0].line.length,
         insertText: replacementText,
-      })
+      }),
     );
   }
 
   const tokensAfterFirstContent = tokensAfterHeading.slice(
     tokensAfterHeading.findIndex(
       (token, _index, arr) =>
-        token.type === arr[0].type.replace("_open", "_close")
-    ) + 1
+        token.type === arr[0].type.replace("_open", "_close"),
+    ) + 1,
   );
   const bulletListOpenTokenIndex = sectionTokens.findIndex(
-    (token) => token.type === "bullet_list_open"
+    (token) => token.type === "bullet_list_open",
   );
   if (
     (defaultContentOpenTokenIndex === 0 && !tokensAfterFirstContent.length) ||
@@ -134,8 +134,8 @@ function getListSectionErrors(sectionTokens, section) {
               insertText:
                 "\n- It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.",
             }
-          : {}
-      )
+          : {},
+      ),
     );
   }
 
@@ -151,13 +151,13 @@ function getListSectionErrors(sectionTokens, section) {
         {
           lineNumber: tokensAfterFirstContent[0].lineNumber,
           deleteCount: WHOLE_LINE,
-        }
-      )
+        },
+      ),
     );
   }
 
   const lastBulletListCloseIndex = sectionTokens.findLastIndex(
-    (token) => token.type === "bullet_list_close"
+    (token) => token.type === "bullet_list_close",
   );
 
   if (
@@ -165,7 +165,7 @@ function getListSectionErrors(sectionTokens, section) {
     lastBulletListCloseIndex !== sectionTokens.length - 1
   ) {
     const tokensAfterBulletListClose = sectionTokens.slice(
-      lastBulletListCloseIndex + 1
+      lastBulletListCloseIndex + 1,
     );
 
     listSectionErrors.push(
@@ -175,8 +175,8 @@ function getListSectionErrors(sectionTokens, section) {
         {
           lineNumber: tokensAfterBulletListClose[0].lineNumber,
           deleteCount: WHOLE_LINE,
-        }
-      )
+        },
+      ),
     );
   }
 
@@ -186,19 +186,19 @@ function getListSectionErrors(sectionTokens, section) {
 function getAssignmentSectionErrors(sectionTokens) {
   const assignmentErrors = [];
   const divBlockTokens = sectionTokens.filter(
-    (token) => token.type === "html_block" && token.content.startsWith("<div")
+    (token) => token.type === "html_block" && token.content.startsWith("<div"),
   );
   const hasAssignmentDiv = divBlockTokens.some(
     (token) =>
       token.content.includes(`class="lesson-content__panel"`) &&
-      token.content.includes(`markdown="1"`)
+      token.content.includes(`markdown="1"`),
   );
   if (!divBlockTokens || !hasAssignmentDiv) {
     assignmentErrors.push(
       createErrorObject(
         sectionTokens[0].lineNumber,
-        `Assignment sections must include an HTML div element with class="lesson-content__panel" and markdown="1" attributes`
-      )
+        `Assignment sections must include an HTML div element with class="lesson-content__panel" and markdown="1" attributes`,
+      ),
     );
   }
 
@@ -211,7 +211,7 @@ module.exports = {
   tags: ["content"],
   parser: "markdownit",
   information: new URL(
-    "https://github.com/TheOdinProject/curriculum/blob/main/markdownlint/docs/TOP003.md"
+    "https://github.com/TheOdinProject/curriculum/blob/main/markdownlint/docs/TOP003.md",
   ),
   function: function TOP003(params, onError) {
     const { tokens } = params.parsers.markdownit;
@@ -233,24 +233,35 @@ module.exports = {
 
         const tokensBetweenHeadings = tokens.slice(
           tokenIndexValue,
-          tokenIndicesArr[arrIndex + 1]
+          tokenIndicesArr[arrIndex + 1],
         );
+        const isSectionEmpty =
+          tokensBetweenHeadings.at(-1).type === "heading_close";
 
-        switch (headingContent) {
-          case sectionsWithDefaultContent.lessonOverview:
-          case sectionsWithDefaultContent.knowledgeCheck:
-          case sectionsWithDefaultContent.additionalResources:
-            totalErrors.push(
-              ...getListSectionErrors(tokensBetweenHeadings, headingContent)
-            );
-            break;
-          case sectionsWithDefaultContent.assignment:
-            totalErrors.push(
-              ...getAssignmentSectionErrors(tokensBetweenHeadings)
-            );
-            break;
+        if (isSectionEmpty) {
+          totalErrors.push(
+            createErrorObject(
+              tokensBetweenHeadings[0].lineNumber,
+              `The ${headingContent} section cannot be empty`,
+            ),
+          );
+        } else {
+          switch (headingContent) {
+            case sectionsWithDefaultContent.lessonOverview:
+            case sectionsWithDefaultContent.knowledgeCheck:
+            case sectionsWithDefaultContent.additionalResources:
+              totalErrors.push(
+                ...getListSectionErrors(tokensBetweenHeadings, headingContent),
+              );
+              break;
+            case sectionsWithDefaultContent.assignment:
+              totalErrors.push(
+                ...getAssignmentSectionErrors(tokensBetweenHeadings),
+              );
+              break;
+          }
         }
-      }
+      },
     );
 
     totalErrors.forEach((error) => {

--- a/markdownlint/TOP003_defaultSectionContent/tests/TOP003_test_empty-section.md
+++ b/markdownlint/TOP003_defaultSectionContent/tests/TOP003_test_empty-section.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-This file should flag 3 errors due to the "Lesson overview", "Knowledge check", and "Additional resources" sections not containing unordered lists.
+This file should flag 3 errors due to the "Lesson overview", "Knowledge check", and "Additional resources" sections being empty.
 
 ### Lesson overview
 

--- a/markdownlint/TOP003_defaultSectionContent/tests/TOP003_test_empty-section.md
+++ b/markdownlint/TOP003_defaultSectionContent/tests/TOP003_test_empty-section.md
@@ -1,0 +1,21 @@
+### Introduction
+
+This file should flag 3 errors due to the "Lesson overview", "Knowledge check", and "Additional resources" sections not containing unordered lists.
+
+### Lesson overview
+
+### Custom section
+
+Text content
+
+### Assignment
+
+<div class="lesson-content__panel" markdown="1">
+
+Assignment content
+
+</div>
+
+### Knowledge check
+
+### Additional resources


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

TOP003 lints default content sections (lesson overview, assignment, knowledge checks, additional resources) but misses the case when they're empty. If empty, it'll try to grab the non-existent contents then throw an error trying to read properties of `undefined`. Instead, it should report an appropriate error when the relevant section is empty (and no other TOP003 errors for that section).

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds error reporting specific to empty default content sections.
- Adds test file demonstrating error reports for empty default content sections.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
N/A

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
Can't include the other test files in the PR without making unnecessary changes to them. Checking out to this PR branch and linting the test files locally, the others remain untouched.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
