### PR TITLE
Project: Calculator: Add assignment bullet point to avoid possible bug

### DIFF
--- a/foundations/javascript_basics/project_calculator.md
+++ b/foundations/javascript_basics/project_calculator.md
@@ -42,6 +42,7 @@ Here are some use cases (expectations about your project):
    - Pressing "clear" should wipe out any existing data. Make sure the user is really starting fresh after pressing "clear".
    - Display a snarky error message if the user tries to divide by 0... and don't let it crash your calculator!
    - Make sure that your calculator only runs an operation when supplied with two numbers and an operator by the user. Example: you enter a number (`2`), followed by an operator button (`+`). You press the operator button (`+`) a second consecutive time. Your calculator should not evaluate this as (`2 + 2`) and should not display the result (`4`). If consecutive operator buttons are pressed, your calculator should not run any evaluations, it should only take the last operator entered to be used for the next operation.
+   - When a result is displayed, pressing a new digit should clear the result and start a new calculation instead of appending the digit to the existing result. Check whether this is the case on your calculator!
 
 #### Extra credit
 


### PR DESCRIPTION
## Because
Depending on how the logic behind the calculator is implemented this bug can occur:

When a result is displayed, pressing a new digit could append the digit to the end of the displayed result and not clear the result and start a new calculation. 

E.G. the top rated community solution has this issue as well: https://michalosman.github.io/calculator/

## This PR
- Added one bullet point with a to do at the assignment part of the calculator project

## Issue

No open issue atm.


## Pull Request Requirements

-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
