### PR TITLE
Express Routes: Migrate to v5 pathing (breaking changes)

### DIFF
--- a/nodeJS/express/routing.md
+++ b/nodeJS/express/routing.md
@@ -62,7 +62,7 @@ A common use case for a splat would be as a catch-all for all otherwise unmatche
 "/{*splat}"
 ```
 
-<div id="order-matters" class="lesson-note lesson-note--warning" markdown="1">
+<div class="lesson-note lesson-note--warning" markdown="1">
 
 #### Order matters!
 

--- a/nodeJS/express/routing.md
+++ b/nodeJS/express/routing.md
@@ -40,20 +40,17 @@ That would tell us the route matches any POST requests to the `/messages` path o
 
 The first argument we pass a route is the path to match, which can either be a string or a regular expression. `/messages` matches that exactly, while `/messages/all` only matches if the path is `/messages/all` (not `/messages`, nor `/messages/new`).
 
-With string paths, we can also use certain symbols like `?`, `+`, `*` and `()` to provide some pattern-matching functionality, similar to regular expressions. For example:
+With string paths, we can also use `{}` to make characters optional. For example:
 
 ```javascript
-// ? makes a character optional
-// The following path matches both /message and /messages
-"/messages?"
+// Matches both /message and /messages
+"/message{s}"
 
-// () groups characters together, allowing symbols to act on the group
-// The following path matches both / and /messages
-"/(messages)?"
+// Matches both / and /messages
+"/{messages}"
 
-// * is a wildcard matching any number of any characters
-// The following path can match /foo/barbar and even /foo-FOO/bar3sdjsdfbar
-"/foo*/bar*bar"
+// Matches both /foo/baz and /foo/bar/baz
+"/foo{/bar}/baz"
 ```
 
 <div id="order-matters" class="lesson-note lesson-note--warning" markdown="1">
@@ -63,15 +60,15 @@ With string paths, we can also use certain symbols like `?`, `+`, `*` and `()` t
 Your routes will be set up in your server in the order they are defined.
 
 ```javascript
-app.get("*", (req, res) => {
-  res.send("* is a great way to catch all otherwise unmatched paths, e.g. for custom 404 error handling.");
+app.get("/{*splat}", (req, res) => {
+  res.send("/{*splat} is a great way to catch all otherwise unmatched paths, e.g. for custom 404 error handling.");
 });
 app.get("/messages", (req, res) => {
   res.send("This route will not be reached because the previous route's path matches first.");
 });
 ```
 
-In order for our `GET /messages` request to match the `/messages` route, we will need to reverse the order our routes are defined. Doing so will prevent it from reaching the `*` route, as it will match the `/messages` route first.
+In order for our `GET /messages` request to match the `/messages` route, we will need to reverse the order our routes are defined. Doing so will prevent it from reaching the `/{*splat}` route, as it will match the `/messages` route first.
 
 </div>
 

--- a/nodeJS/express/routing.md
+++ b/nodeJS/express/routing.md
@@ -53,6 +53,15 @@ With string paths, we can also use `{}` to make characters optional. For example
 "/foo{/bar}/baz"
 ```
 
+With `*` (a "splat" or "wildcard"), we can match any number of any characters. [Splats in Express paths must always be followed by a name](https://expressjs.com/en/guide/migrating-5.html#path-syntax).
+
+A common use case for a splat would be as a catch-all for all otherwise unmatched paths, e.g. for custom 404 error handling.
+
+```javascript
+// Matches / and /odin as well as /sdds8fjsdifhj98sdfh
+"/{*splat}"
+```
+
 <div id="order-matters" class="lesson-note lesson-note--warning" markdown="1">
 
 #### Order matters!

--- a/nodeJS/express/routing.md
+++ b/nodeJS/express/routing.md
@@ -204,6 +204,16 @@ To test these routes, use [Postman](https://www.postman.com/downloads/) which wi
 
 <div class="lesson-content__panel" markdown="1">
 
+<div class="lesson-note" markdown="1">
+
+#### Express v5 changes
+
+We are currently using Express v5 and as of writing this, some of the sections in the article below will not work in v5, though they are clearly marked and links provided to more relevant documentation.
+
+This resource will be updated once a v5-only routing primer exists.
+
+</div>
+
 1. Read through the Express' [primer on Routing](https://expressjs.com/en/guide/routing.html) for an overview of this lesson's topics. Remember to reference the [Express documentation](https://expressjs.com/en/api.html) for more information on specific methods.
 
 </div>

--- a/nodeJS/express/routing.md
+++ b/nodeJS/express/routing.md
@@ -83,17 +83,17 @@ In order for our `GET /messages` request to match the `/messages` route, we will
 
 #### Route parameters
 
-What if we wanted to have a route for all messages for any username, for example, `/odin/messages` or `/thor/messages`, or even `/theodinproject79687378/messages`? We could technically use `/*/messages`, but what if we wanted to extract and use the username in our middleware functions? Just like with React Router, we can use `route parameters`, and a path can contain as many of these parameters as we need.
+What if we wanted to have a route for all messages for any username, for example, `/odin/messages` or `/thor/messages`, or even `/theodinproject79687378/messages`? Just like with React Router, we can use `route parameters`, and a path can contain as many of these parameters as we need.
 
 To denote a route parameter, we start a segment with a `:` followed by the name of the parameter (which can only consist of case-sensitive alphanumeric characters, or `_`). Whatever we name that route parameter, Express will automatically populate the `req.params` object in any of the following middleware functions with whatever value the path passed into the parameter, using the parameter name as its key.
 
 ```javascript
 /**
  * GET /odin/messages will have this log
- * { username: 'odin' }
+ * { username: "odin" }
  *
  * GET /theodinproject79687378/messages would instead log
- * { username: 'theodinproject79687378' }
+ * { username: "theodinproject79687378" }
  */
 app.get("/:username/messages", (req, res) => {
   console.log(req.params);


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

[Express v5 is now the latest npm release](https://expressjs.com/2025/03/31/v5-1-latest-release.html), i.e. it's now what learners will end up installing when they run `npm install express`. There aren't too many breaking changes in v5 but there are some with [routes and paths](https://expressjs.com/2024/10/15/v5-release.html#changes-to-path-matching-and-regular-expressions). Breaking changes elsewhere, such as async middleware and error-catching, will not be addressed in this PR.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Replaces `?`/`()`/`*` example with new examples using `{}` (v5 optional chars) and `*splat` (new splat format that requires a name and matches slightly differently from before).
- Amends any existing paths as necessary
- Removes redundant id (duplicate id generated by note box heading already)
- Add note in assignment about v4/5 contents compatibility.
  - Currently, there doesn't seem to be a v5-only routing primer, so for now the mixed v4/5 primer with links to v5-only parts will have to do. I imagine in due course, Express will update docs and there will be a cleaner v5-only primer to link to if not the same URL. There are a couple of areas in Express docs that they are aware aren't yet up to scratch for v5 only.


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
N/A
Closes #29638
## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
