### PR TITLE
JS Linting: Remove eslint-config-airbnb-base content

### DIFF
--- a/javascript/javascript_in_the_real_world/linting.md
+++ b/javascript/javascript_in_the_real_world/linting.md
@@ -11,9 +11,11 @@ This section contains a general overview of topics that you will learn in this l
 
 ### Style guides
 
-Code style is important! Having a consistent set of style rules for things such as indentation or preferred quote style makes your code more maintainable and easier to read. There are several popular JavaScript style guides on the net that set standards for these types of things, and a little time spent looking through them *will* make you a better developer. Have a little look at some popular style guides for an idea of what sort of things can be done to improve consistency:
+Code style is important! Having a consistent set of style rules for things such as indentation, preferred quote style or general code structure practices, makes your code more maintainable and easier to read. There are several popular JavaScript style guides on the net that set standards for these types of things and you'll find they often differ in what they enforce. None are "right" or "wrong", only that they enforce *something* to promote consistency across a codebase.
 
-1. The [Airbnb Style Guide](https://github.com/airbnb/javascript) is one of the most popular. It is also very well formatted and easy to read.
+Here are a few examples of style guides, including ones used by specific companies:
+
+1. The [Airbnb Style Guide](https://github.com/airbnb/javascript) is one of the most popular.
 1. There is also a [JavaScript style guide used at Google](https://google.github.io/styleguide/jsguide.html).
 1. The [JavaScript Standard Style](https://standardjs.com/rules.html).
 

--- a/javascript/javascript_in_the_real_world/linting.md
+++ b/javascript/javascript_in_the_real_world/linting.md
@@ -23,18 +23,6 @@ The style guides we mentioned above are full of really helpful advice for format
 
 ESLint is installed as a dev dependency in your project which will allow you to run checks on any of your files via the command line. [ESLint's official "Getting Started" page](https://eslint.org/docs/user-guide/getting-started) is a good place to start which covers installation and basic configuration. You will also want to look at the [docs on configuring ESLint](https://eslint.org/docs/latest/use/configure/) for a list of options that you can change, such as including or excluding certain folders or files, and details about specific rules.
 
-<div class="lesson-note lesson-note--warning" markdown="1">
-
-#### ESLint v9 and flat config support
-
-The above ESLint doc links take you to the docs for v9, which was released in April 2024. v9 came with a lot of big changes, including forcing all ESLint config files to use the "flat config" format (`eslint.config.(m|c)js`).
-
-Because of these changes, some community plugins like [eslint-config-airbnb-base](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base) (which makes ESLint use Airbnb's ruleset) have not yet been able to release a version that supports v9 or flat config.
-
-For the time being, if you wish to use airbnb's style guide with ESLint, you will need to use [ESLint's v8.57 version of the docs](https://eslint.org/docs/v8.x/use/getting-started) and make sure you use one of the older [eslintrc configuration file formats](https://eslint.org/docs/v8.x/use/configure/configuration-files), **not** the newer flat config format.
-
-</div>
-
 ### Formatters
 
 Formatters are *awesome*. They are similar to linters, but serve a slightly different function. Formatters take your JavaScript code and then automatically format it according to a set of rules. Unlike linters, they do not look for style errors, but specifically target the layout of your code, making intelligent decisions about things like spaces, indentation levels and line-breaks.
@@ -54,14 +42,6 @@ For example, when installed, the [ESLint extension](https://marketplace.visualst
 It is important that you still have the packages installed as dependencies in your project along any configuration files. The extensions can have fallback rules set, but if they detect the respective package and configuration file in your project, they will use those rules and the package version installed. That way, projects always hold the source of truth for what linting and formatting rules should be applied, and should you ever work on other projects, you're less likely to introduce unwanted style changes from your local settings.
 
 In summary, the extensions are great tools for convenience but they should not be used as the source of truth for a project's linting or formatting setup.
-
-### Using ESLint and Prettier together
-
-We **highly** recommend that you install ESlint and Prettier and use them for all future projects. It will make your code easier to read, both for yourself and for anyone else looking at it.
-
-For most people using the default ESLint ruleset, there will be no special setup needed apart from installing both of them.
-
-Some community plugins, such as [eslint-config-airbnb-base](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base), turn on some stylistic rules that may clash with what Prettier formats. If you wish to use a plugin like `eslint-config-airbnb-base` and Prettier together, you will also need to install [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) which will turn off any of the ESLint rules that clash with Prettier. If you are using the default ESLint ruleset, you will not need this.
 
 <div class="lesson-note lesson-note--tip" markdown="1">
 

--- a/javascript/javascript_in_the_real_world/linting.md
+++ b/javascript/javascript_in_the_real_world/linting.md
@@ -23,7 +23,9 @@ Here are a few examples of style guides, including ones used by specific compani
 
 The style guides we mentioned above are full of really helpful advice for formatting, organizing and composing your code. But there are a *lot* of rules - it can be difficult to internalize them all. **Linters** are tools that will scan your code with a set of style rules and will report any errors to you that they find. In some cases, they can even auto-fix the errors! There are many linters that exist for JavaScript but by far the most common one is [ESLint](https://eslint.org/).
 
-ESLint is installed as a dev dependency in your project which will allow you to run checks on any of your files via the command line. [ESLint's official "Getting Started" page](https://eslint.org/docs/user-guide/getting-started) is a good place to start which covers installation and basic configuration. You will also want to look at the [docs on configuring ESLint](https://eslint.org/docs/latest/use/configure/) for a list of options that you can change, such as including or excluding certain folders or files, and details about specific rules.
+ESLint is installed as a dev dependency in your project which will allow you to run checks on any of your files via the command line. [ESLint's official "Getting Started" page](https://eslint.org/docs/user-guide/getting-started) is a good place to start which covers installation and basic configuration. The default rule set covers many of the most common scenarios with sensible default settings.
+
+You will also want to look at the [docs on configuring ESLint](https://eslint.org/docs/latest/use/configure/) for a list of options that you can change, such as including or excluding certain folders or files, and details about specific rules.
 
 ### Formatters
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Going to assume that (https://github.com/TheOdinProject/curriculum/pull/29516#issuecomment-2908082288) is the equivalent of assignment on the linked issue.

1. `eslint-config-airbnb-base` and ESLint v9 compatibility is still and issue, and users often end up more confused when trying to set up ESLint v8 and eslint-airbnb when they've only just learnt about ESLint in the first place.
2. Mentioning how to resolve this makes it sound like the curriculum endorses/recommends the use of Airbnb's style guide specifically over other possible options.
3. People are still somewhat often misunderstanding the Style Guides section in that they think they need to read the style guides cover-to-cover like they're articles/lessons, and/or that the lesson is telling them to pick one to use from now on, as opposed to them just being shown as examples of what style guides are and contain.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Removes content specific to `eslint-config-airbnb-base`
- Rephrases style guides section to be clearer about the linked guides just being examples and not specific recommendations
- Makes clear that ESLint's default setup uses its default rule set which should be plenty sufficient for learners throughout the curriculum.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #29533


## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
N/A

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
