### PR TITLE
Markdownlint: New descriptive headings rule

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -98,6 +98,7 @@
     "./markdownlint/TOP009_lessonOverviewItemsSentenceStructure/TOP009_lessonOverviewItemsSentenceStructure.js",
     "./markdownlint/TOP010_useLazyNumbering/TOP010_useLazyNumbering.js",
     "./markdownlint/TOP011_headingIndentation/TOP011_headingIndentation.js",
-    "./markdownlint/TOP012_noteBoxHeadings/TOP012_noteBoxHeadings.js"
+    "./markdownlint/TOP012_noteBoxHeadings/TOP012_noteBoxHeadings.js",
+    "./markdownlint/TOP013_descriptiveHeadings/TOP013_descriptiveHeadings.js"
   ]
 }

--- a/LAYOUT_STYLE_GUIDE.md
+++ b/LAYOUT_STYLE_GUIDE.md
@@ -153,6 +153,10 @@ OPTIONAL POST-ASSIGNMENT SECTION CONTENT.
 
 ## Headings
 
+### Accessible headings
+
+For accessibility, headings must briefly summarize their section's contents, rather than just saying something overly generic like "Note", "Remember" or "Warning".
+
 ### Indentation
 
 Headings must not be indented, regardless of level and even if they are inside an assignment `div`. The only exception is when the heading is for a [note box](#note-boxes).
@@ -412,7 +416,7 @@ Will result in the following output:
 
 Note boxes can be added by wrapping the content in a `div` with the class `lesson-note`. This will add styling to make the note stand out visually to users.
 
-All note boxes must open with a level 4 heading (`####`), which will also require the note box div to have the `markdown="1"` attribute so the heading renders correctly. Headings must describe the note box's contents, rather than just "Note" or "Warning".
+All note boxes must open with a level 4 heading (`####`), which will also require the note box div to have the `markdown="1"` attribute so the heading renders correctly. Note box [headings must be sufficiently descriptive](#accessible-headings) for accessibility.
 
 Note box headings must match the note box's indentation level, such as if the note box is indented as a child of a list item.
 

--- a/markdownlint/TOP013_descriptiveHeadings/TOP013_descriptiveHeadings.js
+++ b/markdownlint/TOP013_descriptiveHeadings/TOP013_descriptiveHeadings.js
@@ -48,7 +48,7 @@ module.exports = {
       if (BLACKLISTED_HEADINGS.includes(headingText.toLowerCase())) {
         onError({
           lineNumber: token.lineNumber,
-          detail: `"${headingText}" is not sufficiently descriptive by itself. Use a more descriptive heading that briefly but clearly summarises the content of the section.`,
+          detail: `"${headingText}" is not sufficiently descriptive by itself. Use a more descriptive heading that briefly but clearly summarizes the content of the section.`,
           context: token.line,
         });
       }

--- a/markdownlint/TOP013_descriptiveHeadings/TOP013_descriptiveHeadings.js
+++ b/markdownlint/TOP013_descriptiveHeadings/TOP013_descriptiveHeadings.js
@@ -1,0 +1,47 @@
+const BLACKLISTED_HEADINGS = [
+  "note",
+  "notes",
+  "a note",
+  "tip",
+  "tips",
+  "a tip",
+  "warning",
+  "warnings",
+  "a warning",
+  "important",
+  "important note",
+  "important tip",
+  "important warning",
+  "info",
+  "information",
+  "critical",
+  "danger",
+  "remember",
+];
+
+module.exports = {
+  names: ["TOP013", "descriptive-headings"],
+  description: "Headings must have descriptive text",
+  information: new URL(
+    "https://github.com/TheOdinProject/curriculum/blob/main/markdownlint/docs/TOP013.md",
+  ),
+  tags: ["accessibility", "headings"],
+  parser: "markdownit",
+  function: function TOP012(params, onError) {
+    const { tokens } = params.parsers.markdownit;
+    const headings = tokens.filter((token) => token.type === "heading_open");
+
+    headings.forEach((heading) => {
+      const headingTextStartIndex = heading.markup.length + 1;
+      const headingText = heading.line.slice(headingTextStartIndex);
+
+      if (BLACKLISTED_HEADINGS.includes(headingText.toLowerCase())) {
+        onError({
+          lineNumber: heading.lineNumber,
+          detail: `"${headingText}" is not sufficiently descriptive by itself. Use a more descriptive heading that briefly but clearly summarises the content of the section.`,
+          context: heading.line,
+        });
+      }
+    });
+  },
+};

--- a/markdownlint/TOP013_descriptiveHeadings/TOP013_descriptiveHeadings.js
+++ b/markdownlint/TOP013_descriptiveHeadings/TOP013_descriptiveHeadings.js
@@ -19,6 +19,11 @@ const BLACKLISTED_HEADINGS = [
   "remember",
 ];
 
+function removeTrailingPunctuation(text) {
+  // https://regexr.com/8grso to test this regex
+  return text.replaceAll(/\W+$/g, "");
+}
+
 module.exports = {
   names: ["TOP013", "descriptive-headings"],
   description: "Headings must have descriptive text",
@@ -33,7 +38,9 @@ module.exports = {
 
     headings.forEach((heading) => {
       const headingTextStartIndex = heading.markup.length + 1;
-      const headingText = heading.line.slice(headingTextStartIndex);
+      const headingText = removeTrailingPunctuation(
+        heading.line.slice(headingTextStartIndex),
+      );
 
       if (BLACKLISTED_HEADINGS.includes(headingText.toLowerCase())) {
         onError({

--- a/markdownlint/TOP013_descriptiveHeadings/TOP013_descriptiveHeadings.js
+++ b/markdownlint/TOP013_descriptiveHeadings/TOP013_descriptiveHeadings.js
@@ -32,21 +32,24 @@ module.exports = {
   ),
   tags: ["accessibility", "headings"],
   parser: "markdownit",
-  function: function TOP012(params, onError) {
+  function: function TOP013(params, onError) {
     const { tokens } = params.parsers.markdownit;
-    const headings = tokens.filter((token) => token.type === "heading_open");
 
-    headings.forEach((heading) => {
-      const headingTextStartIndex = heading.markup.length + 1;
+    tokens.forEach((token) => {
+      if (token.type !== "heading_open") {
+        return;
+      }
+
+      const headingTextStartIndex = token.markup.length + 1;
       const headingText = removeTrailingPunctuation(
-        heading.line.slice(headingTextStartIndex),
+        token.line.slice(headingTextStartIndex),
       );
 
       if (BLACKLISTED_HEADINGS.includes(headingText.toLowerCase())) {
         onError({
-          lineNumber: heading.lineNumber,
+          lineNumber: token.lineNumber,
           detail: `"${headingText}" is not sufficiently descriptive by itself. Use a more descriptive heading that briefly but clearly summarises the content of the section.`,
-          context: heading.line,
+          context: token.line,
         });
       }
     });

--- a/markdownlint/TOP013_descriptiveHeadings/tests/TOP013.md
+++ b/markdownlint/TOP013_descriptiveHeadings/tests/TOP013.md
@@ -22,7 +22,7 @@ Heading is blacklisted, so will flag a TOP013 error.
 
 <div class="lesson-note" markdown="1">
 
-#### Remember
+#### Remember!
 
 Note box heading is blacklisted, so will flag a TOP013 error.
 

--- a/markdownlint/TOP013_descriptiveHeadings/tests/TOP013.md
+++ b/markdownlint/TOP013_descriptiveHeadings/tests/TOP013.md
@@ -32,7 +32,7 @@ Note box heading is blacklisted, so will flag a TOP013 error.
 
 #### Remember to use quotes
 
-Note box heading is not blacklisted, so will flag a TOP013 error.
+Note box heading is not blacklisted, so will not flag a TOP013 error.
 
 </div>
 

--- a/markdownlint/TOP013_descriptiveHeadings/tests/TOP013.md
+++ b/markdownlint/TOP013_descriptiveHeadings/tests/TOP013.md
@@ -1,0 +1,55 @@
+### Introduction
+
+This file should flag with TOP013 errors only, and no other linting errors.
+
+### Lesson overview
+
+This section contains a general overview of topics that you will learn in this lesson.
+
+- A LESSON OVERVIEW ITEM.
+
+### Custom section with descriptive heading
+
+Section content relevant to descriptive heading.
+
+### Important
+
+Heading is blacklisted, so will flag a TOP013 error.
+
+#### A warning
+
+Heading is blacklisted, so will flag a TOP013 error.
+
+<div class="lesson-note" markdown="1">
+
+#### Remember
+
+Note box heading is blacklisted, so will flag a TOP013 error.
+
+</div>
+
+<div class="lesson-note" markdown="1">
+
+#### Remember to use quotes
+
+Note box heading is not blacklisted, so will flag a TOP013 error.
+
+</div>
+
+### Assignment
+
+<div class="lesson-content__panel" markdown="1">
+
+</div>
+
+### Knowledge check
+
+The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
+
+- [A KNOWLEDGE CHECK QUESTION](A-KNOWLEDGE-CHECK-URL)
+
+### Additional resources
+
+This section contains helpful links to related content. It isn't required, so consider it supplemental.
+
+- It looks like this lesson doesn't have any additional resources yet. Help us expand this section by contributing to our curriculum.

--- a/markdownlint/docs/TOP013.md
+++ b/markdownlint/docs/TOP013.md
@@ -6,7 +6,7 @@ Aliases: `descriptive-headings`
 
 Fixable via script: Not fixable due to being context-based
 
-This rule is triggered when a heading exactly matches one of our blacklisted headings (case insensitive). This list contains commonly used headings that are insufficiently descriptive for their contents and are thus insufficiently accessible.
+This rule is triggered when a heading exactly matches one of our blacklisted headings (case insensitive and ignoring trailing punctuation). This list contains commonly used headings that are insufficiently descriptive for their contents and are thus insufficiently accessible.
 
 Examples include (but are not limited to) "Note", "Tip", "A tip", "Warning", "Important", "Important note", and "Remember":
 
@@ -17,7 +17,7 @@ The HTML boilerplate in the `index.html` file is complete at this point, but how
 
 <div class="lesson-note lesson-note--warning" markdown="1">
 
-#### Remember
+#### Remember!
 
 In order to avoid branching our lesson’s instructions to accommodate for all of the differences between browsers, we are going to be using Google Chrome as our primary browser for the remainder of this course. All references to the browser will pertain specifically to Google Chrome. We strongly suggest that you use Google Chrome for all of your testing going forward.
 

--- a/markdownlint/docs/TOP013.md
+++ b/markdownlint/docs/TOP013.md
@@ -1,0 +1,47 @@
+# `TOP013` - Descriptive headings
+
+Tags: `accessibility`, `headings`
+
+Aliases: `descriptive-headings`
+
+Fixable via script: Not fixable due to being context-based
+
+This rule is triggered when a heading exactly matches one of our blacklisted headings (case insensitive). This list contains commonly used headings that are insufficiently descriptive for their contents and are thus insufficiently accessible.
+
+Examples include (but are not limited to) "Note", "Tip", "A tip", "Warning", "Important", "Important note", and "Remember":
+
+```markdown
+### Important
+
+The HTML boilerplate in the `index.html` file is complete at this point, but how do you view it in the browser? There are a couple of different options:
+
+<div class="lesson-note lesson-note--warning" markdown="1">
+
+#### Remember
+
+In order to avoid branching our lesson’s instructions to accommodate for all of the differences between browsers, we are going to be using Google Chrome as our primary browser for the remainder of this course. All references to the browser will pertain specifically to Google Chrome. We strongly suggest that you use Google Chrome for all of your testing going forward.
+
+</div>
+```
+
+In the above, there are two headings and neither of them really let you know what the section or note box's contents will talk about.
+
+Headings should ideally be brief; being descriptive does not mean they have to be some long paragraph. Both headings can be rephrased to be more descriptive by themselves:
+
+```markdown
+### Viewing HTML files in the browser
+
+The HTML boilerplate in the `index.html` file is complete at this point, but how do you view it in the browser? There are a couple of different options:
+
+<div class="lesson-note lesson-note--warning" markdown="1">
+
+#### Use Google Chrome
+
+In order to avoid branching our lesson’s instructions to accommodate for all of the differences between browsers, we are going to be using Google Chrome as our primary browser for the remainder of this course. All references to the browser will pertain specifically to Google Chrome. We strongly suggest that you use Google Chrome for all of your testing going forward.
+
+</div>
+```
+
+## Rationale
+
+Anyone navigating by heading, whether that's via assistive technology or just scanning the page, will find it much harder to locate information if headings are too generic. It can also be easier to follow the contents of a section or note box when the heading sets an expectation for the topic to come. Headings are also linkable via ID fragments based on their text. It's easier to know what the link will go to if the heading is sufficiently descriptive of its contents.


### PR DESCRIPTION
## Because

Similarly to how [links must have descriptive link text labels](github.com/TheOdinProject/curriculum/blob/main/markdownlint/TOP001_descriptiveLinkTextLabels/TOP001_descriptiveLinkTextLabels.js), headings should also be sufficiently descriptive of their section's contents for accessibility. Best we can do lint-wise is blacklist some common headings that are not sufficiently descriptive, such as the generic "Note" or "Important" or "Remember" etc. These must only flag an error if they are an exact match (case insensitive and after stripping any trailing punctuation), not just because they contain those word(s).

## This PR

- Adds descriptive headings custom rule
- Adds test examples
- Adds rule doc page
- Moves info about descriptive headings in layout style guide from Note Boxes section to Headings section

## Issue

Closes #30054

## Additional Information

3 lint errors are expected, all should only be TOP013.

## Pull Request Requirements

-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
