### PR TITLE
Authentication Basics: Fix Passport middleware order and clarify passport.initialize() requirement

### DIFF
--- a/nodeJS/authentication/authentication_basics.md
+++ b/nodeJS/authentication/authentication_basics.md
@@ -64,9 +64,16 @@ const app = express();
 app.set("views", path.join(__dirname, "views"));
 app.set("view engine", "ejs");
 
-app.use(session({ secret: "cats", resave: false, saveUninitialized: false }));
-app.use(passport.session());
 app.use(express.urlencoded({ extended: false }));
+app.use(
+  session({
+    secret: "cats",
+    resave: false,
+    saveUninitialized: false,
+  })
+);
+app.use(passport.initialize());
+app.use(passport.session());
 
 app.get("/", (req, res) => res.render("index"));
 
@@ -370,7 +377,7 @@ You should now be able to log in using the new user you've created (the one with
 <div class="lesson-content__panel" markdown="1">
 
 1. Watch videos 1, 2, 3, 5 and 6 of this [Youtube Playlist on sessions in Express and local strategy authentication with Passport.js](https://www.youtube.com/playlist?list=PLYQSCk-qyTW2ewJ05f_GKHtTIzjynDgjK).
-   - You may notice at some points in the videos, the Express app contains the line `app.use(passport.initialize())`. This line is no longer required to include in current versions of Passport.
+   - Note: Many older tutorials mention omitting passport.initialize(), but in most Express apps, you must include it. passport.initialize() sets up Passport’s internal request state so that strategies, passport.authenticate(), req.login(), and req.logout() work correctly. It must be added before passport.session().
    - They are using MongoDB and you can replace any instance of it with PostgreSQL.
    - In [video 3: "Your complete guide to understanding the express-session library"](https://youtu.be/J1qXK66k1y4?list=PLYQSCk-qyTW2ewJ05f_GKHtTIzjynDgjK) and [video 5: "Passport Local Configuration (Node + Passport + Express)"](https://youtu.be/xMEOT9J0IvI?list=PLYQSCk-qyTW2ewJ05f_GKHtTIzjynDgjK), it shows using the `connect-mongo` library to use your MongoDB connection to store sessions, as opposed to storing them in memory. However, since we are using PostgreSQL, we need to replace it with a library called `connect-pg-simple` instead. You can view the implementation for doing this on the [npm page for connect-pg-simple](https://www.npmjs.com/package/connect-pg-simple).
    - Do note that the table needed to be used for the session store is not automatically created by default, be sure to check the available options in their npm page.


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
The Authentication Basics lesson contains an incorrect Passport.js middleware setup:
- `passport.initialize()` is missing from the example, which can cause authentication and session handling to fail in real Express apps.
- The middleware is shown in the wrong order (`passport.session()` before body parsing).
- The Assignment section incorrectly states that `passport.initialize()` is “no longer required,” which contradicts current Passport documentation and can mislead students.

These issues can prevent learners from successfully implementing authentication and cause silent failures that are difficult for beginners to debug.

## This PR
- Replaces the middleware block with the correct Passport.js setup:
  - Parses the request body before authentication.
  - Adds `passport.initialize()` before `passport.session()`.
  - Ensures `express-session` is positioned correctly.
- Updates the Assignment note to accurately reflect modern Passport behavior and clarify why `passport.initialize()` is required.
- Ensures the example code aligns with current Passport.js documentation and avoids common beginner errors.

## Issue
<!-- Remove this comment and replace XXXXX with an issue number if one exists.
If none exists, leave the "Closes #XXXXX" line as-is or delete it entirely. -->
Closes #XXXXX

## Additional Information
These changes were previewed using the Lesson Preview Tool and validated with markdownlint to ensure proper formatting.  

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Authentication Basics: Fix Passport middleware order`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
