### PR TITLE
Markdownlint: Change TOP001 rule name

### DIFF
--- a/markdownlint/TOP001_descriptiveLinkText/TOP001_descriptiveLinkText.js
+++ b/markdownlint/TOP001_descriptiveLinkText/TOP001_descriptiveLinkText.js
@@ -1,5 +1,5 @@
 module.exports = {
-  names: ["TOP001", "descriptive-link-text"],
+  names: ["TOP001", "descriptive-link-text-labels"],
   description: "Links have descriptive text labels",
   tags: ["accessibility", "links"],
   parser: "markdownit",

--- a/markdownlint/docs/TOP001.md
+++ b/markdownlint/docs/TOP001.md
@@ -2,7 +2,7 @@
 
 Tags: `accessibility`, `links`
 
-Aliases: `descriptive-link-text`
+Aliases: `descriptive-link-text-labels`
 
 Fixable via script: Not fixable due to being context-based
 


### PR DESCRIPTION


<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
"Recent" [built-in MD059](https://github.com/DavidAnson/markdownlint/blob/main/doc/md059.md) shares the same rule name and breaks the markdownlint VSC extension:

<img width="583" height="404" alt="image" src="https://github.com/user-attachments/assets/148bc2c8-3b35-41ce-a304-021a2548631c" />

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Amends TOP001 rule name to avoid clash with built-in

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
As far as I can see, MD059 is not enabled in the default rule set nor our own config, so the rule itself shouldn't clash with TOP001. I'm not entirely sure of the specific differences but we can probably leave it as is and stick with TOP001 which works well.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
