### PR TITLE
Foundations function_basics lesson: Fix typo in assignment section

### DIFF
--- a/foundations/javascript_basics/function_basics.md
+++ b/foundations/javascript_basics/function_basics.md
@@ -64,7 +64,7 @@ For now, just write each function and test the output with `console.log`.
 
 1. Write a function called `add7` that takes one number and returns that number + 7.
 1. Write a function called `multiply` that takes 2 numbers and returns their product.
-1. Write a function called `capitalize` that takes a string and returns that string with *only* the first letter capitalized.  Make sure that it can take strings that are lowercase, UPPERCASE or BoTh.
+1. Write a function called `capitalize` that takes a string and returns that string with *only* the first letter capitalized.  Make sure that it can take strings that are lowercase, UPPERCASE or Both.
 1. Write a function called `lastLetter` that takes a string and returns the very last letter of that string:
     - `lastLetter("abcd")` should return `"d"`
 


### PR DESCRIPTION
## Because
There was a typo in the assignment section of the `function_basics` lesson inside the `foundations` folder.  
In the 3rd point, "boTh" was written instead of "both".

## This PR
- Corrected "boTh" to "both" in the assignment section of `function_basics`.

## Issue
N/A

## Additional Information
N/A

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
