### PR TITLE
feat(css-intro): add section explaining CSS initial values

### DIFF
--- a/foundations/html_css/css-foundations/intro-to-css.md
+++ b/foundations/html_css/css-foundations/intro-to-css.md
@@ -420,5 +420,5 @@ Every CSS property has an **initial value**, which is the default value used by 
 
 Understanding initial values helps you predict how elements will appear before you apply your own styles.
 
-You can check the initial value of any CSS property on [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference)
+You can check the initial value of any CSS property on [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference).
 


### PR DESCRIPTION
## What changed
- Added a new section at the end of intro-to-css.md explaining CSS initial values.
- Provided examples and a link to MDN reference.

## Why
- Helps learners understand default behavior of CSS properties.

Fixes #30187
