### PR TITLE
Ruby Pattern Matching lesson: Fix array vs hash wording in Find Pattern section

### DIFF
--- a/ruby/advanced_ruby/pattern_matching.md
+++ b/ruby/advanced_ruby/pattern_matching.md
@@ -568,7 +568,7 @@ The case/in format is best used when there are multiple conditionals you could p
 
 ### Find pattern
 
-As we saw earlier, we can match against part of a hash using the array pattern match. So what do you do if you need to match against part of an array? The as pattern would capture all of the array and the variable pattern captures individual parts of it. To address this, Ruby added the find pattern.
+As we saw earlier, we can match against part of an array using the array pattern match. So what do you do if you need to match against part of an array? The as pattern would capture all of the array and the variable pattern captures individual parts of it. To address this, Ruby added the find pattern.
 
 It works by placing a `*` either side of the part you want to match. You can even use the variable pattern to give each `*` a variable name to reference later. Let's look at some examples.
 


### PR DESCRIPTION
## Because
The Find Pattern section incorrectly states that part of a hash can be matched using an array pattern. Ruby uses distinct pattern types for arrays and hashes, and this wording is technically incorrect. Correcting it improves accuracy and prevents confusion for learners.

## This PR
- Corrects a wording error in the Find Pattern section by replacing “hash” with “array”
- Improves clarity without changing the lesson’s structure or intent

## Issue
N/A

## Additional Information
N/A

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
