### PR TITLE
JS Working with APIs: Rephrase content on fetch error handling

### DIFF
--- a/javascript/asynchronous_javascript_and_apis/working_with_apis.md
+++ b/javascript/asynchronous_javascript_and_apis/working_with_apis.md
@@ -221,7 +221,9 @@ While we are pushing this API key to the frontend, this isn't something you shou
 1. Read the [Fetch documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch). It's not all that complicated to use, but we've only really scratched the surface at this point.
 1. Check out this [list of Public APIs](https://github.com/n0shake/Public-APIs) and let your imagination go wild.
 1. Expand on our little project here by adding a button that fetches a new image without refreshing the page.
-1. Add a search box so users can search for specific gifs. You should also investigate adding a `.catch()` to manage some errors (i.e. invalid URL). Keep in mind that Giphy responds with a status code of 200 with an empty data array when it doesn't find any gifs with the searched keyword, in other words the `.catch()` won't be executed. Adjust your code to effectively handle such scenarios, displaying a default image or an error message if the search fails.
+1. Add a search box so users can search for specific gifs. You should also investigate adding a `.catch()` to manage some errors (e.g. invalid URL). Keep in mind that if the API responds, even with something like a `404 Not Found` or some other non-2XX status response, that is still a valid response and `fetch` will therefore not throw an error, meaning the `.catch()` will not run. It may still end up running if your following JavaScript code throws an error, such as trying to access a property of `undefined`, or even if you manually throw an error yourself.
+
+   If you want to conditionally handle any situations where the API does not give you the desired response (e.g. a `404 Not Found` or similar), you will need to do this manually in your `.then()`. Check out [MDN's docs for the Response object](https://developer.mozilla.org/en-US/docs/Web/API/Response) for some useful properties.
 
 </div>
 


### PR DESCRIPTION
## Because

GIPHY behaviour also changed re: could not find requested GIF - it now returns a random GIF instead of an empty array (still 200).

That contents has been replaced with more generic info about `fetch` and what will and won't cause it to throw an error to be `caught`. It's very common that people think a 404 will throw and therefore be caught, when that's still a repsonse and `fetch` is otherwise satisfied it did its job.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Replaces GIPHY "can't find GIF" contents with more generic fetch/catch/error handling info

## Issue

Closes #30142

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
