### PR TITLE
Style guide: Document mandatory note box headings/indentation

### DIFF
--- a/LAYOUT_STYLE_GUIDE.md
+++ b/LAYOUT_STYLE_GUIDE.md
@@ -153,6 +153,10 @@ OPTIONAL POST-ASSIGNMENT SECTION CONTENT.
 
 ## Headings
 
+### Indentation
+
+Headings must not be indented, regardless of level and even if they are inside an assignment `div`. The only exception is when the heading is for a [note box](#note-boxes).
+
 ### Case
 
 Headings should always use sentence case:
@@ -409,6 +413,8 @@ Will result in the following output:
 Note boxes can be added by wrapping the content in a `div` with the class `lesson-note`. This will add styling to make the note stand out visually to users.
 
 All note boxes must open with a level 4 heading (`####`), which will also require the note box div to have the `markdown="1"` attribute so the heading renders correctly. Headings must describe the note box's contents, rather than just "Note" or "Warning".
+
+Note box headings must match the note box's indentation level, such as if the note box is indented as a child of a list item.
 
 The opening and closing tags must each be wrapped with a single blank line on either side, or a codeblock delimiter (triple backticks). This applies to any line that contains only a single HTML tag. The only exceptions to this rule are HTML tags inside `html`, `jsx`, `erb`, `ejs`, `javascript` or `ruby` codeblocks.
 

--- a/LAYOUT_STYLE_GUIDE.md
+++ b/LAYOUT_STYLE_GUIDE.md
@@ -408,9 +408,7 @@ Will result in the following output:
 
 Note boxes can be added by wrapping the content in a `div` with the class `lesson-note`. This will add styling to make the note stand out visually to users.
 
-For nested markdown inside note boxes to be displayed properly additional `markdown="1" attribute` is needed.
-
-A heading can be added to a note by using a `####` heading. When adding a heading, be sure to provide text that helps describe the note rather than "A note" or "Warning".
+All note boxes must open with a level 4 heading (`####`), which will also require the note box div to have the `markdown="1"` attribute so the heading renders correctly. Headings must describe the note box's contents, rather than just "Note" or "Warning".
 
 The opening and closing tags must each be wrapped with a single blank line on either side, or a codeblock delimiter (triple backticks). This applies to any line that contains only a single HTML tag. The only exceptions to this rule are HTML tags inside `html`, `jsx`, `erb`, `ejs`, `javascript` or `ruby` codeblocks.
 
@@ -418,7 +416,7 @@ The opening and closing tags must each be wrapped with a single blank line on ei
 
 Different types of note boxes can be set by adding an extra class together with `lesson-note`:
 
-- `lesson-note--tip` for tips or general information
+- `lesson-note--tip` for tips
 - `lesson-note--warning` for warnings about potential issues/pitfalls, and are more severe than a tip
 - `lesson-note--critical` for the most important warnings, such as critical information about handling sensitive data
 
@@ -427,7 +425,7 @@ Different types of note boxes can be set by adding an extra class together with 
 ```markdown
 <div class="lesson-note" markdown="1">
 
-#### An optional title
+#### A descriptive title
 
 A sample note box.
 
@@ -437,7 +435,7 @@ A sample note box.
 ```markdown
 <div class="lesson-note lesson-note--tip" markdown="1">
 
-#### An optional title
+#### A descriptive title
 
 A sample note box, variation: tip.
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
With the recent inclusion of [TOP011](https://github.com/TheOdinProject/curriculum/blob/main/markdownlint/docs/TOP011.md) and [TOP012](https://github.com/TheOdinProject/curriculum/blob/main/markdownlint/docs/TOP012.md) custom linting rules, the style guide must be updated to reflect their requirements (that's on me for missing this as part of those PRs).

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Documents mandatory note box headings
- Documents expected heading indentation behaviour
- Removes incorrect note box variation description (general information would just be a normal note)

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
N/A


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
