### PR TITLE
fix: Remove additional resources section from Using Ruby on Rails for Your Backend lesson

### DIFF
--- a/react/react_and_the_backend/using_ruby_on_rails_for_your_backend.md
+++ b/react/react_and_the_backend/using_ruby_on_rails_for_your_backend.md
@@ -34,11 +34,3 @@ The following questions are an opportunity to reflect on key topics in this less
 
 - [What possibilities exist to connect a React frontend with a Rails backend?](https://thoughtbot.com/blog/how-to-integrate-react-rails)
 - [How do you integrate React with Rails using esbuild?](https://www.digitalocean.com/community/tutorials/how-to-set-up-a-ruby-on-rails-v7-project-with-a-react-frontend-on-ubuntu-20-04#step-3-installing-frontend-dependencies)
-
-### Additional resources
-
-This section contains helpful links to related content. It isn't required, so consider it supplemental.
-
-- [Broaden your knowledge about AJAX requests by skimming working with JavaScript in rails article from RailsGuides](https://guides.rubyonrails.org/v6.1/working_with_javascript_in_rails.html)
-- [Grabbing your Rails form CSRF token with JavaScript so Rails doesn't yell at you with "Warning, can't verify CSRF token authenticity", via SO](http://stackoverflow.com/questions/7203304/warning-cant-verify-csrf-token-authenticity-rails)
-- [... and another SO post on the CSRF token](http://stackoverflow.com/questions/8503447/rails-how-to-add-csrf-protection-to-forms-created-in-javascript)


### PR DESCRIPTION
## Because

The additional resources in the "Using Ruby on Rails for Your Backend" lesson have been evaluated and are no longer needed as part of the broader React additional resources cleanup initiative.

## This PR

- Remove the entire "Additional resources" section from the Using Ruby on Rails for Your Backend lesson

## Issue

Closes #30920

## Additional Information

N/A

## Pull Request Requirements

- [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
- [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
