### PR TITLE
Active Record Callbacks lesson: Fix likely incorrect mention of before_rollback

### DIFF
--- a/ruby_on_rails/advanced_forms_and_activerecord/active_record_callbacks.md
+++ b/ruby_on_rails/advanced_forms_and_activerecord/active_record_callbacks.md
@@ -72,7 +72,7 @@ You can also use conditional logic options `:if` and `:unless` to try a method b
 
 Sometimes your Rails app will need to interact with an external application (which is inherently imperfect) as a part of the save process.  Other times your save will involve juggling several balls at once and, if one fails, they all need to be rolled back.  Typically these cases will involve wrapping your database save operation in a "transaction," which means that either all the steps work or they all fail and are rolled back.
 
-The `commit`ting of a transaction and its potential `rollback` if it fails are both lifecycle events that you can latch onto with callbacks, e.g. `after_commit` and `before_rollback`.  This is uncommon, so consider it another one of those "just remember that it's an option" type things.
+The `commit`ting of a transaction and its potential `rollback` if it fails are both lifecycle events that you can latch onto with callbacks, e.g. `after_commit` and `after_rollback`.  This is uncommon, so consider it another one of those "just remember that it's an option" type things.
 
 ### Conclusion
 

--- a/ruby_on_rails/advanced_forms_and_activerecord/active_record_queries.md
+++ b/ruby_on_rails/advanced_forms_and_activerecord/active_record_queries.md
@@ -113,7 +113,6 @@ Just like with SQL, you often want to group fields together (or "roll up" the va
   # => {"tag1" => 4, "tag2" => 2, "tag3" => 5}
 ```
 
-`#having` is sort of like a `#where` clause for grouped queries.
 
 ### Joins
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
The lesson currently lists `before_rollback` as a valid Rails transaction callback. 

Based on official Rails documentations, only `after_commit` and `after_rollback` are supported transaction callbacks. 
This change updates the lesson to reflect that.


## This PR
- Replaces the mention of `before_rollback` with `after_rollback` in the Active Record callbacks lesson.


## Issue
No open issue found related to this. Submitting this PR directly in case it’s a small oversight.

## Additional Information
References (documentation resources) used for verification:
- [Rails Guides – Active Record Callbacks](https://guides.rubyonrails.org/active_record_callbacks.html#transaction-callbacks)
- [Rails API – ActiveRecord::Transactions::ClassMethods](https://api.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html)

If I missed a valid use case, I am sorry in advance!


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
