### PR TITLE
Deployment: Remove redundant sentence

### DIFF
--- a/nodeJS/express/deployment.md
+++ b/nodeJS/express/deployment.md
@@ -70,7 +70,7 @@ The peace of mind this affords you can't be overstated. You never want to be in 
 
 Many PaaS services come with SQL databases included.
 
-Either choice isn't too difficult to set up, but it's always nice to have a fallback option! For now, we encourage you to try and figure out how to deploy your mini-message board project with just what you learn in this lesson.
+For now, we encourage you to try and figure out how to deploy your mini-message board project with just what you learn in this lesson.
 
 #### Domain names
 


### PR DESCRIPTION
## Because
The sentence "Either choice isn't too difficult to set up, but it's always nice to have a fallback option!" is unnecessary and should be removed from the lesson 

## This PR
- Removes the sentence "Either choice isn't too difficult to set up, but it's always nice to have a fallback option!" from the lesson

## Issue

Closes #30091

## Additional Information

None.

## Pull Request Requirements
- [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
- [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)