### PR TITLE
Fix: removed broken link in async lesson

### DIFF
--- a/javascript/asynchronous_javascript_and_apis/asynchronous_code.md
+++ b/javascript/asynchronous_javascript_and_apis/asynchronous_code.md
@@ -27,7 +27,7 @@ myDiv.addEventListener("click", function(){
 
 Here, the function `addEventListener()` takes a callback (the "do something" function) and then calls it when `myDiv` gets clicked.
 
-You will likely recognize this pattern as something that happens *all the time* in JavaScript code.  Unfortunately, though they are useful in situations like the above example, using callbacks can get out of hand, especially when you need to chain several of them together in a specific order.  The rest of this lesson discusses patterns and functions that will help keep you out of [Callback hell](http://callbackhell.com/).
+You will likely recognize this pattern as something that happens *all the time* in JavaScript code.  Unfortunately, though they are useful in situations like the above example, using callbacks can get out of hand, especially when you need to chain several of them together in a specific order.  The rest of this lesson discusses patterns and functions that will help keep you out of Callback hell.
 
 Take a moment to skim through this [article on callbacks](https://github.com/maxogden/art-of-node#callbacks) before moving on.  Or, if you prefer to watch a video of [Callback functions](https://www.youtube.com/watch?v=QRq2zMHlBz4).
 


### PR DESCRIPTION
This fixes the issue in the Asynchronous JavaScript lesson which was leading to a broken link.

## Because
The lesson on asynchronous JavaScript contained a broken Markdown link which could confuse learners or lead them to the wrong resource. Fixing this improves the learner experience and ensures the content is accurate and up-to-date.

## This PR
- Removed a broken Markdown link in the `asynchronous_code.md` lesson file.
- Ensured the surrounding sentence remains grammatically correct without the link.

## Issue
No related open issue.

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
