### PR TITLE
React Intro: Remove additional resources

### DIFF
--- a/react/getting_started_with_react/react_components.md
+++ b/react/getting_started_with_react/react_components.md
@@ -91,4 +91,3 @@ The following questions are an opportunity to reflect on key topics in this less
 - [What does a React element look like?](#what-are-components)
 - [How would you create a functional component?](#how-to-create-components)
 - [How do you export and then import a component?](#where-do-components-live)
-

--- a/react/introduction/introduction_to_react.md
+++ b/react/introduction/introduction_to_react.md
@@ -54,4 +54,3 @@ The following questions are an opportunity to reflect on key topics in this less
 
 - [What is the purpose of React?](#what-is-react)
 - [What are the benefits of using React?](#why-cover-react)
-

--- a/react/introduction/setting_up_a_react_environment.md
+++ b/react/introduction/setting_up_a_react_environment.md
@@ -149,4 +149,3 @@ The following questions are an opportunity to reflect on key topics in this less
 - [What is in the `public` folder?](#delving-deeper)
 - [What is in the `src` folder?](#delving-deeper)
 - [Why are the React Developer Tools useful?](#developer-tools)
-


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
This PR addresses GitHub issue #30916 which requests the removal of Additional resources sections from React Introduction lessons. The changes streamline the curriculum by removing supplemental content to focus students on core lesson material.

## This PR
- Removed the entire "Additional resources" section from Introduction to React lesson
- Removed the entire "Additional resources" section from Setting Up a React Environment lesson  
- Removed the entire "Additional resources" section from React Components lesson

## Issue
Closes #30916

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text` 
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)