### PR TITLE
Intermediate HTML and CSS Course - Advanced Selectors: Remove obsolete text

### DIFF
--- a/intermediate_html_css/intermediate_css_concepts/advanced_selectors.md
+++ b/intermediate_html_css/intermediate_css_concepts/advanced_selectors.md
@@ -88,7 +88,7 @@ Finally, if we want to select all of the siblings following an element and not j
 
 Just like the descendant combinator, these selectors don't have any special specificity rules - their specificity score will just be made up of their component parts.
 
-This [MDN article on combinators](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Selectors/Combinators) provides a good overview if you want to learn more about them. You don't have to do the "Test your skills!" at the bottom of the article as it covers concepts not yet discussed. Don't worry, more on those later in the lesson!
+This [MDN article on combinators](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Selectors/Combinators) provides a good overview if you want to learn more about them.
 
 ### Pseudo-selectors
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
The lesson in the end of combinators [section](https://www.theodinproject.com/lessons/node-path-intermediate-html-and-css-advanced-selectors#child-and-sibling-combinators) tells us not to do "Test your skills!” section at the bottom of [MDN article](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Styling_basics/Combinators) that doesn't exist there anymore. While reading I tried to search it to review ahead but couldn't find so this can be misleading.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Removes obsolete text

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Related to #29241, was proposed there

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
