### PR TITLE
Motivation and Mindset: Remove assignment

### DIFF
--- a/foundations/introduction/motivation_and_mindset.md
+++ b/foundations/introduction/motivation_and_mindset.md
@@ -172,7 +172,6 @@ Learning any new skill is a journey full of speed bumps and obstacles to overcom
    - [You can learn anything](https://www.khanacademy.org/college-careers-more/talks-and-interviews/talks-and-interviews-unit/conversations-with-sal/a/the-learning-myth-why-ill-never-tell-my-son-hes-smart)
    - [Grit](https://ted.com/talks/angela_lee_duckworth_grit_the_power_of_passion_and_perseverance)
    - [Believe you can get better](https://www.ted.com/talks/carol_dweck_the_power_of_believing_that_you_can_improve)
-1. To learn more about the best ways to learn, watch this summary of [Coursera's learning how to learn course](https://www.youtube.com/watch?v=O96fE1E-rf8).
 
 </div>
 


### PR DESCRIPTION
## Because
Additional resources section was removed last week in #30494 so this text should also be removed since the link no longer exist in the page.


## This PR
- remove the text "The full course is linked in the additional resources." from [Assignment 4 of Motivation and Mindset](https://www.theodinproject.com/lessons/foundations-motivation-and-mindset#assignment)


## Issue

## Additional Information

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
