### PR TITLE
fix: refactor the Preparing to Interview to fix lint errors

### DIFF
--- a/getting_hired/applying_and_interviewing/preparing_to_interview_and_interviewing.md
+++ b/getting_hired/applying_and_interviewing/preparing_to_interview_and_interviewing.md
@@ -128,14 +128,6 @@ Once you have an offer, you can check it against fair market rate by asking othe
 
 Finally, if a recruiter has reached out to you, it can also be helpful to ask what the budget for the role is up front. However, this must be done tactfully. If you have not been asked your compensation expectations and have not been told the budget up front in the initial message, it can be a great way to understand if both parties are wasting each other's time, but do keep in mind that asking must be done in a respectful manner. It can be helpful to phrase this ask by saying, "Is there an allocated salary range for the role?". Sometimes they may reply that the salary is based on experience, so do keep in mind your range as you move through the interview process!  
 
-### Assignment
-
-<div class="lesson-content__panel" markdown="1">
-
-- It looks like this lesson doesn't have any assignments.
-
-</div>
-
 ### Knowledge check
 
 The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The first (hopefully of many :) ) PR to fix existing lint errors throughout the lessons in the curriculum.
A number of changes were needed to resolve all the lint issues in this lesson.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Fix lazy numbering of ordered lists according to [TOP010](https://github.com/TheOdinProject/curriculum/blob/main/markdownlint/docs/TOP010.md) rule
- Fix unordered lists according to [MD004](https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md004.md) rule
- Many smaller fixes
- Add Lesson Preview, Knowledge Check, Additional Resources and Assignments sections to satisfy [TOP004](https://github.com/TheOdinProject/curriculum/blob/main/markdownlint/docs/TOP004.md) rule
## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #30262

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
One issue I would like to raise, is that in order to satisfy rule TOP004 I needed to add (among other things) Assignments section.
 
For now, the section only contains a message that it has no assignments (similar to how it is done when the Additional resources section is empty) since it would take a pretty big rework to move some of the links from various parts of the lesson into the section itself - and as I said in the issue opened for this PR, my goal is to remove all the linter errors, while keeping any additional work to a minimum.

I tried looking up a different way to solve this, but none come to mind, so i hope this is alright.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
