### PR TITLE
Node Controllers: Remove express-async-handler content

### DIFF
--- a/nodeJS/express/controllers.md
+++ b/nodeJS/express/controllers.md
@@ -225,9 +225,9 @@ async function getAuthorById(req, res) {
 
 What if we have many async middleware functions and a lot of them respond the same way just with things like different status codes and response messages? Instead of `try/catch` in each middleware, Express automatically catches any thrown errors and calls `next(error)`, which will pass control over to a special "error middleware function", meaning we wouldn't need to catch and handle in the original controller itself.
 
-#### With a middleware
+#### Error handler middleware
 
-An error middleware function handles all errors in our application that come down from other middleware functions. We want to place this error middleware function at the very end of the application code to ensure it's the last middleware function executed and only handles errors bubbling down from preceding middleware functions.
+An error handler middleware function handles all errors in our application that come down from other middleware functions. We want to place this error middleware function at the very end of the application code to ensure it's the last middleware function executed and only handles errors bubbling down from preceding middleware functions.
 
 Add the following code in `app.js` at the end of all middleware functions in our application:
 
@@ -390,7 +390,7 @@ The following questions are an opportunity to reflect on key topics in this less
 - [What are the other arguments you can pass to the next function?](#what-is-the-next-function)
 - [What is a controller?](#controllers)
 - [What is the difference between a controller and a middleware?](#controllers)
-- [What happens if you define a middleware function with four parameters?](#with-a-middleware)
+- [What happens if you define a middleware function with four parameters?](#error-handler-middleware)
 - [What would you do to create a custom error?](#creating-custom-errors)
 
 ### Additional resources

--- a/nodeJS/express/controllers.md
+++ b/nodeJS/express/controllers.md
@@ -218,7 +218,7 @@ async function getAuthorById(req, res) {
 
     // or we can call next(error) instead of sending a response here
     // Using `next(error)` however will only render an error page in the express' default view and respond with the whole html to the client.
-    // So we will need to create a special type of middleware function if we want a different response and we will get to that...next.
+    // So we will need to create a special type of middleware function if we want a different response and we will get to that... next.
   }
 };
 ```

--- a/nodeJS/express/controllers.md
+++ b/nodeJS/express/controllers.md
@@ -218,40 +218,16 @@ async function getAuthorById(req, res) {
 
     // or we can call next(error) instead of sending a response here
     // Using `next(error)` however will only render an error page in the express' default view and respond with the whole html to the client.
-    // So we will need to create a special type of middleware function if we want a different response and we will get to that in a bit.
+    // So we will need to create a special type of middleware function if we want a different response and we will get to that...next.
   }
 };
 ```
 
-However, this is not exactly a clean solution since eventually, we will have to add the same try/catch block to *all* controllers. We can install a package called [express-async-handler](https://www.npmjs.com/package/express-async-handler) to hide this bit of code.
-
-```javascript
-const asyncHandler = require("express-async-handler");
-
-// The function will automatically catch any errors thrown and call the next function
-const getAuthorById = asyncHandler(async (req, res) => {
-  const { authorId } = req.params;
-
-  const author = await db.getAuthorById(Number(authorId));
-
-  if (!author) {
-    res.status(404).send("Author not found");
-    return;
-  }
-
-  res.send(`Author Name: ${author.name}`);
-});
-```
-
-<div class="lesson-note lesson-note--tip" markdown="1">
-
-The asyncHandler function in the `express-async-handler` library is just 6 lines of code. Try to take a guess on how it's implemented and then do [check out the asyncHandler source code](https://github.com/Abazhenov/express-async-handler/blob/master/index.js) for yourself.
-
-</div>
+What if we have many async middleware functions and a lot of them respond the same way just with things like different status codes and response messages? Instead of `try/catch` in each middleware, Express automatically catches any thrown errors and calls `next(error)`, which will pass control over to a special "error middleware function", meaning we wouldn't need to catch and handle in the original controller itself.
 
 #### With a middleware
 
-Remember our earlier discussion about a "special type of middleware"? Let's dive into that now. An error middleware function handles all errors in our application that come down from other middleware functions. We want to place this error middleware function at the very end of the application code to ensure it's the last middleware function executed and only handles errors bubbling down from preceding middleware functions.
+An error middleware function handles all errors in our application that come down from other middleware functions. We want to place this error middleware function at the very end of the application code to ensure it's the last middleware function executed and only handles errors bubbling down from preceding middleware functions.
 
 Add the following code in `app.js` at the end of all middleware functions in our application:
 
@@ -269,7 +245,7 @@ This is an odd one where the error object *must* be the first parameter in the c
 
 This middleware function handles the *errors thrown* in other middleware functions or something that is sent by a previous middleware function using the `next` function (e.g. `next(err)`).
 
-So the way Express distinguishes this middleware function is again through adding *four parameters*, not a single one missing. A route middleware function or a middleware function with *less than four parameters* will always be considered as a request middleware function instead of this error middleware function, even if we place it last.
+So the way Express distinguishes this middleware function is again through adding *four parameters*, not a single one missing. A route middleware function or a middleware function with *fewer than four parameters* will always be considered as a request middleware function instead of this error middleware function, even if we place it last.
 
 ```javascript
 app.use((req, res, next) => {
@@ -310,7 +286,7 @@ We can then use this custom error class and refactor the earlier version of `get
 ```javascript
 const CustomNotFoundError = require("../errors/CustomNotFoundError");
 
-const getAuthorById = asyncHandler(async (req, res) => {
+const getAuthorById = async (req, res) => {
   const { authorId } = req.params;
 
   const author = await db.getAuthorById(Number(authorId));
@@ -320,10 +296,10 @@ const getAuthorById = asyncHandler(async (req, res) => {
   }
 
   res.send(`Author Name: ${author.name}`);
-});
+};
 ```
 
-Since we are using `express-async-handler`, we don't need to send an error response inside of this function but instead just throw an error. `asyncHandler` automatically catches the thrown error and calls `next()`, passing in the caught error as an argument, which passes control to our custom error handler!
+Since Express will auto-catch any thrown errors in the async middleware function, we don't need to send an error response inside of this function but instead just throw an error. Express calls `next()`, passing in the caught error as an argument, which passes control to our custom error handler!
 
 It will eventually end up in the error middleware function where we can also modify:
 


### PR DESCRIPTION
## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Express v5 has been the npm current for a while i.e. what will be installed with `npm install express`, and rejected Promise support for async middleware is now built-in: https://expressjs.com/en/guide/migrating-5.html#rejected-promises. `express-async-handler` is no longer needed.

I've tested this and can confirm the exact same behaviour built in:

Crashes server in v4, catches and calls `next(err)` in v5:
```js
app.get('/', async () => {
    throw new Error('catch me!');
};
```

Required in v4 to catch and call `next(err)` in v4:
```js
const asyncHandler = require('express-async-handler');

app.get('/', asyncHandler(async () => {
    throw new Error('catch me!');
});
```

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Removes content on `express-async-handler`
- Rewords relevant sentences

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
N/A

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
