### PR TITLE
Text Editors: Add note about Microsoft VSCode repository option for Linux

### DIFF
--- a/foundations/installations/text_editors.md
+++ b/foundations/installations/text_editors.md
@@ -47,6 +47,14 @@ sudo apt install ./code-latest.deb
 
 <div class="lesson-note lesson-note--tip" markdown="1">
 
+#### Adding Microsoft's VSCode repository (optional)
+
+If you prefer to have VSCode update automatically alongside your other system updates, you can add Microsoft's official VSCode repository to your apt sources. This is completely fine and safe to do. The repository will allow VSCode to be updated whenever you run `sudo apt update && sudo apt upgrade` with your other system packages.
+
+</div>
+
+<div class="lesson-note lesson-note--tip" markdown="1">
+
 #### A note on typing passwords in the terminal
 
   When using a command in the terminal that requires you to enter your password for authentication (such as sudo), you will notice that the characters aren't visible as you type them. While it might seem like the terminal isn’t responding, don’t worry!


### PR DESCRIPTION
## Because

This addresses issue #29503 by adding clarification that it's safe and acceptable to add Microsoft's official VSCode repository to apt sources for automatic updates.

## This PR

- Add optional note in Linux installation section explaining Microsoft VSCode repository can be safely added to apt
- Note explains this allows VSCode to update alongside system packages
- Formatted as a tip box to match existing lesson style

## Issue

Closes #29503

## Additional Information

None.


## Pull Request Requirements

-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
