### PR TITLE
Node.js testing lesson: Update superagent and supertest links

### DIFF
--- a/nodeJS/testing_express/testing_routes_and_controllers.md
+++ b/nodeJS/testing_express/testing_routes_and_controllers.md
@@ -149,8 +149,8 @@ If we were using a real database here, then we would want to do something simila
 
 <div class="lesson-content__panel" markdown="1">
 
-1. Make sure that you read through the [SuperTest docs](https://github.com/visionmedia/supertest)
-1. SuperTest actually pulls from another related project called SuperAgent.  Any method that you can call in SuperAgent you can also call from SuperTest, so you'll need to take a look through the [SuperAgent docs](https://ladjs.github.io/superagent/) as well.
+1. Make sure that you read through the [SuperTest docs](https://github.com/forwardemail/supertest)
+1. SuperTest actually pulls from another related project called SuperAgent.  Any method that you can call in SuperAgent you can also call from SuperTest, so you'll need to take a look through the [SuperAgent docs](https://forwardemail.github.io/superagent/) as well.
 
 </div>
 
@@ -158,10 +158,10 @@ If we were using a real database here, then we would want to do something simila
 
 The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
 
-- [What is the motivation behind SuperTest?](https://github.com/visionmedia/supertest#about)
+- [What is the motivation behind SuperTest?](https://github.com/forwardemail/supertest#about)
 - [What is the purpose of `done`? What convenience does SuperTest provide concerning it?](#done)
-- [What is the difference in handling errors when using .end() method in conjunction with .expect() provided by SuperTest?](https://github.com/visionmedia/supertest#example)
-- [What are the methods provided by SuperAgent to handle multipart requests and how to use them?](https://ladjs.github.io/superagent/#multipart-requests)
+- [What is the difference in handling errors when using .end() method in conjunction with .expect() provided by SuperTest?](https://github.com/forwardemail/supertest#example)
+- [What are the methods provided by SuperAgent to handle multipart requests and how to use them?](https://forwardemail.github.io/superagent/#multipart-requests)
 
 ### Additional resources
 


### PR DESCRIPTION
## Because
Several links to the `superagent` and `supertest` documentation in the "Testing Routes and controllers" lesson are outdated due to project migrations. These broken or redirecting links can confuse learners and hinder access to resources. This PR updates all identified instances of these links to their current, correct URLs.

## This PR
- Updates the primary documentation link for **`superagent`**.
- Updates the primary repository link for **`supertest`**.
- Corrects three additional links to specific sections of the `superagent` and `supertest` documentation found in the 'Knowledge check' and 'Additional resources' sections.

## Issue
Closes #29921

## Additional Information
N/A

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)