### PR TITLE
Modify React rerendering explanation

### DIFF
--- a/react/states_and_effects/introduction_to_state.md
+++ b/react/states_and_effects/introduction_to_state.md
@@ -48,7 +48,8 @@ Great, you can now use state! But, what's going on under the hood?
 
 Let's hit you with some theory.
 
-In React, when a component's state or props change, the component is destroyed and recreated from scratch. Yes, you heard that right: *destroyed*. This includes the variables, functions, and React nodes. The entire component is recreated but this time the latest state value will be returned from `useState`. This process is called rerendering. Rerendering is a key feature of React that enables it to efficiently update the user interface in response to changes in the underlying data.
+In React, when a component's state or props change, React runs your component function again from the beginning to figure out what should be displayed based on the freshly-set state and props. All the calculated changes are then applied to the DOM (committed).
+That is, the entire component is recreated, in a sense, but this time the latest state value will be returned from `useState`. This process is called rerendering. Rerendering is a key feature of React that enables it to efficiently update the user interface in response to changes in the underlying data.
 
 <div class="lesson-note" markdown="1">
 


### PR DESCRIPTION
## Change of opening explanation
Newcomers should have a fairly clearer idea on the nature of the rerendering process. That components are "destroyed", while more evocative of an image, could lead to confusion down the line, with regards to the unmounting process.
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->


## This PR
- Changes the beginning of [this section](https://www.theodinproject.com/lessons/node-path-react-new-introduction-to-state#how-does-state-work-in-react) for more clarity


## Issue
Closes ##29973


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
