### PR TITLE
Update project_hash_map.md

### DIFF
--- a/javascript/computer_science/project_hash_map.md
+++ b/javascript/computer_science/project_hash_map.md
@@ -8,6 +8,8 @@ You already know the magic behind hash maps. Now it's time to write your own imp
 
   Use the following snippet whenever you access a bucket through an index. We want to throw an error if we try to access an out-of-bounds index:
 
+  Note: This code snippet is unnecessary when implementing the Multipication method in your hash function , as the method inherently guarantees that the computed index will always be within bounds.
+
 ```javascript
 if (index < 0 || index >= buckets.length) {
   throw new Error("Trying to access index out of bounds");


### PR DESCRIPTION
HashMap lesson: Add note explaining why out-of-bounds index checks are unnecessary when using the multiplication method for hashing

## Because
This PR adds clarification to help learners understand that the multiplication method in hashing inherently ensures the computed index stays within valid bounds, making explicit index checks unnecessary.

## This PR
- Adds a note explaining why an out-of-bounds index prevention snippet is redundant when using the multiplication method for hashing.

## Issue
This PR does not close any existing issue. It creates a new issue.

## Additional Information
N/A


-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
