### PR TITLE
Environment Variables: Fixed wording in note about documentation

### DIFF
--- a/nodeJS/introduction_to_nodeJS/environment_variables.md
+++ b/nodeJS/introduction_to_nodeJS/environment_variables.md
@@ -96,7 +96,7 @@ No hardcoding of those values into the source code! If you want to change the va
 
 #### Documenting your environment variables
 
-When your projects include environment variables, those that assist you will need to know what environment variables are needed to run your them. Therefore, we highly recommend that you document them in your `README.md` file, like which ones are required and what they should contain. You could also include a dummy example `.env` file, such as an `.env.sample`, that others can rename then edit with the values they need.
+When your projects include environment variables, those that assist you will need to know what environment variables are needed to run your project. Therefore, we highly recommend that you document them in your `README.md` file, like which ones are required and what they should contain. You could also include a dummy example `.env` file, such as an `.env.sample`, that others can rename then edit with the values they need.
 
 </div>
 


### PR DESCRIPTION
## Because
Swapped the word "them" with "project" in the note about documentation because it made the sentence flow better and makes more sense in the context of the sentence. The word "your"  leading up to "them" could have also just been removed.


## This PR
- Replaced the word "them" with "project"


## Issue
Simple Change (could not find existing related issue).

## Additional Information


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
