### PR TITLE
Foundations: variables and operators: fix assignment link

### DIFF
--- a/foundations/javascript_basics/variables_and_operators.md
+++ b/foundations/javascript_basics/variables_and_operators.md
@@ -124,9 +124,9 @@ Numbers are the building blocks of programming logic! In fact, it's hard to thin
 
 For instance, JavaScript follows the standard mathematical **Order of Operations** (often remembered by acronyms like **PEMDAS** or **BODMAS**). This means:
 
-1.  **Parentheses** (or Brackets) are evaluated first.
-2.  **Multiplication** and **Division** are done next, from left to right.
-3.  **Addition** and **Subtraction** are done last, from left to right.
+1.**Parentheses** (or Brackets) are evaluated first.
+1.**Multiplication** and **Division** are done next, from left to right.
+1.**Addition** and **Subtraction** are done last, from left to right.
 
 For example, the mathematical expression `(3 + 2) - 76 * (1 + 1)` is perfectly valid JavaScript and will evaluate exactly as you'd expect, if you put that expression into a `console.log`.
 
@@ -154,7 +154,7 @@ Try the following exercises by adding code to a script tag in your HTML file:
 
 Go through the following articles to deepen your knowledge.
 
-1. Read up on [variables in JavaScript](https://javascript.info/variables#variable-naming) from JavaScript.info.
+1. Read up on [variables in JavaScript](https://javascript.info/variables) from JavaScript.info.
 1. This W3Schools lesson on [JavaScript arithmetic](https://www.w3schools.com/js/js_arithmetic.asp) followed by this on [JavaScript numbers](https://www.w3schools.com/js/js_numbers.asp), are good introductions to what you can accomplish with numbers in JavaScript.
 1. This MDN article on [JavaScript math](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/First_steps/Math) covers the same info from a slightly different point of view, while also teaching you how to apply some basic math in JavaScript. There's much more that you can do with numbers, but this is all you need at the moment.
 1. Read through (and code along with!) this article on [JavaScript operators](http://javascript.info/operators). Don't forget to do the "Tasks" at the bottom of the page! It will give you a pretty good idea of what you can accomplish with numbers (among other things!) in JavaScript.


### PR DESCRIPTION
## Because
The assignment step 1 suggests that the learner read the article https://javascript.info/variables but it points to https://javascript.info/variables#variable-naming. The learner should read the whole article, not just the part about naming and other parts.

## This PR
- Fixes the assignment step 1 link to point to the start of the article
- Uses lazy numbering for order of operations list
- Fixes empty space between list numbers and text

## Additional Information
If the goal of the first step was to make learner read about naming, I can change my PR to explicitly mention it and revert to the old link

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
