### PR TITLE
Understanding Errors: Remove console note and clarify `script.js` usage

### DIFF
--- a/foundations/javascript_basics/understanding_errors.md
+++ b/foundations/javascript_basics/understanding_errors.md
@@ -16,13 +16,7 @@ This section contains a general overview of topics that you will learn in this l
 
 An error is a type of object built into the JS language, consisting of a name/type and a message. Errors contain crucial information that can assist you in locating the code responsible for the error, determining why you have this error, and resolving the error.
 
-<div class="lesson-note lesson-note--tip" markdown=1>
-
-For all examples in this lesson, you should run the code in the browser's console.
-
-</div>
-
-Let’s assume we have written the following code:
+Let’s assume we have written the following code in a `script.js` file linked to an HTML page:
 
 ```javascript
 const a = "Hello";


### PR DESCRIPTION
## Because

The lesson currently instructs learners to run code examples in the browser console, which produces different output due to Content Security Policy restrictions (e.g., `eval()` blocked). This causes confusion when the lesson output does not match the expected result.

## This PR

- Removes the outdated tip note box recommending running code in the browser console.
- Updates the following sentence to clarify that the examples should be written in a `script.js` file linked to an HTML page.

## Issue

Closes #30111 

## Additional Information

[Related Discord discussion](https://discord.com/channels/505093832157691914/505093832157691916/1415239007306125392)

## Pull Request Requirements

-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
