### PR TITLE
Change paragraph to ensure clarity on why we move modulo operator

### DIFF
--- a/javascript/computer_science/project_hash_map.md
+++ b/javascript/computer_science/project_hash_map.md
@@ -37,7 +37,9 @@ if (index < 0 || index >= buckets.length) {
 
       You are free to use that, or you can conduct your own research on hashing algorithms. Beware, this is a deep, deep rabbit hole.
 
-      However, there is one edge case our `hash` function still needs to address. For very long keys, our hash code will exceed the maximum integer value allowed by JavaScript. Once that happens, calculations become inaccurate, and the chance of collisions significantly increases. One way to avoid this issue is to apply the modulo `%` operator on *each iteration* instead of outside the loop at the end. This ensures the output never becomes larger than our bucket's length.
+      However, there is one edge case our `hash` function still needs to address. For very long keys, our hash code will exceed the maximum integer value allowed by JavaScript. Once that happens, calculations become inaccurate, and the chance of collisions significantly increases. One way to avoid this issue is to apply the modulo `%` operator on *each iteration* instead of outside the loop at the end.
+
+      You may remember from the [previous lesson](https://www.theodinproject.com/lessons/javascript-hashmap-data-structure#growth-of-a-hash-map) that we used % at the end of the hash function to fit the final hash into the bucket array. This approach still works for sizing, but placing % inside the loop helps avoid internal overflow for long keys while still keeping the result within bucket range.
 
       You might find yourself confusing keys with hash codes while accessing key-value pairs later. We would like to stress that the key is what your `hash` function will take as an input. In a way, we could say that the key is important for us *only* inside the `hash` function, as we never access a bucket directly with the key. Instead, we always do so with the hash code.
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Change:

> However, there is one edge case our hash function still needs to address. For very long keys, our hash code will exceed the maximum integer value allowed by JavaScript. Once that happens, calculations become inaccurate, and the chance of collisions significantly increases. One way to avoid this issue is to apply the modulo % operator on each iteration instead of outside the loop at the end. This ensures the output never becomes larger than our bucket’s length.

To:

> However, there is one edge case our hash function still needs to address. For very long keys, our hash code will exceed the maximum integer value allowed by JavaScript. Once that happens, calculations become inaccurate, and the chance of collisions significantly increases. One way to avoid this issue is to apply the modulo % operator on each iteration instead of outside the loop at the end.
>
> You may remember from the [previous lesson](https://www.theodinproject.com/lessons/javascript-hashmap-data-structure#growth-of-a-hash-map) that we used % at the end of the hash function to fit the final hash into the bucket array. This approach still works for sizing, but placing % inside the loop helps avoid internal overflow for long keys while still keeping the result within bucket range.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->

- Remove "This ensures the output never becomes larger than our bucket’s length."

- Add :
 You may remember from the [previous lesson](https://www.theodinproject.com/lessons/javascript-hashmap-data-structure#growth-of-a-hash-map) that we used % at the end of the hash function to fit the final hash into the bucket array. This approach still works for sizing, but placing % inside the loop helps avoid internal overflow for long keys while still keeping the result within bucket range.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #29908

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
