### PR TITLE
Prisma ORM lesson: fix broken link in assignment

### DIFF
--- a/nodeJS/orms/prisma_orm.md
+++ b/nodeJS/orms/prisma_orm.md
@@ -140,7 +140,7 @@ In the [Using PostgreSQL lesson](https://www.theodinproject.com/lessons/nodejs-u
    - [Raw SQL](https://www.prisma.io/docs/orm/prisma-client/using-raw-sql/typedsql)
    - [Prisma migrate getting started](https://www.prisma.io/docs/orm/prisma-migrate/getting-started)
    - [Prisma migrate mental model](https://www.prisma.io/docs/orm/prisma-migrate/understanding-prisma-migrate/mental-model)
-   - [Data migrations](https://www.prisma.io/docs/guides/data-migration-with-expand-and-contract)
+   - [Data migrations](https://www.prisma.io/docs/guides/data-migration)
 
 </div>
 


### PR DESCRIPTION
Prisma ORM lesson: Fix broken link for "Data migration" guide in assignment

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The link to the "Data migration" page was broken because the page has been moved to a new href.

## This PR
- Fixed the link for "Data Migration" guide in assignment.

## Issue
Couldn't find any existing issue/PR regarding this fix.

## Additional Information



## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
