### PR TITLE
Setting up Git: Update ChromeOS Git installation to use apt instead of DigitalOcean

### DIFF
--- a/foundations/installations/setting_up_git.md
+++ b/foundations/installations/setting_up_git.md
@@ -135,11 +135,11 @@ sudo apt upgrade
 
 #### A note on typing passwords in the terminal
 
-  When using a command in the terminal that requires you to enter your password for authentication (such as sudo), you will notice that the characters aren't visible as you type them. While it might seem like the terminal isn't responding, don't worry!
+When using a command in the terminal that requires you to enter your password for authentication (such as sudo), you will notice that the characters aren't visible as you type them. While it might seem like the terminal isn't responding, don't worry!
 
-  This is a security feature to protect confidential information, like how password fields on websites use asterisks or dots. By not displaying the characters you write, the terminal keeps your password secure.
+This is a security feature to protect confidential information, like how password fields on websites use asterisks or dots. By not displaying the characters you write, the terminal keeps your password secure.
 
-  You can still enter your password as normal and press Enter to submit it.
+You can still enter your password as normal and press Enter to submit it.
 
 </div>
 


### PR DESCRIPTION
## Because
The ChromeOS Git installation instructions used an outdated DigitalOcean workaround that is no longer necessary since ChromeOS Linux Development Environment now supports standard package management.

## This PR

- Updates ChromeOS section to use apt install git instead of DigitalOcean guide
- Keeps ChromeOS as separate section
- Removes support for older Chromebooks without Linux Dev Environment
- Includes Google Support link for enabling Linux on ChromeOS

## Issue

Closes #28232

## Additional Information

I have been using ChromeOS for 2 years and can confirm that the Linux Development Environment now supports standard package management, making the DigitalOcean workaround unnecessary. The `apt install git` method works reliably on current ChromeOS versions with Linux Dev Environment enabled.

## Pull Request Requirements

-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
