### PR TITLE
Revert typo fix in git/intermediate_git/a_deeper_look_at_git.md lesson

### DIFF
--- a/git/intermediate_git/a_deeper_look_at_git.md
+++ b/git/intermediate_git/a_deeper_look_at_git.md
@@ -36,7 +36,7 @@ Before we get started with the lesson, let's create a Git playground in which we
 ```bash
 touch test{1..4}.md
 git add test1.md && git commit -m 'Create first file'
-git add test2.md && git commit -m 'Create second file'
+git add test2.md && git commit -m 'Create send file'
 git add test3.md && git commit -m 'Create third file and create fourth file'
 ```
 


### PR DESCRIPTION
## Because
This reverts a typo fix that was incorrectly merged on the git lesson: `git/intermediate_git/a_deeper_look_at_git.md`.


## This PR
- Changes line 39 `second` back to `send`.  `send` is "correct" in this context because this lesson is about making amendments to a commit history that has mistakes.
- Line 76 and Line 80 supports this reversion.


## Issue
Related to https://github.com/TheOdinProject/curriculum/pull/29409.

## Additional Information
Null.

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
