### PR TITLE
Ruby on Rails: Update to use HTTParty instead of RestClient

### DIFF
--- a/ruby_on_rails/apis/project_kittens_api.md
+++ b/ruby_on_rails/apis/project_kittens_api.md
@@ -74,11 +74,17 @@ This is a fast and straightforward project where you'll set up a Rails app to be
 
 1. Now it's time to make the Kittens resource available via API.
 
-   1. Open a new command line tab and fire up IRB.  We'll use `rest-client` gem to send requests to our app:
+   1. Add the HTTParty gem to your project and open a Rails console. We'll use the `HTTParty` gem to send requests to our app:
+
+      ```bash
+      bundle add httparty
+      rails console
+      ```
+
+      Then in the console:
 
       ```ruby
-      require 'rest-client' # If you get an error here, you most likely need to install the gem.
-      response = RestClient.get("http://localhost:3000/kittens")
+      response = HTTParty.get("http://localhost:3000/kittens")
       ```
 
    1. Let's see what we got back:
@@ -90,18 +96,18 @@ This is a fast and straightforward project where you'll set up a Rails app to be
       ```
 
       If you check out your server output, it's probably processing as \*/\* (i.e. all media types), e.g. `Processing by KittensController#index as */*`
-   1. Try asking specifically for a JSON response by adding the option `accept: :json`, e.g.:
+   1. Try asking specifically for a JSON response by adding the headers option:
 
       ```ruby
-      json_response = RestClient.get("http://localhost:3000/kittens", accept: :json)
+      json_response = HTTParty.get("http://localhost:3000/kittens", headers: { 'Accept' => 'application/json' })
       ```
 
       You most likely will get a 406 Not Acceptable error - check your server console and you will see ActionController talking about UnknownFormat for your controller.
    1. Now modify your KittenController's `#index` method to `#respond_to` JSON and render the proper variables.
-   1. Test it out by making sure your RestClient calls return the proper JSON strings, e.g.:
+   1. Test it out by making sure your HTTParty calls return the proper JSON strings, e.g.:
 
       ```ruby
-      json_response = RestClient.get("http://localhost:3000/kittens", accept: :json)
+      json_response = HTTParty.get("http://localhost:3000/kittens", headers: { 'Accept' => 'application/json' })
       puts json_response.body
       ```
 


### PR DESCRIPTION
## Because

The `rest-client` gem used in the Kittens API lesson is in maintenance mode and hasn't received updates in years. This PR updates the lesson to use `HTTParty`, a modern, actively maintained gem that is widely used in the Rails ecosystem.

## This PR

- Replaces global `rest-client` installation with `bundle add httparty` to add the gem to the project's Gemfile
- Changes from using IRB to Rails console for testing API requests
- Updates all `RestClient.get()` calls to `HTTParty.get()`
- Updates JSON request header syntax from `accept: :json` to `headers: { 'Accept' => 'application/json' }`
- Updates all code examples and variable names to reflect the new HTTParty syntax

## Issue

Closes #30456

## Additional Information

## Pull Request Requirements

-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
