### PR TITLE
Webpack: Reintroduce `npm init -y` and instruct to remove `"type"` field

### DIFF
--- a/javascript/organizing_your_javascript_code/webpack.md
+++ b/javascript/organizing_your_javascript_code/webpack.md
@@ -25,21 +25,25 @@ While it does this, we could also get it to do a whole bunch of other things, su
 
 Webpack is one of the most popular JavaScript bundlers, if not the most popular one, and has been for a long time. Let's get started with bundling!
 
-We'll first need to make a new directory for our practice app, so run the following in your terminal:
+We'll first need to make a new directory for our practice app, then create a `package.json` file in it for npm to record information about packages we use (like Webpack). Run the following in your terminal:
 
 ```bash
-mkdir webpack-practice && cd webpack-practice
+mkdir webpack-practice &&
+cd webpack-practice &&
+npm init -y
 ```
 
-Once inside your new directory, we can go ahead and install Webpack, which involves two packages.
+Inside your new directory, before we install anything, open `package.json`. If you see `"type": "commonjs"` or `"type": "module"` inside, **remove it**, otherwise Webpack will start throwing errors at us due to clashing module issues.
+
+Once we've made sure `package.json` does not contain a `"type"` property, we can go ahead and install Webpack, which involves two packages.
 
 ```bash
 npm install --save-dev webpack webpack-cli
 ```
 
-Note that we included the `--save-dev` flag (you can also use `-D` as a shortcut), which tells npm to record our two packages as development dependencies. You will see a `package.json` has been created for us with both packages marked as development dependencies. We will only be using Webpack during development. The actual code that makes Webpack run will not be part of the code that the browser will run.
+Note that we included the `--save-dev` flag (you can also use `-D` as a shortcut), which tells npm to record our two packages as development dependencies. We will only be using Webpack during development. The actual code that makes Webpack run will not be part of the code that the browser will run.
 
-Also notice that when these finished installing, a `node_modules` directory and a `package-lock.json` got auto-generated. `node_modules` is where Webpack's actual code (and a whole bunch of other stuff) lives, and `package-lock.json` is just another file npm uses to track more specific package information.
+Also notice that when these finished installing, npm created a `node_modules` directory and a `package-lock.json` file for us. `node_modules` is where Webpack's actual code (and a whole bunch of other stuff) lives, and `package-lock.json` is just another file npm uses to track more specific package information.
 
 <div class="lesson-note" markdown="1">
 


### PR DESCRIPTION
## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Original context: #29303 npm v11 introduced a breaking change so `npm init` always includes a `"type"` field in `package.json`, but Webpack can only run a CJS config and bundle ESM at the same time if no `"type"` field is present in `package.json`.

#29306 removed the `npm init -y` instruction since installing a package will make npm auto-create `package.json` etc. in the project dir.

However, it's been surprisingly *very* common where people at some point accidentally created a `package.json` and/or `node_modules/` in a parent dir e.g. `~`, forget or don't realise those files/dirs need deleting, which then causes npm to search upwards and install packages there, confusing learners.

Therefore, it would be better for now to reintroduce `npm init -y` to force npm to install packages in the real project dir, and instruct learners to remove `"type"` if `package.json` contains it (npm LTS still ships with npm v10.9.2 but some people will have manually updated for whatever reason).

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Reverts initial commands to include `npm init -y`
- Instructs to remove `package.json` `"type"` field if present

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Related to #29303

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
When Node LTS starts shipping with npm v11.X, I'll explore a proposal to shift the Webpack lessons to full ESM. It would simplify some things, but some challenges include clashes with Webpack docs which use CJS. Mainly relevant in "Revisiting Webpack" where the webpack-merge guide is full CJS.


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
