### PR TITLE
Using PostgreSQL: Fix typo

### DIFF
--- a/nodeJS/express/using_postgresql.md
+++ b/nodeJS/express/using_postgresql.md
@@ -258,7 +258,7 @@ DROP TABLE usernames;
 
 You can then run this script via `node db/populatedb.js`, or add it as a [script in package.json](https://stackoverflow.com/a/36433748).
 
-Do note that the script is designed to be ran only once.
+Do note that the script is designed to be run only once.
 
 #### Local vs production dbs
 


### PR DESCRIPTION
## Because
Fix small typo in Using PostgreSQL lesson.


## This PR
- Change sentence "Do note that the script is designed to be _**ran**_ only once." to "Do note that the script is designed to be _**run**_ only once."


## Issue
Closes #30217

## Additional Information


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
