### PR TITLE
TOP013: Fix rule not accounting for indented headings

### DIFF
--- a/markdownlint/TOP013_descriptiveHeadings/TOP013_descriptiveHeadings.js
+++ b/markdownlint/TOP013_descriptiveHeadings/TOP013_descriptiveHeadings.js
@@ -19,6 +19,11 @@ const BLACKLISTED_HEADINGS = [
   "remember",
 ];
 
+function getHeadingTextStartIndex(text) {
+  // https://regexr.com/8gs8i to test this regex
+  return text.search(/[^ #]/);
+}
+
 function removeTrailingPunctuation(text) {
   // https://regexr.com/8grso to test this regex
   return text.replaceAll(/\W+$/g, "");
@@ -40,7 +45,7 @@ module.exports = {
         return;
       }
 
-      const headingTextStartIndex = token.markup.length + 1;
+      const headingTextStartIndex = getHeadingTextStartIndex(token.line);
       const headingText = removeTrailingPunctuation(
         token.line.slice(headingTextStartIndex),
       );

--- a/markdownlint/TOP013_descriptiveHeadings/tests/TOP013.md
+++ b/markdownlint/TOP013_descriptiveHeadings/tests/TOP013.md
@@ -28,6 +28,16 @@ Note box heading is blacklisted, so will flag a TOP013 error.
 
 </div>
 
+- List item
+
+  <div class="lesson-note" markdown="1">
+
+  #### Important note
+
+  Note box heading is blacklisted, so will flag a TOP013 error.
+
+  </div>
+
 <div class="lesson-note" markdown="1">
 
 #### Remember to use quotes


### PR DESCRIPTION
## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
I'm an idiot and only realised I didn't account for indented headings (which should only appear for indented note boxes), immediately after TOP013 got merged.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Fixes TOP013 not accounting for indented headings
- Adds indented note box heading example to TOP013 test file

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
N/A

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
