### PR TITLE
Objects and Object Constructors Lesson: Escape double underscores in __proto__ for proper Markdown rendering

### DIFF
--- a/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
+++ b/javascript/organizing_your_javascript_code/objects_and_object_constructors.md
@@ -380,7 +380,7 @@ If we had used `Object.setPrototypeOf()` in this example, then we could safely e
 1. You might have noticed us using the `this` keyword in object constructors and prototype methods in the examples above.
 
    1. [JavaScript Tutorial's article on the `this` keyword](https://www.javascripttutorial.net/javascript-this/) covers how `this` changes in various situations. Pay special attention to the pitfalls mentioned in each section.
-1. Read the article [[[Prototype]] vs \_\_proto__ vs .prototype in JavaScript](https://medium.com/@eamonocallaghan/prototype-vs-proto-vs-prototype-in-javascript-6758cadcbae8)
+1. Read the article [`[[Prototype]]` vs `__proto__` vs `.prototype` in JavaScript](https://medium.com/@eamonocallaghan/prototype-vs-proto-vs-prototype-in-javascript-6758cadcbae8)
 
 </div>
 


### PR DESCRIPTION
## Because

When \_\_proto__ is mentioned in this document outside of a code element, Markdown interprets the underscores as bold syntax, causing it to display as **proto** instead of \_\_proto__.

## This PR

- Escapes the double underscores in \_\_proto__ so it displays correctly in Markdown without being rendered as bold.

## Issue

N/A

## Additional Information

N/A

## Pull Request Requirements

-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
