### PR TITLE
React/refs-and-memoization: Rephrase a sentence for more clarity

### DIFF
--- a/react/more_react_concepts/refs_and_memoization.md
+++ b/react/more_react_concepts/refs_and_memoization.md
@@ -38,7 +38,7 @@ function ButtonComponent() {
 The implementation is straightforward:
 
 1. We imported `useRef` and `useEffect` in the `react` module.
-1. We call useRef with an argument of null, which returns an `object` with a property called `current` whose initial value is set to the passed argument (which in this case, null). This passed argument—like the passsed argument for useState—is ignored in subsequent renders.
+1. We call `useRef` with an argument of `null`, which returns an object with a property called `current` whose initial value is set to the passed argument (which in this case, is `null`). This argument—like the passed argument for `useState`—is ignored in subsequent renders.
 1. Created a `useEffect` to be executed once on the mount of the component that will try to call the `focus` method of the button element.
 1. We've attached `buttonRef` to the `ref` attribute of the button element. This establishes the connection between the `buttonRef` and the button in the DOM.
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
fixing a typo and improving clarity 


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->

changes step 2 in "The useRef hook" 

from  "We created a ref object `buttonRef` with a `current` property initially set to `null`. Yes, passing an argument to `useRef` sets the value of `current` to `null` just like `useState`. This argument is ignored in subsequent renders."

to  "We call useRef with an argument of null, which returns an `object` with a property called `current` whose initial value is set to the passed argument (which in this case, null). This passed argument—like the passsed argument for useState—is ignored in subsequent renders."



## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #30346

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
