### PR TITLE
Alignment: Fix Broken Flexbox Guide Link

### DIFF
--- a/foundations/html_css/flexbox/flexbox_alignment.md
+++ b/foundations/html_css/flexbox/flexbox_alignment.md
@@ -61,7 +61,7 @@ Take your time going through the reading. There will be some review of the items
 <div class="lesson-content__panel" markdown="1">
 
 1. This beautiful [Interactive Guide to Flexbox](https://www.joshwcomeau.com/css/interactive-guide-to-flexbox/) covers everything you need to know. It will help reinforce concepts we've already touched on with some really fun and creative examples. Spend some time here, some of it should be review at this point, but the foundations here are important!
-1. The [CSS Tricks "Guide to Flexbox"](https://css-tricks.com/snippets/css/a-guide-to-flexbox/) is a classic. The images and examples are super helpful. It would be a good idea to review parts 1-3 and part 5 (don't worry about the media query parts, we will cover them later in the course) and then bookmark it as a great cheat sheet for future reference (keep it handy for the practice exercises).
+1. The [CSS Tricks "Guide to Flexbox"](https://css-tricks.com/snippets/css/complete-guide-to-css-flexbox-layout/) is a classic. The images and examples are super helpful. It would be a good idea to review parts 1-3 and part 5 (don't worry about the media query parts, we will cover them later in the course) and then bookmark it as a great cheat sheet for future reference (keep it handy for the practice exercises).
 1. Complete [Flexbox Froggy](https://flexboxfroggy.com/), which is a funny little game to practice moving things around with flexbox.
 1. Do the exercises in our [CSS exercises repository's `foundations/flex` directory](https://github.com/TheOdinProject/css-exercises/tree/main/foundations/flex) (remember that the instructions are in the README) in the order:
     - `01-flex-center`


### PR DESCRIPTION
## Because
The CSS-Tricks flexbox guide link was returning a 404 error, preventing students from accessing the resource.

## This PR
- Updates the broken CSS-Tricks flexbox guide URL to the current working link
- Changes from `css-tricks.com/snippets/css/a-guide-to-flexbox/` to `css-tricks.com/snippets/css/complete-guide-to-css-flexbox-layout/`

## Issue
No existing issue - discovered while working through the lesson.

## Additional Information
N/A

## Pull Request Requirements
- [x] I have thoroughly read and understand The Odin Project curriculum contributing guide
- [x] The title of this PR follows the `location of change: brief description of change` format
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If any lesson files are included in this PR, they have been previewed with the Markdown preview tool
- [x] If any lesson files are included in this PR, they follow the Layout Style Guide