### PR TITLE
Links and Images: Fix missing brackets

### DIFF
--- a/foundations/html_css/html-foundations/links-and-images.md
+++ b/foundations/html_css/html-foundations/links-and-images.md
@@ -65,7 +65,7 @@ While `href` specifies the destination link, `target` specifies where the linked
 `noopener`: The `noopener` value of the `rel` attribute ensures that a link opened in a new tab or window cannot interact with or access the original page. Without it, the new page can use JavaScript to manipulate the original page, which poses a security risk.
 
 For example:
-"<a href="https://example.com" target="_blank" rel="noopener">Open Example</a>"
+`<a href="https://example.com" target="_blank" rel="noopener">Open Example</a>`
 
 In this code:
 target="_blank": opens the link in a new tab.
@@ -75,7 +75,7 @@ Without `noopener`, the new tab could use JavaScript to interact with the origin
 `noreferrer`: The `noreferrer` value of the `rel` attribute provides both privacy and security. It prevents the new page from knowing where the user came from (hiding the referrer) and also includes the behavior of `noopener`, preventing the new page from accessing the original page.
 
 For example:
-"<a href="https://example.com" target="_blank" rel="noreferrer">Visit Example</a>"
+`<a href="https://example.com" target="_blank" rel="noreferrer">Visit Example</a>`
 
 In this example:
 target="_blank": opens the link in a new tab.
@@ -280,7 +280,7 @@ What if we want to use the dog image in the about page? We would first have to g
 
 To break this down:
 
-1. First, we are going to the parent directory of the pages directory which is `odin-links-and-images`.
+1. First, we are going to the parent directory of the `pages` directory which is `odin-links-and-images`.
 1. Then, from the parent directory, we can go into the `images` directory.
 1. Finally, we can access the `dog.jpg` file.
 

--- a/foundations/html_css/html-foundations/links-and-images.md
+++ b/foundations/html_css/html-foundations/links-and-images.md
@@ -78,9 +78,11 @@ Without `noopener`, the new tab could use JavaScript to interact with the origin
 `noreferrer`: The `noreferrer` value of the `rel` attribute provides both privacy and security. It prevents the new page from knowing where the user came from (hiding the referrer) and also includes the behavior of `noopener`, preventing the new page from accessing the original page.
 
 For example:
+
 ```html
 `<a href="https://example.com" target="_blank" rel="noreferrer">Visit Example</a>`
 ```
+
 In this example:
 target="_blank": opens the link in a new tab.
 rel="noreferrer": ensures the new page cannot see the referring page’s address (privacy) and prevents it from accessing the original page (security).

--- a/foundations/html_css/html-foundations/links-and-images.md
+++ b/foundations/html_css/html-foundations/links-and-images.md
@@ -65,9 +65,11 @@ While `href` specifies the destination link, `target` specifies where the linked
 `noopener`: The `noopener` value of the `rel` attribute ensures that a link opened in a new tab or window cannot interact with or access the original page. Without it, the new page can use JavaScript to manipulate the original page, which poses a security risk.
 
 For example:
+
 ```html
 <a href="https://example.com" target="_blank" rel="noopener">Open Example</a>
 ```
+
 In this code:
 target="_blank": opens the link in a new tab.
 rel="noopener": prevents the new tab from accessing the original page, ensuring security.

--- a/foundations/html_css/html-foundations/links-and-images.md
+++ b/foundations/html_css/html-foundations/links-and-images.md
@@ -80,7 +80,7 @@ Without `noopener`, the new tab could use JavaScript to interact with the origin
 For example:
 
 ```html
-`<a href="https://example.com" target="_blank" rel="noreferrer">Visit Example</a>`
+<a href="https://example.com" target="_blank" rel="noreferrer">Visit Example</a>
 ```
 
 In this example:

--- a/foundations/html_css/html-foundations/links-and-images.md
+++ b/foundations/html_css/html-foundations/links-and-images.md
@@ -65,8 +65,9 @@ While `href` specifies the destination link, `target` specifies where the linked
 `noopener`: The `noopener` value of the `rel` attribute ensures that a link opened in a new tab or window cannot interact with or access the original page. Without it, the new page can use JavaScript to manipulate the original page, which poses a security risk.
 
 For example:
-`<a href="https://example.com" target="_blank" rel="noopener">Open Example</a>`
-
+```html
+<a href="https://example.com" target="_blank" rel="noopener">Open Example</a>
+```
 In this code:
 target="_blank": opens the link in a new tab.
 rel="noopener": prevents the new tab from accessing the original page, ensuring security.
@@ -75,8 +76,9 @@ Without `noopener`, the new tab could use JavaScript to interact with the origin
 `noreferrer`: The `noreferrer` value of the `rel` attribute provides both privacy and security. It prevents the new page from knowing where the user came from (hiding the referrer) and also includes the behavior of `noopener`, preventing the new page from accessing the original page.
 
 For example:
+```html
 `<a href="https://example.com" target="_blank" rel="noreferrer">Visit Example</a>`
-
+```
 In this example:
 target="_blank": opens the link in a new tab.
 rel="noreferrer": ensures the new page cannot see the referring page’s address (privacy) and prevents it from accessing the original page (security).


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
The word pages was missing backticks that would denote it as code.


## This PR
Changed:
First, we are going to the parent directory of the pages directory which is `odin-links-and-images`.
To:
First, we are going to the parent directory of the `pages` directory which is `odin-links-and-images`.


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
No open isssues.

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
Since I got a markdown linter error, I've also added another commit changing the `a` link tag, to correct markdown formatting changing it into actual code, following the linter guidelines.
```
"<a href="https://example.com" target="_blank" rel="noopener">Open Example</a>"
```
to
```
`<a href="https://example.com" target="_blank" rel="noopener">Open Example</a>`
```
and
```
"<a href="https://example.com" target="_blank" rel="noreferrer">Visit Example</a>"
```
to
```
`<a href="https://example.com" target="_blank" rel="noreferrer">Visit Example</a>`
```


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
