### PR TITLE
Update advanced_selectors.md: remove redundant expression "finely grained"

### DIFF
--- a/intermediate_html_css/intermediate_css_concepts/advanced_selectors.md
+++ b/intermediate_html_css/intermediate_css_concepts/advanced_selectors.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-By now you should be comfortable with basic CSS selectors and have no trouble grabbing things by their type, class or ID. But to be a real CSS surgeon, sometimes you need more specialized tools. In this lesson we'll look at advanced CSS selectors and show you how to target elements in a more specific and finely grained way.
+By now you should be comfortable with basic CSS selectors and have no trouble grabbing things by their type, class or ID. But to be a real CSS surgeon, sometimes you need more specialized tools. In this lesson we'll look at advanced CSS selectors and show you how to target elements in a more specific way.
 
 These selectors can be especially useful when you can't (or don't want to) change your HTML markup.
 

--- a/intermediate_html_css/intermediate_css_concepts/advanced_selectors.md
+++ b/intermediate_html_css/intermediate_css_concepts/advanced_selectors.md
@@ -1,6 +1,6 @@
 ### Introduction
 
-By now you should be comfortable with basic CSS selectors and have no trouble grabbing things by their type, class or ID. But to be a real CSS surgeon, sometimes you need more specialized tools. In this lesson we'll look at advanced CSS selectors and show you how to target elements in a more specific way.
+By now you should be comfortable with basic CSS selectors and have no trouble grabbing things by their type, class or ID. But to be a real CSS surgeon, sometimes you need more specialized tools. In this lesson we'll look at advanced CSS selectors and show you how to target elements in a more fine-grained way.
 
 These selectors can be especially useful when you can't (or don't want to) change your HTML markup.
 
@@ -98,9 +98,11 @@ Before diving into pseudo-selectors, a quick note on the difference between [pse
 
 Pseudo-classes offer us different ways to target elements in our HTML. There are quite a lot of them, and they come in a couple of different flavors. Some are based on their position or structure within the HTML. Others are based on the state of a particular element, or how the user is currently interacting with it. There are too many to cover in detail here but we'll have a look at some of the most useful ones. Pseudo-classes share the same specificity as regular classes (0, 0, 1, 0). Just like regular classes, most can be chained together.
 
-<div class="lesson-note lesson-note--tip" markdown=1>
+<div class="lesson-note lesson-note--tip" markdown="1">
 
-The (0,0,1,0) above is the notation for calculating specificity. To find out more about how it works, glance over the "Calculating CSS Specificity Value" section from this [article on CSS Specificity](https://css-tricks.com/specifics-on-css-specificity/).
+#### Calculating CSS Specificity notation
+
+The (0,0,1,0) above is the notation for calculating specificity. To find out more about how it works, glance over the "Calculating CSS Specificity Value" section from this [article on CSS Specificity](https://css-tricks.com/specifics-on-css-specificity/#aa-calculating-css-specificity-value).
 
 </div>
 

--- a/intermediate_html_css/intermediate_css_concepts/advanced_selectors.md
+++ b/intermediate_html_css/intermediate_css_concepts/advanced_selectors.md
@@ -100,7 +100,7 @@ Pseudo-classes offer us different ways to target elements in our HTML. There are
 
 <div class="lesson-note lesson-note--tip" markdown="1">
 
-#### Calculating CSS Specificity notation
+#### Calculating CSS specificity notation
 
 The (0,0,1,0) above is the notation for calculating specificity. To find out more about how it works, glance over the "Calculating CSS Specificity Value" section from this [article on CSS Specificity](https://css-tricks.com/specifics-on-css-specificity/#aa-calculating-css-specificity-value).
 


### PR DESCRIPTION
## Because
"specific" and "finely grained" mean the same thing so it's probably enough to have one. "specific" is shorter, so I chose that version. 

## This PR
- I removed "and finely grained" from the lesson

## Issue
It's a tiny word choice suggestion. "finely grained" doesn't sound correct. It might be better to change it to the idiomatic form, which is "fine-grained way" rather than "finely grained way". But I suggest removing it altogether because "specific" is pointing to the same meaning.


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
