### PR TITLE
Forms and Data Handling: Change incorrect link in Knowledge Check

### DIFF
--- a/nodeJS/express/forms_and_data_handling.md
+++ b/nodeJS/express/forms_and_data_handling.md
@@ -565,7 +565,7 @@ The following questions are an opportunity to reflect on key topics in this less
 - [How do you validate and sanitize form input using express-validator?](#understanding-the-body-function)
 - [What is the difference between validation and sanitization?](#validation-and-sanitization)
 - [How do you handle validation errors in Express routes?](#validation-results)
-- [What is the importance of escaping HTML characters in a form?](https://owasp.org/www-community/attacks/SQL_Injection)
+- [What is the importance of escaping HTML characters in a form?](https://www.theodinproject.com/lessons/nodejs-forms-and-data-handling#escaping-user-input)
 
 ### Additional resources
 


### PR DESCRIPTION
## Because
This PR updates an incorrect link under Knowledge Check section of Forms and Data Handling topic.


## This PR
- Fixes the incorrect link which leads to a page about [SQL Injection](https://owasp.org/www-community/attacks/SQL_Injection) in the final question in the Knowledge Check section to a link that leads to a section about [escaping HTML characters](https://www.theodinproject.com/lessons/nodejs-forms-and-data-handling#escaping-user-input).


## Issue
Closes #29515 

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
