### PR TITLE
Docs: Fix incorrect numbering in Job Search course introduction

### DIFF
--- a/getting_hired/preparing_for_job_search/how_this_course_will_work.md
+++ b/getting_hired/preparing_for_job_search/how_this_course_will_work.md
@@ -14,8 +14,8 @@ This course is structured a bit differently than the others because it's much mo
 ### In each lesson:
 
 1. We'll introduce the topic and provide you with its context in your overall search.
-2. You'll be asked to do readings, watch videos, do online courses or otherwise consume content to help you out.
-3. You'll often be asked to do specific tasks, for instance keeping track of the applications you've submitted.  This is purely to help you along the way.
-5. Finally, we'll include additional helpful resources and other potentially useful tidbits at the end of each lesson.
+1. You'll be asked to do readings, watch videos, do online courses or otherwise consume content to help you out.
+1. You'll often be asked to do specific tasks, for instance keeping track of the applications you've submitted.  This is purely to help you along the way.
+1. Finally, we'll include additional helpful resources and other potentially useful tidbits at the end of each lesson.
 
 ### Enough talk, go get hired!


### PR DESCRIPTION
## Because
The numbering of the section "In each lesson:" in the introduction to the Job Search course skips from step 3 to step 5. This causes an inconsistency in the lesson formatting and should be corrected to maintain clarity.

## This PR
• Changes the final step in the "In each lesson:" sequence from '5.' to '4.' to correct the numbering sequence.

## Issue
Closes #N/A

## Additional Information

## Pull Request Requirements
- [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `docs: Fix incorrect numbering in Job Search course introduction`
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [ ] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
- [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)