### PR TITLE
How Does the Web Work? lesson: Remove reading advice from additional resources

### DIFF
--- a/foundations/installations/how_does_the_web_work.md
+++ b/foundations/installations/how_does_the_web_work.md
@@ -55,5 +55,4 @@ This section contains helpful links to related content. It isn't required, so co
 - Watch ["A Packet's Tale" - a video about how data travels across the internet](https://www.youtube.com/watch?v=ewrBalT_eBM).
 - If you're in for a bit more reading, you can check out the [Introduction to HTTP](https://launchschool.com/books/http) online book at LaunchSchool. This book also touches on some topics covered later in the curriculum, such as developer tools and security. Additionally, you can learn about HTTP tools, which you may find helpful in the future.
 - Explore how fiber optics uses light to transmit data over long distances, and with integrated photonics, expands our virtual world beyond the internet. [The hidden network that makes the internet possible](https://youtu.be/er3v4PVNQqE).
-- Some advice on reading: We recommend that you only review the immediate links posted in our curriculum. You can always go deeper on any subject if you wish, but be careful not to overload yourself on information!
 - Watch [How the Web Brings You Websites](https://www.youtube.com/watch?v=gDUEgYrAv2c&t=1s) with nice comparison to real life examples.


### PR DESCRIPTION
## Because
Redundant comment under additional resources.

## This PR
- Removes the redundant comment.

## Issue
Closes #30481 

## Additional Information

## Pull Request Requirements
-   [X] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [X] The `Because` section summarizes the reason for this PR
-   [X] The `This PR` section has a bullet point list describing the changes in this PR
-   [X] If this PR addresses an open issue, it is linked in the `Issue` section
-   [X] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [X] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
