### PR TITLE
CSS Foundations lesson: Fix class name in selectors discussion

### DIFF
--- a/foundations/html_css/css-foundations/intro-to-css.md
+++ b/foundations/html_css/css-foundations/intro-to-css.md
@@ -82,7 +82,7 @@ Class selectors will select all elements with the given class, which is just an 
 Note the syntax for class selectors: a period immediately followed by the case-sensitive value of the class attribute. Classes aren't required to be specific to a particular element, so you can use the same class on as many elements as you want.
 
 <div class="lesson-note" markdown="1">
-Class selectors won’t work if the class name begins with a number. For example, if you give an element the class name `.4lert-text`, using `.4lert-text` as a selector won’t match it.
+Class selectors won’t work if the class name begins with a number. For example, if you give an element the class name `4lert-text`, using `.4lert-text` as a selector won’t match it.
 </div>
 
 Another thing you can do with the class attribute is to add multiple classes to a single element as a space-separated list, such as `class="alert-text severe-alert"`. Since whitespace is used to separate class names like this, you should never use spaces for multi-worded names and should use a hyphen instead.


### PR DESCRIPTION
The class name "4lert-text " should not start with a period ".". 
Remove the "." from the class name.

## Because
The class name itself should not start with a period. Only class _selectors_ start with a period.

## This PR
* Fixes the mistake by removing the period "." from the class name i.e. ".4lert-text" becomes "4lert-text".

## Issue
None found.

## Additional Information
N/A

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
