### PR TITLE
 Transitions Lesson: Add stacking context description and align links

### DIFF
--- a/advanced_html_css/animation/transitions.md
+++ b/advanced_html_css/animation/transitions.md
@@ -63,7 +63,7 @@ The above transition will occur when the user hovers their mouse over the button
 
 Generally, keeping your CSS transitions performant will not be an issue. However there are a couple of things you need to keep in mind.
 
-The first is the "stacking context". Basically, a stacking context is formed when certain element scenarios are in place. A relevant scenario for us would be to transition a `transform` property like below:
+The first is the "stacking context". The "stacking context" refers to the stacking, or layering, of HTML elements in a parent container along the z axis (the depth dimension). The position of an element within a stacking context is relative only to the other elements within the same stacking context. The `z-index` property controls how far back or how far forward an element should appear on the web page when elements overlap. In addition to setting an elements' `z-index`, several CSS properties can also trigger the creation of new stacking contexts e.g. `transform`, `opacity`, `filter`, etc. A relevant scenario for us would be to transition a `transform` property like below:
 
 ```css
 div {
@@ -101,7 +101,7 @@ The following questions are an opportunity to reflect on key topics in this less
 
 - [Are all CSS properties animatable?](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_animated_properties)
 - [What are the long and short-hand notations for transitions?](https://developer.mozilla.org/en-US/docs/Web/CSS/transition)
-- [What is the stacking context?](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context)
+- [What is the stacking context?](https://www.joshwcomeau.com/css/stacking-contexts/)
 - [Why do you need to keep an eye on repaints?](https://dzhavat.github.io/2021/02/18/debugging-layout-repaint-issues-triggered-by-css-transition.html)
 
 ### Additional resources


### PR DESCRIPTION

## Because

To resolve issue #29379 - Transitions: Stacking Context definition is unclear. The lesson introduces the term 'stacking context' and gives a brief example of when one is formed. However there is no explanation as to what a stacking context is and some clarity on the term could be beneficial at this point in the lesson.

Additionally, when a reader clicks on [What is the stacking context?](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context) in the knowledge check section, they are brought to a MDN doc that isn't assigned. There is a different article assigned  https://www.joshwcomeau.com/css/stacking-contexts/. It would be beneficial if these resources were aligned.

## This PR

* Provide a description of what the term 'stacking context' means.
* Update the stacking context link in the knowledge section to match the stacking context link in the assignment section.



## Issue

Closes #29379

## Additional Information


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [X] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [X] The `Because` section summarizes the reason for this PR
-   [X] The `This PR` section has a bullet point list describing the changes in this PR
-   [X] If this PR addresses an open issue, it is linked in the `Issue` section
-   [X] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [X] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
