### PR TITLE
Forms validations: Replace :valid with mordern :user-valid pseudo-class 

### DIFF
--- a/intermediate_html_css/forms/form_validations.md
+++ b/intermediate_html_css/forms/form_validations.md
@@ -180,7 +180,7 @@ The pattern attribute can only be used on `<input>` elements. Some input element
 
 ### Styling validations
 
-The `:user-valid` and `:user-invalid` pseudo-classes allow targeting form controls that have passed or failed validation, ensuring input fields remain neutral until user interaction. This is presented as an upgrade from `:valid` and `:invalid` pseudo-classes, which often trigger [premature validation](https://0xdezman.hashnode.dev/how-to-fix-form-validation-ux-switching-from-invalid-to-user-invalid) before a user has even finished typing.
+The `:user-valid` and `:user-invalid` pseudo-classes allow targeting form controls that have passed or failed validation, ensuring input fields remain neutral until user interaction.
 
 To see this in action, we will be using our email and website example that we looked at previously:
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
This update fix form premature validation errors common with :valid and :invalid CSS pseudo-classes after page load, by using the modern :user-valid and :user-invalid pseudo-classes.

This ensures users only see validation messages after they finish interacting with a field.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
* Replace `:invalid` with `:user-invalid`.
* Replace `:valid` with `:user-valid`.
* Replace contents of "styling validation" section of the lesson with explantion that fits the newly added pseudo-classes.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/30786

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #30786 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
Someone on the maintainer team need to update the codepen example to use `:user-valid` and `:user-invalid` instead of `:valid` and `:invalid`.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
