### PR TITLE
Recursive Methods: Move 'Test Yourself' subheading contents into 'Assignment' section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -253,7 +253,6 @@
       "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.12.1.tgz",
       "integrity": "sha512-RcK+l5FjJEyrU3REhrThiEUXNK89dLYNJCYbvOUKypxqIGfkcgpz8g08EKqhrmUbYfYoLC5nEYQy53NhJSEtfQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "globby": "14.0.0",
         "jsonc-parser": "3.2.0",


### PR DESCRIPTION
## Because
The 'Test Yourself' section was in a div by itself creating a discrepancy with other lessons that required one to attempt and solve questions in the Javascript excercise folder. Potentially causing confusion on the importance of the excercise.

## This PR
- Fixes the problem by moving the subheading and its contents into the assignment heading's section whilst retaining the intended format of the text.


## Issue
N/A


## Additional Information
Link to the conversation on discord that prompted this pull request https://discord.com/channels/505093832157691914/1179952911548174346/1461212317113909248


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
