### PR TITLE
Working With APIs: Replace example fetch error "invalid Api key" with "invalid URL"

### DIFF
--- a/javascript/asynchronous_javascript_and_apis/working_with_apis.md
+++ b/javascript/asynchronous_javascript_and_apis/working_with_apis.md
@@ -235,7 +235,7 @@ While we are pushing this API key to the frontend, this isn't something you shou
 1. Read the [Fetch documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch). It's not all that complicated to use, but we've only really scratched the surface at this point.
 1. Check out this [list of Public APIs](https://github.com/n0shake/Public-APIs) and let your imagination go wild.
 1. Expand on our little project here by adding a button that fetches a new image without refreshing the page.
-1. Add a search box so users can search for specific gifs. You should also investigate adding a `.catch()` to manage most errors (i.e. invalid API key). Keep in mind that Giphy responds with a status code of 200 with an empty data array when it doesn't find any gifs with the searched keyword, in other words the `.catch()` won't be executed. Adjust your code to effectively handle such scenarios, displaying a default image or an error message if the search fails.
+1. Add a search box so users can search for specific gifs. You should also investigate adding a `.catch()` to manage some errors (i.e. invalid URL). Keep in mind that Giphy responds with a status code of 200 with an empty data array when it doesn't find any gifs with the searched keyword, in other words the `.catch()` won't be executed. Adjust your code to effectively handle such scenarios, displaying a default image or an error message if the search fails.
 
 </div>
 


### PR DESCRIPTION


<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
An invalid API key does not trip the catch, thus making this instruction confusing. An invalid URL will. This error will be easier to test than simulating a network error. (https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch)


## This PR
Updates a few words relating to it

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
https://discordapp.com/channels/505093832157691914/505093832157691916/1356208005305204836

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
