### PR TITLE
Foundations/Nodejs: fix broken discord link

### DIFF
--- a/foundations/javascript_basics/project_etch_a_sketch.md
+++ b/foundations/javascript_basics/project_etch_a_sketch.md
@@ -4,7 +4,7 @@ In this project, you'll be creating a pretty neat toy to flex your DOM manipulat
 
 This project should *not* be easy. You'll probably have to Google frequently to find the right JavaScript methods and CSS to use – in fact, that's the point! You *can* build this using the tools that you have already learned. There are plenty of resources on the net for learning stuff that we haven't covered yet if you decide you need it. We'll walk you through the basic steps, but it will be up to you to actually implement them.
 
-If you get totally stuck, drop by and ask for help in [our Discord server](https://discord.gg/theodinproject). Someone will be there to point you in the right direction.
+If you get totally stuck, drop by and ask for help in [our Discord server](https://discord.gg/fbFCkYabZB). Someone will be there to point you in the right direction.
 
 ### Assignment
 

--- a/getting_hired/applying_and_interviewing/conclusion.md
+++ b/getting_hired/applying_and_interviewing/conclusion.md
@@ -1,6 +1,6 @@
 ### Final words
 
-I hope you're reading this from your new office.  If you got a job after doing The Odin Project, come to [our Discord server](https://discord.gg/theodinproject) and let us know!  We'd love to hear how everything went, and we have a Discord channel where anyone can share their success stories.  The whole reason for putting this project out there is to try and onboard more people into the web development profession and tech in general.  Hopefully your success will inspire even more people to give it a shot.
+I hope you're reading this from your new office.  If you got a job after doing The Odin Project, come to [our Discord server](https://discord.gg/fbFCkYabZB) and let us know!  We'd love to hear how everything went, and we have a Discord channel where anyone can share their success stories.  The whole reason for putting this project out there is to try and onboard more people into the web development profession and tech in general.  Hopefully your success will inspire even more people to give it a shot.
 
 Before you move on, we would love it if you could [send us your feedback on the Getting Hired course](https://docs.google.com/forms/d/e/1FAIpQLSenziSaFuSQ3RFeHwn1YHovQj-G-WmNZc-_dgMuV_JcGB25Cg/viewform?usp=sf_link).  Getting user(you) feedback is important so we can continue to improve the curriculum and get an idea of your experience.  
 

--- a/nodeJS/express/controllers.md
+++ b/nodeJS/express/controllers.md
@@ -340,7 +340,7 @@ app.use(middleware3);
 // will log `Middleware 1` -> `Middleware 2` and send a response with the text "Response from Middleware 2"
 ```
 
-Here we have `middleware1`, `middleware2`, and `middleware3`. `middleware1` calls the `next` function, and since we are not yet sending a response, we pass the control to the next middleware function - `middleware2` (as indicated by the order of `app.use` calls). In `middleware2`, we send a response which ends the request-response cycle. Since it has ended, the third middleware function (`middleware3`) does not run. But if we somehow did not call the `next` function in `middleware1`, do you know what would happen? Perhaps pop in the [TOP Discord server](https://discord.gg/theodinproject) and let us know what you think!
+Here we have `middleware1`, `middleware2`, and `middleware3`. `middleware1` calls the `next` function, and since we are not yet sending a response, we pass the control to the next middleware function - `middleware2` (as indicated by the order of `app.use` calls). In `middleware2`, we send a response which ends the request-response cycle. Since it has ended, the third middleware function (`middleware3`) does not run. But if we somehow did not call the `next` function in `middleware1`, do you know what would happen? Perhaps pop in the [TOP Discord server](https://discord.gg/fbFCkYabZB) and let us know what you think!
 
 Also, as we've discussed earlier with regards to calling the `next` function. We have the following arguments that we can pass to it:
 

--- a/nodeJS/express/introduction_to_express.md
+++ b/nodeJS/express/introduction_to_express.md
@@ -4,7 +4,7 @@ In the previous section, you got up and running with Node. You learned how to re
 
 In this course, we will be using a backend framework called [Express](https://expressjs.com/), which will handle many of the implementation details for us. Express itself is an intentionally barebones and unopinionated framework; it allows us to do many things how we want, and to extend it with only the features we need. However, while this gives us great flexibility in how we do things, it can be a little tricky deciding between multiple viable options at times.
 
-Going forward, we will be diving into how we can use Express in various ways, such as to create a full-stack application using the Model View Controller (MVC) pattern, as well as to create a REST API just like ones you will have used before for things such as the Weather App or the React Shopping Cart projects. There is a lot to take in, so take it steady, and do not be afraid to ask our community for help in the [TOP Discord server](https://discord.gg/theodinproject)!
+Going forward, we will be diving into how we can use Express in various ways, such as to create a full-stack application using the Model View Controller (MVC) pattern, as well as to create a REST API just like ones you will have used before for things such as the Weather App or the React Shopping Cart projects. There is a lot to take in, so take it steady, and do not be afraid to ask our community for help in the [TOP Discord server](https://discord.gg/fbFCkYabZB)!
 
 ### Lesson overview
 


### PR DESCRIPTION
## Because
Some of the links leading to the discord server were broken, after researching i found out that the link has been moved from 
https://discord.gg/theodinproject to https://discord.gg/fbFCkYabZB


## This PR
- updated the links to the newest link on these lessons,
https://www.theodinproject.com/lessons/foundations-etch-a-sketch
https://www.theodinproject.com/lessons/node-path-nodejs-introduction-to-express
https://www.theodinproject.com/lessons/nodejs-controllers
https://www.theodinproject.com/lessons/node-path-getting-hired-conclusion


## Issue
Closes [#30097](https://github.com/TheOdinProject/curriculum/issues/30097)


## Additional Information

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
