### PR TITLE
Markdownlint: Add blacklisted exact matches to TOP012

### DIFF
--- a/markdownlint/TOP012_noteBoxHeadings/TOP012_noteBoxHeadings.js
+++ b/markdownlint/TOP012_noteBoxHeadings/TOP012_noteBoxHeadings.js
@@ -1,3 +1,24 @@
+const BLACKLISTED_HEADINGS = [
+  "note",
+  "notes",
+  "a note",
+  "tip",
+  "tips",
+  "a tip",
+  "warning",
+  "warnings",
+  "a warning",
+  "important",
+  "important note",
+  "important tip",
+  "important warning",
+  "info",
+  "information",
+  "critical",
+  "danger",
+  "remember",
+];
+
 function isNoteBoxOpenTag(token) {
   return token?.type === "html_block" && token?.content.includes("lesson-note");
 }
@@ -45,21 +66,28 @@ module.exports = {
     });
 
     noteBoxHeadings.forEach((heading) => {
-      if (heading.hashes.length === 4) {
-        return;
+      const hashlessHeading = heading.text.slice(heading.hashes.length + 1);
+
+      if (BLACKLISTED_HEADINGS.includes(hashlessHeading.toLowerCase())) {
+        onError({
+          lineNumber: heading.lineNumber,
+          detail: `"${hashlessHeading}" is not sufficiently descriptive by itself. Use a heading that briefly describes the actual contents of the note box.`,
+        });
       }
 
-      const hashesStartColumn = heading.text.indexOf(heading.hashes) + 1;
+      if (heading.hashes.length !== 4) {
+        const hashesStartColumn = heading.text.indexOf(heading.hashes) + 1;
 
-      onError({
-        lineNumber: heading.lineNumber,
-        detail: `Expected a level 4 heading (####) but got a level ${heading.hashes.length} heading (${heading.hashes}) instead.`,
-        fixInfo: {
-          editColumn: hashesStartColumn,
-          deleteCount: heading.hashes.length,
-          insertText: "####",
-        },
-      });
+        onError({
+          lineNumber: heading.lineNumber,
+          detail: `Expected a level 4 heading (####) but got a level ${heading.hashes.length} heading (${heading.hashes}) instead.`,
+          fixInfo: {
+            editColumn: hashesStartColumn,
+            deleteCount: heading.hashes.length,
+            insertText: "####",
+          },
+        });
+      }
     });
   },
 };

--- a/markdownlint/TOP012_noteBoxHeadings/tests/TOP012_test.md
+++ b/markdownlint/TOP012_noteBoxHeadings/tests/TOP012_test.md
@@ -10,6 +10,38 @@ This section contains a general overview of topics that you will learn in this l
 
 ### Custom section
 
+<div class="lesson-note" markdown="1">
+
+#### Note
+
+Note boxes with a blacklisted heading will flag an error.
+
+</div>
+
+<div class="lesson-note" markdown="1">
+
+#### Important warning
+
+Note boxes with a blacklisted heading will flag an error.
+
+</div>
+
+<div class="lesson-note" markdown="1">
+
+#### Tip
+
+Note boxes with a blacklisted heading will flag an error.
+
+</div>
+
+<div class="lesson-note" markdown="1">
+
+#### Tip of the iceberg
+
+Blacklisted headings must match exactly (case insensitive). This heading is not an exact match so will not flag a TOP012 error.
+
+</div>
+
 #### Non-note box level 4 headings will not flag this error
 
 Custom subsection contents.
@@ -40,7 +72,7 @@ Note box contents.
 
 <div class="lesson-note" markdown="1">
 
-Note boxes without a heading will flag a missing heading error
+Note boxes without a heading will flag a missing heading error.
 
 </div>
 

--- a/markdownlint/docs/TOP012.md
+++ b/markdownlint/docs/TOP012.md
@@ -1,4 +1,4 @@
-# TOP012 - Note box headings
+# `TOP012` - Note box headings
 
 Tags: `headings`
 

--- a/markdownlint/docs/TOP012.md
+++ b/markdownlint/docs/TOP012.md
@@ -1,12 +1,12 @@
-# `TOP012` - Note box headings
+# TOP012 - Note box headings
 
 Tags: `headings`
 
 Aliases: `note-box-headings`
 
-Fixable via script: The `fix` script can fix incorrect heading levels but of course cannot add missing headings.
+Fixable via script: The `fix` script can fix incorrect heading levels but of course cannot add missing headings or rename blacklisted headings.
 
-This rule is triggered when a [note box](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md#note-boxes) either does not have a heading or has a heading but it is not a level 4 (####) heading, which is required by our layout style guide.
+This rule is triggered when a [note box](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md#note-boxes) does not open with a level 4 (####) heading, which is required by our layout style guide. It will also trigger if the heading text is on our blacklist of commonly used but insufficiently descriptive headings.
 
 ```markdown
 <div class="lesson-note" markdown="1">
@@ -38,11 +38,26 @@ Note box contents.
 </div>
 ```
 
-If the error is about the heading level, it is fixable with our `fix:*` npm scripts, which will convert the heading to be at level 4. The `fix:*` script cannot do anything about missing headings.
+Some commonly used headings are insufficiently descriptive and accessible, and so are blacklisted and will raise a TOP012 error, even if the heading level is correct:
+
+```markdown
+<div class="lesson-note" markdown="1">
+
+#### Note
+
+"Note" on its own is not sufficiently descriptive, which is not accessible enough for users navigating by headings.
+
+It also poses problems if multiple note boxes on the same page have the same heading, both for navigation and for links, as heading links will only ever go to the first instance.
+
+</div>
+
+```
+
+If the error is about the heading level, it is fixable with our `fix:*` npm scripts, which will convert the heading to be at level 4. The `fix:*` script cannot do anything about missing or blacklisted headings.
 
 ## Rationale
 
-Headings have IDs that can be linked to. Given the nature of note boxes, enforcing headings for them allows all of them to be more easily linked, while the heading also summarizes the note's intent.
+Headings have IDs that can be linked to. Given the nature of note boxes, enforcing headings for them allows all of them to be more easily linked and navigable to, while the heading also summarizes the note's intent for accessibility. Therefore, they must also be unique.
 
 Consistent use of heading levels for note boxes also looks better on the website, and is less confusing as note boxes are not main sections themselves, so they should not use a level 3 heading.
 


### PR DESCRIPTION
## Because

In a similar vein to #28557, TOP012 should also have a small blacklist of commonly used but insufficiently accessible note box headings. These must be a case-insensitive exact match, not just because the headings include the blacklisted text somewhere. Same justification as TOP001's and should be linted given it's part of the style guide and is lintable. This is something I was holding off on adding to TOP012 until #28557 was merged, but forgot to do so when it was.

## This PR

- Adds array of blacklisted note box headings to TOP012 custom rule, and flags on a blacklist error (with blacklist-specific error message).
- Adds examples of blacklisted text labels to TOP012 test file.
- Updates TOP012 doc file with new flag criteria and examples.

## Additional information

The failed lint test should flag only the errors the test file says should flag errors, which will only be TOP012 errors.

## Pull Request Requirements

-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
