### PR TITLE
Accessibility Auditing lesson: Clarify instructions for 'Emulate vision deficiencies' section

### DIFF
--- a/advanced_html_css/accessibility/accessibility_auditing.md
+++ b/advanced_html_css/accessibility/accessibility_auditing.md
@@ -31,7 +31,7 @@ Of course, one of the best ways to check the accessibility of your websites is t
 
 1. Read the following resources:
     - [Accessibility features reference](https://developer.chrome.com/docs/devtools/accessibility/reference/#pane), starting from the Accessibility pane section, provides a brief overview of Chrome's accessibility features in the DevTools.
-    - [Emulate vision deficiencies](https://developer.chrome.com/blog/new-in-devtools-83/#vision-deficiencies) from the Chrome 83 update page.
+    - Read only the [Emulate vision deficiencies](https://developer.chrome.com/blog/new-in-devtools-83/#vision-deficiencies) from the Chrome 83 update page.
     - The [Open the Issues tab](https://developer.chrome.com/docs/devtools/issues/#open) section. You can ignore any mentions of anything that isn't accessibility-related on this page, as we just want you to know how to open this tab in your DevTools. Once you do, you'll be able to see a11y issues in addition to any other issues found.
     - Although there will be differences between different browsers, such as the value of the role property or how a11y properties are presented, check out [the "Features of the Accessibility panel" section in MDN's documentation](https://firefox-source-docs.mozilla.org/devtools-user/accessibility_inspector/index.html#features-of-the-accessibility-panel). There is useful information that, while more tailored to Firefox, may still be useful for Chrome users.
 


### PR DESCRIPTION
…on in Accessibility Auditing lesson

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
The current wording in the Accessibility Auditing lesson makes it unclear whether learners
should read the entire Chrome 83 update page or just the "Emulate vision deficiencies"
section. This change clarifies the instructions.

## This PR
- Updates the Accessibility Auditing lesson assignment to explicitly state that learners
  should read **only the "Emulate vision deficiencies" section** from the Chrome 83 update page.

## Issue
Closes #30225

## Additional Information
N/A

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Accessibility Auditing lesson: Clarify instructions for 'Emulate vision deficiencies' section`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
