### PR TITLE
Type Checking with Proptypes: DefaultProps now deprecated for Function Components

### DIFF
--- a/react/the_react_ecosystem/type_checking_with_proptypes.md
+++ b/react/the_react_ecosystem/type_checking_with_proptypes.md
@@ -53,14 +53,17 @@ RenderName.propTypes = {
 
 ### Using defaultProps
 
-Another cool thing we can do in combination with PropTypes is passing in default props:
+Another cool thing we can do in combination with PropTypes is passing in default props when using Class-based components:
 
 ```jsx
+import React from 'react';
 import PropTypes from 'prop-types';
 
-const RenderName = (props) => {
-  return <div>{props.name}</div>;
-};
+class RenderName extends React.Component {
+  render() {
+    return <div>{this.props.name}</div>;
+  }
+}
 
 RenderName.propTypes = {
   name: PropTypes.string,


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
If a user tries to use default props with a function component, as in the examples, with newer version of react, this won't work. This needs to show the example with a class-based component.


## This PR

- Specifies that this is for class-based components
- Changes the example to fit with this.


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #29510

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
