### PR TITLE
Inspecting HTML and CSS lesson: replace browser inspector images with statically CDN links and update copy to align

### DIFF
--- a/foundations/html_css/css-foundations/inspecting-html-and-css.md
+++ b/foundations/html_css/css-foundations/inspecting-html-and-css.md
@@ -24,7 +24,7 @@ In the Elements panel, you can see the entire HTML structure of your page. You c
 
 <span id="strikethrough">When an element is selected, the Styles tab will show all the currently applied styles, as well as any styles that are being overwritten (indicated by a strikethrough of the text).</span> For example, if you use the inspector to click on the "Your" in the "Your Career in Web Development Starts Here" header on the [TOP homepage](https://www.theodinproject.com/home), on the right-hand side you’ll see all the styles that are currently affecting the element, as seen below (don't worry about the `var()` syntax as that's irrelevant to this point):
 
-![Overwritten style](https://cdn.statically.io/gh/henrylin03/curriculum/e7ab90e044fba9f8ef9b5915c62221e2822b102b/foundations/html_css/css-foundations/inspecting-html-and-css/imgs/01.jpg)
+![Overwritten style](https://cdn.statically.io/gh/TheOdinProject/curriculum/e7ab90e044fba9f8ef9b5915c62221e2822b102b/foundations/html_css/css-foundations/inspecting-html-and-css/imgs/01.jpg)
 
 ### Testing styles in the inspector
 


### PR DESCRIPTION
## Because
The current example image for showing styles applied and overwritten styles is outdated and don't correspond to the current TOP code in the inspector...

## This PR
- Replaces the images used in the lesson with those uploaded from PR #30119 but converted into statically CDN links per [guidance](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md#creating-statically-links)
- Updates copy to align with the usage of the updated images

## Issue
Closes #29968 
Relates to PR #30119

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)