### PR TITLE
Links and Images : Add description of image attributes

### DIFF
--- a/foundations/html_css/html-foundations/links-and-images.md
+++ b/foundations/html_css/html-foundations/links-and-images.md
@@ -316,7 +316,8 @@ As a bit of practice, add an `alt` attribute to the dog image we added to the `o
 While not strictly required, specifying height and width
 attributes in image tags helps the browser layout the page without causing the page to jump and flash.
 
-It is a good habit to always specify these attributes on every image, even when the image is the correct size or you are using CSS to modify it.
+It is a good habit to always specify these attributes on every image, even when the image is the correct size or you are using CSS to modify it. This is to
+prevent content jumping as images load. Use the image's actual dimensions when specifying size. 
 
 Here is our Odin Project logo example with height and width attributes included:
 


### PR DESCRIPTION
## Because
This PR updates the content of the image size attributes of the Links and Images section to include information regarding
what length and width to enter when specifying the size of an image. This is because when the user is asked to update with
the width and height attributes of the dog image, it is not clear as to what exactly to fill them up with. 

## This PR

- Added sentence "This is to
prevent content jumping as images load. Use the image's actual dimensions when specifying size. "

## Issue
Is not related to any open issue
Closes #XXXXX

## Pull Request Requirements

-   [ x ] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [ x ] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [ x ] The `Because` section summarizes the reason for this PR
-   [ x ] The `This PR` section has a bullet point list describing the changes in this PR
-   [ x ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ x ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ x ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
