### PR TITLE
fix link typo in how_does_the_web_work.md

### DIFF
--- a/foundations/installations/how_does_the_web_work.md
+++ b/foundations/installations/how_does_the_web_work.md
@@ -23,7 +23,7 @@ This section contains a general overview of topics that you will learn in this l
   1. Watch [How the Internet Works in 5 Minutes](https://youtu.be/7_LPdttKXPc?t=46s).
   1. Read up on the [differences between a web page, a web server, and a search engine](https://developer.mozilla.org/en-US/Learn/Common_questions/Pages_sites_servers_and_search_engines).
   1. Watch this [Google short explaining what a web browser is](https://youtu.be/BrXPcaRlBqo). Then, use this site to [find out your current web browser and version](https://www.whatsmybrowser.org/).
-  1. Read about [how different parts of the web interact with each other](https://developer.mozilla.org/en-US/Learn/Getting_started_with_the_web/How_the_Web_works#Clients_and_servers) and read this [MDN article about how a DNS request works](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/Web_mechanics/What_is_a_domain_name#how_does_a_dns_request_work). Alternatively, here is a [video about how a DNS request works](https://www.youtube.com/watch?v=72snZctFFtA&t=45s).
+  1. Read about [how different parts of the web interact with each other](https://developer.mozilla.org/en-US/Learn/Getting_started_with_the_web/How_the_Web_works#clients_and_servers) and read this [MDN article about how a DNS request works](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/Web_mechanics/What_is_a_domain_name#how_does_a_dns_request_work). Alternatively, here is a [video about how a DNS request works](https://www.youtube.com/watch?v=72snZctFFtA&t=45s).
 
 </div>
 


### PR DESCRIPTION
## Because
fix link typo in https://www.theodinproject.com/lessons/foundations-how-does-the-web-work


## This PR

fix typo on link for how different parts of the web interact with each other under [assignment section](https://www.theodinproject.com/lessons/foundations-how-does-the-web-work#assignment)



## Pull Request Requirements

-   [x ] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x ] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [ x] The `Because` section summarizes the reason for this PR
-   [ x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
