### PR TITLE
Loops and Arrays lesson: Update Wes Bos video links to skip intro

### DIFF
--- a/foundations/javascript_basics/loops_and_arrays.md
+++ b/foundations/javascript_basics/loops_and_arrays.md
@@ -198,8 +198,8 @@ We will teach you the art of actually writing these tests later in the course. F
    - `Copy and sort array`
    - `Shuffle an array`
    - `Filter unique array members`
-1. Follow up by coding along to [JavaScript Array Cardio Practice - Day 1](https://www.youtube.com/watch?v=HB1ZC7czKRs) by Wes Bos. You will need to fork and clone the [JavaScript30 repository](https://github.com/wesbos/JavaScript30) for this.
-1. Watch and code along with [Wes Bos' Array Cardio Day 2](https://www.youtube.com/watch?v=QNmRfyNg1lw).
+1. Follow up by coding along to [JavaScript Array Cardio Practice - Day 1](https://www.youtube.com/watch?v=HB1ZC7czKRs&t=7) by Wes Bos. You will need to fork and clone the [JavaScript30 repository](https://github.com/wesbos/JavaScript30) for this.
+1. Watch and code along with [Wes Bos' Array Cardio Day 2](https://www.youtube.com/watch?v=QNmRfyNg1lw&t=8).
 1. Go back to the [JavaScript exercises repository](https://github.com/TheOdinProject/javascript-exercises) that we introduced in the [Data Types and Conditionals](https://www.theodinproject.com/lessons/foundations-data-types-and-conditionals) assignment. Review each README file prior to completing the following exercises in order:
     - `06_repeatString`
     - `07_reverseString`


### PR DESCRIPTION
Modified the YouTube links for Wes Bos's Array Cardio Day 1 and Day 2 videos to start at 7 and 8 seconds, respectively. This change avoids the loud guitar intros and lets learners jump straight into the content.

## Because
The original video links started at 0:00, which included a loud guitar intro unrelated to the lesson. Starting the videos at 0:07 and 0:08 skips directly to the coding content, improving the learner experience.

## This PR
- Updated the Day 1 video link to start at 7 seconds.
- Updated the Day 2 video link to start at 8 seconds.

## Issue
N/A

## Additional Information
These time-specific links use the standard YouTube format (`&t=7`) without any tracking/session data.

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
