### PR TITLE
Ruby Course: Loops lesson Fix incorrect method name in parentheses

### DIFF
--- a/ruby/basic_ruby/loops.md
+++ b/ruby/basic_ruby/loops.md
@@ -169,4 +169,4 @@ The following questions are an opportunity to reflect on key topics in this less
 This section contains helpful links to related content. It isn't required, so consider it supplemental.
 
 - If you'd like another overview of loops, read this [Ruby Explained: Iteration](https://www.eriktrautman.com/posts/ruby-explained-iteration) article. (Don't worry about the `#each` method described here; we'll get to that in an upcoming lesson!)
-- If you want yet another take, read [Skork's article on loops](https://skorks.com/2009/09/a-wealth-of-ruby-loops-and-iterators/). (Again, don't worry about the `#each` and `#each_with_index` methods here; they're coming up soon.)
+- If you want yet another take, read [Skork's article on loops](https://skorks.com/2009/09/a-wealth-of-ruby-loops-and-iterators/). (Again, don't worry about the `#each` and `#each_index` methods here; they're coming up soon.)


### PR DESCRIPTION
Corrected the method name in parentheses from #each_with_index to #each_index to match the actual Ruby method referred to in the linked article.

## Because
The referenced Ruby method name in the parentheses was incorrect. The lesson mentioned #each_with_index, but the intended method in the linked article is #each_index. Correcting this prevents confusion for learners.


## This PR
- Corrects the method name in the explanatory parentheses from #each_with_index to #each_index.


## Issue
Closes #XXXXX

## Additional Information


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
