### PR TITLE
React Router lesson: Fix link to useOutletContext documentation

### DIFF
--- a/react/the_react_ecosystem/react_router.md
+++ b/react/the_react_ecosystem/react_router.md
@@ -445,7 +445,7 @@ If we had data in the parent element, such as a state, that we wanted to pass to
 
 Outlets have a `context` prop built in. We can pass any value we want into this prop, even an array or object. Inside *any* component that would be rendered within that outlet (even "grandchild" components), we can call the `useOutletContext()` hook which will return whatever we passed into that context prop. If we passed in an array or object, we could even destructure it!
 
-Take a look at React Router's [documentation on `useOutletContext`](https://reactrouter.com/en/main/hooks/use-outlet-context) to learn more about how to pass context through an outlet and access that context in child components.
+Take a look at React Router's [documentation on `useOutletContext`](https://reactrouter.com/6.30.1/hooks/use-outlet-context) to learn more about how to pass context through an outlet and access that context in child components.
 
 ### Protected routes and navigation
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The currently live link (https://api.reactrouter.com/v7/functions/react_router.useOutletContext.html) goes to the reference documentation page, which doesn't include or link to helpful information for learners.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
 - Changes useOutletContext link from reference documentation to descriptive documentation.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
Unfortunately, the latest (7.3.6) and dev documentation versions *also* have bare-bones documention that only gives the hook signature (e.g. https://reactrouter.com/api/hooks/useOutletContext). However, the 6.30.1 docs provide useful examples, and I suspect this was the documentation the lesson originally intended to link to.

I suspect that as the React Router docs get updated, this link will need to change again, but for now, if the lesson contains a link to official React Router documentation for this hook, this should be the page it links to.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
