### PR TITLE
Rails Sprinkles: Replace Turbo Native and Strada with Hotwire Native

### DIFF
--- a/ruby_on_rails/rails_sprinkles/turbo.md
+++ b/ruby_on_rails/rails_sprinkles/turbo.md
@@ -13,7 +13,7 @@ This section contains a general overview of topics that you will learn in this l
 - Turbo and the four components of it.
 - When to use a Turbo Frame.
 - How to use Turbo Streams to update your pages.
-- What Turbo Native is used for.
+- What Hotwire Native is used for.
 
 ### Single-page applications (SPAs)
 
@@ -30,9 +30,9 @@ In Rails 7, all new applications include Hotwire by default. Hotwire is actually
 
 1. Turbo
 1. Stimulus
-1. Strada
+1. Hotwire Native
 
-The lesson you are reading now is all about Turbo. We will cover Stimulus in another lesson. Strada is a currently unreleased framework that aims to work alongside Turbo to deliver responsive mobile applications. You don't need to worry about Strada for the scope of this course, just be familiar with the name as you will see it mentioned from time-to-time.
+The lesson you are reading now is all about Turbo. We will cover Stimulus in another lesson. You don't need to worry about Hotwire Native for the scope of this course, just be familiar with the name as you will see it mentioned from time-to-time.
 
 ### Turbo
 
@@ -43,7 +43,7 @@ Here is a quick summary of the four Turbo techniques together. As you continue t
 1. **Turbo Drive**: We already covered this in an earlier lesson.
 1. **Turbo Frames**: Turbo Frames, like Turbo Drive, also help with fast navigation, but for predefined portions of a page. Rather than requesting an entire page, you can define a region of your HTML as a Turbo Frame and replace only the content inside of that region.
 1. **Turbo Streams**: Turbo Stream delivers web page changes to instantly insert, update, or remove a region of the webpage. An example of this could be a user creating a new post and that post immediately inserts itself at the top of the post index feed without any refresh or redirection.
-1. **Turbo Native**: Turbo Native is a technique that allows developers to achieve the same Turbo style transitions on a mobile app for iOS or Android.
+1. **Hotwire Native**: Hotwire Native is a technique that allows developers to achieve the same Turbo style transitions on a mobile app for iOS or Android.
 
 ### Turbo Frames
 
@@ -317,9 +317,9 @@ if you would like to learn more:
 
 1. You may have noticed that when you submit a new Post, the text box doesn't clear out. You need to reset the submission element in order for it to be empty again. Hotwire has a remedy for this problem by including Stimulus, a light JavaScript framework. Don't worry about Stimulus for this example though, the next lesson will cover how to write and make use of Stimulus Controllers.
 
-### Turbo Native
+### Hotwire Native
 
-The final piece of Turbo is something that you don't need to know much about for this course, other than it exists. Turbo Native is useful for wrapping your application inside of a mobile-friendly shell. If you are interested in mobile development and how you can use Turbo with it, you may enjoy looking at the demos for [iOS](https://github.com/hotwired/turbo-ios/blob/main/Demo/README.md) and [Android](https://github.com/hotwired/turbo-android/blob/main/demo/README.md) phones.
+The final piece of Turbo is something that you don't need to know much about for this course, other than it exists. Hotwire Native is useful for wrapping your application inside of a mobile-friendly shell. If you are interested in mobile development and how you can use Turbo with it, you may enjoy looking at the demos for [iOS](https://github.com/hotwired/turbo-ios/blob/main/Demo/README.md) and [Android](https://github.com/hotwired/turbo-android/blob/main/demo/README.md) phones.
 
 ### Assignment
 


### PR DESCRIPTION
## Because

Turbo Native and Strada have been consolidated into Hotwire Native. The lesson currently references Strada as an "unreleased framework" and separately mentions Turbo Native, which is now outdated.

## This PR

- Replaces all references to "Turbo Native" and "Strada" with "Hotwire Native" throughout the lesson
- Removes the outdated sentence about Strada being an unreleased framework
- Updates the lesson overview, Hotwire frameworks list, Turbo techniques summary, and section heading/description to reference Hotwire Native

## Issue

Closes #30711 

## Additional Information

This change aligns the curriculum with the current Hotwire documentation. Hotwire Native combines Turbo Native and Strada into a single framework, and Bridge Components (formerly Strada components) are now part of Hotwire Native.



## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
