### PR TITLE
Objects and Object Constructors: Clarify prototype inheritance and `Object.setPrototypeOf()` usage

### DIFF
--- a/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
+++ b/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
@@ -262,7 +262,9 @@ Note:
 
 #### Recommended method for prototypal inheritance
 
-Now, how do you utilize Prototypal Inheritance? What do you need to do to use it? Just as we use `Object.getPrototypeOf()` to 'get' or view the `prototype` of an object, we can use `Object.setPrototypeOf()` to 'set' or mutate it. Let's see how it works by adding a `Person` Object Constructor to the `Player` example, and making `Player` inherit from `Person`!
+Now, how do you utilize Prototypal Inheritance? What do you need to do to use it? Just as we use `Object.getPrototypeOf()` to 'get' or view the `prototype` of an object, 
+we can use `Object.setPrototypeOf()` to 'set' or mutate it. Basically, using `Object.setPrototypeOf()` to set a prototype is same as setting the prototype using objects's `[[Prototype]]` or `__proto__` property.
+Let's see how it works by adding a `Person` Object Constructor to the `Player` example, and making `Player` inherit from `Person`!
 
 ```javascript
 function Person(name) {
@@ -299,6 +301,10 @@ player2.getMarker(); // My marker is 'O'
 ```
 
 From the code, we can see that we've defined a `Person` from whom a `Player` inherits properties and functions, and that the created `Player` objects are able to access both the `.sayName` and the `.getMarker` functions, in spite of them being defined on two separate `prototype` objects! This is enabled by the use of the `Object.setPrototypeOf()` function. It takes two arguments - the first is the one which inherits and the second argument is the one which you want the first argument to inherit from. This ensures that the created `Player` objects are able to access the `.sayName` and `.getMarker` functions through their prototype chain.
+The same can also be achieved using: 
+```javascript
+Player.prototype.__proto__ = Person.prototype
+```
 
 Note:
 
@@ -310,7 +316,9 @@ A warning... this doesn't work:
 Player.prototype = Person.prototype;
 ```
 
-because it will set `Player.prototype` to directly refer to `Person.prototype` (i.e. not a copy), which could cause problems if you want to edit something in the future. Consider one more example:
+because both `Player.prototype` and `Person.prototype` become the exact same object in memory. This means any changes made to `Player.prototype` will also affect `Person.prototype`, which is not the intended behavior.
+Instead, we should set `Player.prototype` to inherit from `Person.prototype`, rather than making them the same object.
+Consider one more example:
 
 ```javascript
 function Person(name) {


### PR DESCRIPTION
## Because
This PR improves the clarity of prototype inheritance. It explains how `Object.setPrototypeOf()` is equivalent to setting `__proto__` or `[[Prototype]]` and why directly assigning `Player.prototype = Person.prototype` is incorrect. 


## This PR

- Improved explanation of `Object.setPrototypeOf()` and how it relates to `__proto__` / `[[Prototype]]`.
- Clarified why `Player.prototype = Person.prototype` is incorrect and why `Object.setPrototypeOf()` should be used instead.


## Issue
Closes #28633

## Additional Information


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
