### PR TITLE
Ruby Pattern Matching lesson: Clarify array-only explanation in Find Pattern section

### DIFF
--- a/ruby/advanced_ruby/pattern_matching.md
+++ b/ruby/advanced_ruby/pattern_matching.md
@@ -568,7 +568,9 @@ The case/in format is best used when there are multiple conditionals you could p
 
 ### Find pattern
 
-As we saw earlier, we can match against part of an array using the array pattern match. So what do you do if you need to match against part of an array? The as pattern would capture all of the array and the variable pattern captures individual parts of it. To address this, Ruby added the find pattern.
+An array pattern matches elements by position, starting from the beginning of the array. This makes it unsuitable when you want to match a value that may appear anywhere inside the array.
+
+While the as pattern can capture the entire array and variable patterns can capture individual elements, they still rely on positional matching. To allow matching a subsequence regardless of its position, Ruby introduced the find pattern.
 
 It works by placing a `*` either side of the part you want to match. You can even use the variable pattern to give each `*` a variable name to reference later. Let's look at some examples.
 


### PR DESCRIPTION
## Because
A previous wording correction in the Find Pattern section fixed an incorrect reference but left a logical inconsistency in the explanation (posing a question about a capability that the text had just implied was already supported). This PR clarifies the explanation so that it accurately reflects how array patterns and find patterns differ.

## This PR
- Fixes a remaining logical inconsistency in the Find Pattern explanation
- Clarifies that standard array patterns are positional and do not match arbitrary subsequences
- Improves conceptual accuracy without changing the lesson’s structure or intent

## Issue
Related to #30663 

## Additional Information
This PR builds on a previously merged wording fix by further clarifying the array-only explanation.

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
