### PR TITLE
fix: correct typo in unordered list link and fix markdown heading spa…

### DIFF
--- a/foundations/html_css/html-foundations/lists.md
+++ b/foundations/html_css/html-foundations/lists.md
@@ -22,7 +22,7 @@ Each list item in an unordered list begins with a bullet point:
 <p class="codepen" data-height="300" data-theme-id="dark" data-default-tab="html,result" data-slug-hash="powjajd" data-user="TheOdinProjectExamples" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;">
 
   <span>See the Pen <a href="https://codepen.io/TheOdinProjectExamples/pen/powjajd">
-  html-unordred-list</a> by TheOdinProject (<a href="https://codepen.io/TheOdinProjectExamples">@TheOdinProjectExamples</a>)
+  html-unordered-list</a> by TheOdinProject (<a href="https://codepen.io/TheOdinProjectExamples">@TheOdinProjectExamples</a>)
   on <a href="https://codepen.io">CodePen</a>.</span>
 
 </p>


### PR DESCRIPTION
## What does this PR do?

This PR fixes minor markdown formatting issues in the `lists.md` file:

- Corrects a broken unordered list link
- Adds proper spacing after a markdown heading to follow formatting conventions

## Why is this change important?

These changes ensure:
- Better readability
- Correct rendering of the markdown content in the curriculum
- Consistent formatting throughout the document

## Checklist

- [x] I have verified the changes render correctly in markdown preview
- [x] I have followed the contribution guidelines
- [x] This PR is targeting the correct branch

---

Closes #29933
