### PR TITLE
Correct 'body tag' to 'body element' in text

### DIFF
--- a/foundations/html_css/html_foundations/working_with_text.md
+++ b/foundations/html_css/html_foundations/working_with_text.md
@@ -155,7 +155,7 @@ In the following example, the body element is the parent and the paragraph is th
 
 Just as in human relationships, HTML parent elements can have many children.  <span id='elements-same-level'>Elements at the same level of nesting are considered to be siblings.</span>
 
-For example, the two paragraphs in the following code are siblings, since they are both children of the body tag and are at the same level of nesting as each other:
+For example, the two paragraphs in the following code are siblings, since they are both children of the body element and are at the same level of nesting as each other:
 
 <p class="codepen" data-height="300" data-theme-id="dark" data-default-tab="html,result" data-slug-hash="ZEybrYx" data-user="TheOdinProjectExamples" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;">
 


### PR DESCRIPTION
Updated the lesson text to replace the term "body tag" with the more accurate "body element" when describing parent-child relationships in HTML.  This improves clarity for learners and aligns terminology with standard HTML practices.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [ ] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [ ] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [ ] The `Because` section summarizes the reason for this PR
-   [ ] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
