### PR TITLE
Revert "Codespell: Ignore URIs and emails"

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -15,4 +15,3 @@ jobs:
             check_hidden: true
             skip: ./.git,*.png,*.csv,./archive,./legacy_submissions
             ignore_words_file: './.codespellignore'
-            uri_ignore_words_list: '*'


### PR DESCRIPTION
Reverts TheOdinProject/curriculum#29830

Codespell broken with ignore params. Example: #29814
Should revert first and I'll explore in a private repo exactly what's wrong, since it seems like it should work going by the action's docs.