### PR TITLE
Transforms Lesson: Correct the example

### DIFF
--- a/advanced_html_css/animation/transforms.md
+++ b/advanced_html_css/animation/transforms.md
@@ -17,7 +17,7 @@ This section contains a general overview of topics that you will learn in this l
 
 The `transform` property takes in one or more CSS transform functions as its values, with those functions taking in their own value, usually an angle or a number.
 
-Almost all elements can have the `transform` property applied to them, with the exceptions being `<col>`, `<colgroup>`, and non-replaced inline elements. "Non-replaced" refers to elements whose content is contained within the HTML document (`<span>`, `<b>`, and `<em>`, for example), as opposed to a "replaced" element's content being contained outside of the document, the element itself being "replaced" by the external content (`<a>`, `<iframe>`, and `<img>`, for example). You do not need to memorize every element that is non-replaced, but rather keep this knowledge in mind should you try to apply the `transform` property to an element and aren't sure why it isn't working.
+Almost all elements can have the `transform` property applied to them, with the exceptions being `<col>`, `<colgroup>`, and non-replaced inline elements. "Non-replaced" refers to elements whose content is contained within the HTML document (`<span>`, `<b>`, and `<em>`, for example), as opposed to a "replaced" element's content being contained outside of the document, the element itself being "replaced" by the external content (`<video>`, `<iframe>`, and `<img>`, for example). You do not need to memorize every element that is non-replaced, but rather keep this knowledge in mind should you try to apply the `transform` property to an element and aren't sure why it isn't working.
 
 ### Two-dimensional transforms
 


### PR DESCRIPTION
## Because
There’s an incorrect example in the Basics of transforms section when describing "replaced elements."


## This PR
- Corrects the example by replacing `<a>` with `<video>` ( Line 20 ).
- `<a>` element is a non replaced element as it's content is not replaced by some external source.
- I chose to replace `<a>` with `<video>` as the same example is also mentioned in [MDN docs](https://developer.mozilla.org/en-US/docs/Glossary/Replaced_elements).


## Issue
N/A

## Additional Information
https://discord.com/channels/505093832157691914/690589233919819797/1404437073360064615


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
