### PR TITLE
Revise text for clarity

### DIFF
--- a/foundations/html_css/flexbox/flexbox-axes.md
+++ b/foundations/html_css/flexbox/flexbox-axes.md
@@ -43,7 +43,7 @@ Another detail to notice: when we changed the <span id='column-flex-basis'>flex-
 
 We've strayed from the point slightly... We were talking about flex-direction and axes. To bring it back home, the default behavior is `flex-direction: row` which arranges things horizontally. The reason this often works well without changing other details in the CSS is because block-level elements default to the full width of their parent. Changing things to vertical using `flex-direction: column` adds complexity because block-level elements default to the height of their content, and in this case there *is* no content.
 
-> There are situations where the behavior of flex-direction could change if you are using a language that is written top-to-bottom or right-to-left, but you should save worrying about that until you are ready to start making a website in Arabic or Hebrew.
+There are situations where the behavior of `flex-direction` could change if you are using a language that is written right-to-left or even vertically, but you should save worrying about that until you are ready to start making a website in Arabic or Manchu.
 
 ### Knowledge check
 


### PR DESCRIPTION
## Because
Original text was slightly ambiguous and led to some confusion.
Wording was revised to improve clarity.

## This PR
* Takes the original text out of an unnecessary quotation block
* Updated wording for clarity
* Puts "flex-direction" in backticks

## Issue
Closes https://github.com/TheOdinProject/curriculum/issues/29946 

## Additional Information
N/A

## Pull Request Requirements
-   [X] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [X] The `Because` section summarizes the reason for this PR
-   [X] The `This PR` section has a bullet point list describing the changes in this PR
-   [X] If this PR addresses an open issue, it is linked in the `Issue` section
-   [X] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [X] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
