### PR TITLE
Advanced Topics lesson: Add PDF download option for SOLID presentation

### DIFF
--- a/ruby_on_rails/mailers_advanced_topics/advanced_topics.md
+++ b/ruby_on_rails/mailers_advanced_topics/advanced_topics.md
@@ -347,7 +347,7 @@ The more general principles like SOLID design and metaprogramming will be useful
   1. Skim the same guide, chapter 4.  Some stuff we've seen but most is just to give you a sense for what's possible.  When you need it, you'll probably Google your way back there.
   1. Read the [Rails Guide on Layouts](http://guides.rubyonrails.org/layouts_and_rendering.html#using-nested-layouts) section 3.5 to see how to pass information between your view file and your layout file, including CSS styles.  Really take a minute to understand what's going on in the example there.
   1. If you're interested, take a peek at [Ruby metaprogramming](https://web.archive.org/web/20210514184321/http://ruby-metaprogramming.rubylearning.com/). It's not essential to building early Rails apps but you'll definitely start running into it more in "the wild".
-  1. Glance through this [Slideshare Presentation on SOLID principles](http://www.slideshare.net/jcfischer/solid-ruby-solid-rails).
+  1. Glance through this [Slideshare Presentation on SOLID principles](http://www.slideshare.net/jcfischer/solid-ruby-solid-rails) or [download the PDF directly](https://github.com/MichaelMahlberg/RailsWayCon2010/blob/master/railswaycon10_SOLID_ruby.pdf) if you prefer.
 
 </div>
 


### PR DESCRIPTION
## Because
The SlideShare website can be slow to load and doesn't provide optimal zoom functionality. Adding a direct PDF download option gives users a faster alternative while maintaining the original SlideShare link for those who prefer it.

## This PR
- Adds PDF download option alongside existing SlideShare link for SOLID principles presentation
- Maintains both options so users can choose their preferred format

## Issue
Closes #30783

## Additional Information
This change provides users with both the original SlideShare presentation and a direct PDF download link, addressing performance concerns while preserving existing functionality.

## Pull Request Requirements
- [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Advanced Topics lesson: Add PDF download option for SOLID presentation`
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
- [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
