### PR TITLE
Fix broken GIF link in Box Model lesson the-box-model.md

### DIFF
--- a/foundations/html_css/css-foundations/the-box-model.md
+++ b/foundations/html_css/css-foundations/the-box-model.md
@@ -2,7 +2,7 @@
 
 Now that you understand the basic syntax of HTML and CSS, we're going to get serious. The most important skills you need to master with CSS are *positioning* and *layout*. Changing fonts and colors is a crucial skill, but being able to put things exactly where you want them on a webpage is even more crucial. After all, how many webpages can you find where absolutely every element is just stacked one on top of another?
 
-Learning to position elements on a webpage is not that difficult once you understand just a few key concepts. Unfortunately, many learners race through learning HTML and CSS to get to JavaScript and end up missing these fundamental concepts. This leads to frustration and pain ([and funny gifs](https://giphy.com/gifs/css-13FrpeVH09Zrb2)) because all the JavaScript skills in the world are meaningless if you can't stick your elements on the page where you need them to be. So with that in mind, let's get started.
+Learning to position elements on a webpage is not that difficult once you understand just a few key concepts. Unfortunately, many learners race through learning HTML and CSS to get to JavaScript and end up missing these fundamental concepts. This leads to frustration and pain ([and funny gifs](https://media1.tenor.com/m/QWdPngpHxZ8AAAAd/family-guy-css.gif)) because all the JavaScript skills in the world are meaningless if you can't stick your elements on the page where you need them to be. So with that in mind, let's get started.
 
 ### Lesson overview
 


### PR DESCRIPTION
Replaced broken meme link with working Peter Griffin blinds GIF from Tenor, matching the original from the Wayback Machine.

## Because

The original GIF link in the Box Model lesson was broken, resulting in a missing image GIF.
This PR fixes it by replacing it with a working equivalent GIF.

## This PR

- Replaced `https://giphy.com/gifs/css-13FreVHb9r2rb2` with `https://media1.tenor.com/m/QWdPngpHxZ8AAAAd/family-guy-css.gif`
- Verified via the Wayback Machine that the new GIF matches the original meme’s content and context

## Issue

No open issue; minor content fix.

## Additional Information

Original broken GIF was confirmed missing.  
The new link is from Tenor and provides the same Peter Griffin “CSS” meme as originally intended.

## Pull Request Requirements

- [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format
- [x] The Because section summarizes the reason for this PR
- [x] The This PR section has a bullet point list describing the changes in this PR
- [] If this PR addresses an open issue, it is linked in the Issue section
- [x] Lesson file has been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure correct formatting
- [x] Lesson file follows the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
