### PR TITLE
Fix: replace broken HTTP video link with working YouTube URL

### DIFF
--- a/ruby_on_rails/introduction/web_refresher.md
+++ b/ruby_on_rails/introduction/web_refresher.md
@@ -23,7 +23,7 @@ Check out these resources:
 
 1. This [tutsplus post on HTTP](http://code.tutsplus.com/tutorials/http-the-protocol-every-web-developer-must-know-part-1--net-31177) describes what's going on with HTTP.
 1. This [sniffer tool](http://testuri.org/sniffer) - try retrieving a couple of websites (like `https://www.theodinproject.com/`) on your own.
-1. This great video on [communications between http requests and the web server](https://code.tutsplus.com/how-to-become-a-web-developer--CRS-200371c/http-and-the-web-server).
+1. This great video on [communications between http requests and the web server](https://www.youtube.com/watch?v=CFzgKfnmG-Q).
 
 One key component to pay attention to is the fact that the request and response both have header and (usually) body components. The header contains information about the request or response itself (meta data), including which website to send or return to and what the status of the response is. The body of the request can contain things like data submitted by a form or cookies or authentication tokens while the response will usually contain the HTML page you're trying to access.
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
The original HTTP video link in the Rails Web Refresher lesson was broken (TutsPlus URL no longer works). This PR updates it to a working YouTube video, improving the learning experience for students.


## This PR
Replaces the outdated and broken TutsPlus HTTP video link with a working YouTube video URL.


## Issue
No open issue was created for this change. (This is a simple fix for a broken link found during lesson review.)
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [ X] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [ X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [X ] The `Because` section summarizes the reason for this PR
-   [ X] The `This PR` section has a bullet point list describing the changes in this PR
-   [X ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [X ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [X ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
