### PR TITLE
JS Testing/Battleship: Clarify and remind about Jest ESM compatibility config

### DIFF
--- a/javascript/testing_javascript/project_battleship.md
+++ b/javascript/testing_javascript/project_battleship.md
@@ -10,6 +10,8 @@ We have not yet discussed testing the appearance of a webpage, which requires a 
 
 <div class="lesson-content__panel" markdown="1">
 
+Remember that Jest does not have built-in stable support for ESM. Refer back to [Jest's instructions for "Using Babel"](https://jestjs.io/docs/getting-started#using-babel) from the Testing Practice project to make it compatible with your ESM src code. You do not need to do the steps in "Making your Babel config jest-aware", nor do you need to do the steps in the "Using webpack" section, as we are not testing bundled code or assets/CSS etc.
+
 1. Begin your app by creating the `Ship` class/factory (your choice).
    1. Your 'ships' will be objects that include their length, the number of times they've been hit and whether or not they've been sunk.
    1. **REMEMBER** you only have to test your object's public interface. Only methods or properties that are used outside of your 'ship' object need unit tests.

--- a/javascript/testing_javascript/project_testing_practice.md
+++ b/javascript/testing_javascript/project_testing_practice.md
@@ -4,7 +4,7 @@ Let's practice!  This testing thing really is not that difficult, but it *is* qu
 
 ### Using ES6 import statements with Jest
 
-By default, the current version of Jest will not recognize ES6 import statements. In order for you to be able to use ES6 modules for this project you may follow the [Jest instructions for using Babel](https://jestjs.io/docs/en/getting-started#using-babel).
+By default, the current version of Jest will not recognize ES6 import statements. In order for you to be able to use ES6 modules for this project you may follow the two steps in [Jest's instructions for "Using Babel"](https://jestjs.io/docs/en/getting-started#using-babel) (ignore the "Making your Babel config jest-aware" section).
 
 ### Assignment
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
In [Project: Testing Practice](https://www.theodinproject.com/lessons/node-path-javascript-testing-practice#using-es6-import-statements-with-jest), there is a link to Jest instructions for setting up Babel to get it to work with ESM code. This comprises 2 steps: install deps, then make `babel.config.js` and paste in the provided config. That's all.

It's a *very* common confusion in the community that more steps are needed and people struggle to understand the sections like "Making your babel config jest-aware" or "Using webpack" when it comes to the Battleship project. Sometimes this leads people to just research CJS on their own and do both projects in CJS, then run into further issues caused by it.

We could do with making the instruction clearer that there are only 2 steps and to ignore the conditional babel config section, and then remind about it in Battleship and be explicit about not following the "Using webpack" section (not necessary since they're not testing bundled code and assets etc.).


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds note to Jest ESM compat instructions to ignore irrelevant sections.
- Reminds about said compat instructions in Project: Battleship, being explicit about sections to ignore.
- Fixes incorrect nested list indentation.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
N/A


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
