### PR TITLE
Mocking Callbacks And Components: Remove Unnecessary async Keyword from a Function

### DIFF
--- a/react/react_testing/mocking_callbacks_and_components.md
+++ b/react/react_testing/mocking_callbacks_and_components.md
@@ -63,7 +63,7 @@ describe("CustomButton", () => {
     expect(onClick).toHaveBeenCalled();
   });
 
-  it("should not call the onClick function when it isn't clicked", async () => {
+  it("should not call the onClick function when it isn't clicked", () => {
     const onClick = vi.fn();
     render(<CustomButton onClick={onClick} />);
 


### PR DESCRIPTION
## Because

It resolves an issue raised by another user.


## This PR

- Removes the unnecessary `async` keyword from the last test callback in the code block.


## Issue

Closes #29316


## Additional Information


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
