### PR TITLE
Databases and SQL lesson: Update anchor id from foreign-key to primary-key

### DIFF
--- a/databases/databases/databases_and_sql.md
+++ b/databases/databases/databases_and_sql.md
@@ -82,6 +82,8 @@ If you want to get all the posts created by a given user, you need to tell SQL w
 
 <div class="lesson-note lesson-note--tip" markdown="1">
 
+#### Clarifying what `LEFT` is in a `JOIN`
+
 The "left" table is the original table (the one that the `FROM` clause was `ON`), e.g., `users` in examples below.
 
 </div>

--- a/databases/databases/databases_and_sql.md
+++ b/databases/databases/databases_and_sql.md
@@ -34,9 +34,9 @@ This section contains a general overview of topics that you will learn in this l
 
 This is a very brief soup-to-nuts explanation of SQL.  It won't do a particularly good job teaching you specific new tactics but should present a general overview to have going into the reading assignment.  Here we go...
 
-SQL is the language used to talk to many relational databases.  These databases use lots of tables to store different types of data (e.g., `users` and `posts` tables).  Tables are long lists like spreadsheets where each row is a different record (or object, e.g., a single user) and each column is one of that record's attributes (like name, email, etc.).  The one column that all tables include is an `ID` column, which gives the unique row numbers, and is called the record's "primary key."
+SQL is the language used to talk to many relational databases.  These databases use lots of tables to store different types of data (e.g., `users` and `posts` tables).  Tables are long lists like spreadsheets where each row is a different record (or object, e.g., a single user) and each column is one of that record's attributes (like name, email, etc.).  <span id='primary-key'>The one column that all tables include is an `ID` column, which gives the unique row numbers, and is called the record's "primary key."</span>
 
-You can "link" tables together by making one of the columns in one table point to the ID of another table. For instance, a row in the `posts` table might include the author's ID under the column called `user_id`.  <span id='foreign-key'>Because the `posts` table has the ID of another table in it, that column is called a "foreign key."</span>
+You can "link" tables together by making one of the columns in one table point to the ID of another table. For instance, a row in the `posts` table might include the author's ID under the column called `user_id`. Because the `posts` table has the ID of another table in it, that column is called a "foreign key."
 
 #### Setting stuff up
 
@@ -156,7 +156,7 @@ The next step, once you've had a chance to practice this all in the project, is 
 
 The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
 
-- [What is the difference between a foreign key and a primary key?](#foreign-key)
+- [What is the difference between a foreign key and a primary key?](#primary-key)
 - [Where is the setup information for your database stored?](#schema)
 - [What are the important parts of a SQL command?](#command-parts)
 - [Which SQL statement is associated with "Read" from the CRUD acronym?](#sql-read)


### PR DESCRIPTION
## Because  
Previously, the _Knowledge Check_ in the lesson had an anchor link for `foreign-key`, which is placed under the paragraph for `primary-key`. This caused confusion for readers, as the link navigated them to the wrong section, forcing them to search for the `primary-key` explanation. Updating the scroll navigation to `primary-key` ensures that readers are directed to the sentences covering both `primary` and `foreign` keys.

## This PR  
- Removed `id="foreign-key"`  
- Added `id="primary-key"` so readers can easily jump to that section.  

## Additional Information  
This update improves in-page navigation and makes the lesson content more consistent.  


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
