### PR TITLE
Styling React Applications: Remove CSS-in-JS recommendation from warning box

### DIFF
--- a/react/the_react_ecosystem/styling_react_applications.md
+++ b/react/the_react_ecosystem/styling_react_applications.md
@@ -30,9 +30,11 @@ What if everything's already done for you? Styling, behavior, and accessibility 
 
 There are also icon component libraries like [lucide react](https://lucide.dev/guide/packages/lucide-react), which let you include icons in your project as components.
 
-<div class="lesson-note lesson-note--warning" markdown="1" >
+<div class="lesson-note lesson-note--warning" markdown="1">
 
-For learning purposes throughout this course, we strongly recommend that you avoid using CSS frameworks or component libraries (using icon component libraries is fine), and instead implement your component's styling from scratch i.e. use [CSS Modules](#css-modules) or a [CSS-in-JS](#css-in-js) option.
+#### Recommended styling approach
+
+For learning purposes throughout this course, we strongly recommend that you avoid using CSS frameworks or component libraries (using icon component libraries is fine), and instead implement your components' styling from scratch using CSS Modules.
 
 </div>
 


### PR DESCRIPTION
## Because
The  lesson  suggests CSS-in-JS solutions like styled-components, but the styled-components maintainer has announced the library is in maintenance mode and recommends against using it for new projects. The lesson should focus on CSS Modules as the primary learning approach.

## This PR
- Removes recommendation for CSS-in-JS from the warning box
- Updates warning box text to focus on CSS Modules
- Adds descriptive level 4 heading "Recommended styling approach" to the warning box

## Issue

Closes #29560

## Additional Information

None.

## Pull Request Requirements
- [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
- [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)