### PR TITLE
Intro to CSS: Replace references to HTML comments with line numbers

### DIFF
--- a/foundations/html_css/css-foundations/intro-to-css.md
+++ b/foundations/html_css/css-foundations/intro-to-css.md
@@ -82,7 +82,9 @@ Class selectors will select all elements with the given class, which is just an 
 Note the syntax for class selectors: a period immediately followed by the case-sensitive value of the class attribute. Classes aren't required to be specific to a particular element, so you can use the same class on as many elements as you want.
 
 <div class="lesson-note" markdown="1">
+
 Class selectors won’t work if the class name begins with a number. For example, if you give an element the class name `4lert-text`, using `.4lert-text` as a selector won’t match it.
+
 </div>
 
 Another thing you can do with the class attribute is to add multiple classes to a single element as a space-separated list, such as `class="alert-text severe-alert"`. Since whitespace is used to separate class names like this, you should never use spaces for multi-worded names and should use a hyphen instead.
@@ -108,7 +110,9 @@ ID selectors are similar to class selectors. They select an element with the giv
 For IDs, instead of a period, we use a hashtag immediately followed by the case-sensitive value of the ID attribute. A common pitfall is people overusing the ID attribute when they don't necessarily need to, and when classes will suffice. While there are cases where using an ID makes sense or is needed, such as taking advantage of specificity or having links redirect to a section on the current page, you should use IDs **sparingly** (if at all).
 
 <div class="lesson-note" markdown="1">
+
 Just like class selectors, ID selectors can’t start with a number. For example, if you give an element the ID `7itle`, the selector `#7itle` won’t work - it’s not a valid CSS selector.
+
 </div>
 
 #### The grouping selector
@@ -205,14 +209,12 @@ So something like `.ancestor .child` would select an element with the class `chi
 <!-- index.html -->
 
 <div class="ancestor">
-  <!-- A -->
   <div class="contents">
-    <!-- B -->
-    <div class="contents"><!-- C --></div>
+    <div class="contents"></div>
   </div>
 </div>
 
-<div class="contents"><!-- D --></div>
+<div class="contents"></div>
 ```
 
 ```css
@@ -223,7 +225,7 @@ So something like `.ancestor .child` would select an element with the class `chi
 }
 ```
 
-In the above example, the first two elements with the `contents` class (B and C) would be selected, but that last element (D) wouldn't be. Was your guess correct?
+In the above example, the first two elements with the `contents` class (on lines 4 and 5) would be selected, but the last element (on line 9) wouldn't be. Was your guess correct?
 
 There's really no limit to how many combinators you can add to a rule, so `.one .two .three .four` would be totally valid. This would just select an element that has a class of `four` if it has an ancestor with a class of `three`, and if that ancestor has its own ancestor with a class of `two`, and so on. You generally want to avoid trying to select elements that need this level of nesting, though, as it can get pretty confusing and long, and it can cause issues when it comes to specificity.
 

--- a/foundations/html_css/css-foundations/intro-to-css.md
+++ b/foundations/html_css/css-foundations/intro-to-css.md
@@ -18,7 +18,7 @@ At the most basic level, CSS is made up of various rules. Each rule is made up o
 
 <div class="lesson-note" markdown="1">
 
-#### Note
+#### Semantic HTML
 
 A `<div>` is one of the basic HTML elements. It is an empty container. In general, it is best to use other tags such as `<h1>` or `<p>` for content in your projects, but as we learn more about CSS you'll find that there are many cases where the thing you need is just a container for other elements. Many of our exercises use plain`<div>`s for simplicity. Later lessons will go into much more depth about when it is appropriate to use the various HTML elements.
 
@@ -83,6 +83,8 @@ Note the syntax for class selectors: a period immediately followed by the case-s
 
 <div class="lesson-note" markdown="1">
 
+#### Leading digits and classes
+
 Class selectors won’t work if the class name begins with a number. For example, if you give an element the class name `4lert-text`, using `.4lert-text` as a selector won’t match it.
 
 </div>
@@ -110,6 +112,8 @@ ID selectors are similar to class selectors. They select an element with the giv
 For IDs, instead of a period, we use a hashtag immediately followed by the case-sensitive value of the ID attribute. A common pitfall is people overusing the ID attribute when they don't necessarily need to, and when classes will suffice. While there are cases where using an ID makes sense or is needed, such as taking advantage of specificity or having links redirect to a section on the current page, you should use IDs **sparingly** (if at all).
 
 <div class="lesson-note" markdown="1">
+
+#### Leading digits and IDs
 
 Just like class selectors, ID selectors can’t start with a number. For example, if you give an element the ID `7itle`, the selector `#7itle` won’t work - it’s not a valid CSS selector.
 


### PR DESCRIPTION
## Because

The current way of using HTML comments to reference elements in an example was a common cause of confusion, since the comments were intended to be inside the elements they referenced, but were typically read as referring to the element below them (as is often the case with code comments).

## This PR

- Removes HTML comments from the descendant HTML example
- References elements in that example via line numbers in the code block instead
- Appeases linter with descriptive headings for note boxes

## Issue

Closes #29933

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
