### PR TITLE
Active Record Queries Lesson: Remove unexplained #having mention from Aggregations section

### DIFF
--- a/ruby_on_rails/advanced_forms_and_activerecord/active_record_queries.md
+++ b/ruby_on_rails/advanced_forms_and_activerecord/active_record_queries.md
@@ -113,7 +113,6 @@ Just like with SQL, you often want to group fields together (or "roll up" the va
   # => {"tag1" => 4, "tag2" => 2, "tag3" => 5}
 ```
 
-`#having` is sort of like a `#where` clause for grouped queries.
 
 ### Joins
 


### PR DESCRIPTION
## Because
Fixes confusion by removing an unexplained and out-of-place mention of the `having` method in the Aggregations section. 

This improves the flow and clarity of the Aggregations section of the Active Record Queries lesson.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
・Removed the line introducing the `having` method.


## Issue
No related issue -  just a small clarification to improve lesson flow and reduce confusion.



## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
