### PR TITLE
Git Basics lesson: Fix Capitalization of 'VS Code'

### DIFF
--- a/git/foundations_git/git_basics.md
+++ b/git/foundations_git/git_basics.md
@@ -74,7 +74,7 @@ This section contains a general overview of topics that you will learn in this l
 
    MacOS users: If your terminal reads *"command not found: code"*, you must head back to [Command Line Basics](https://www.theodinproject.com/lessons/foundations-command-line-basics#opening-files-in-vscode-from-the-command-line) and follow the instructions provided to allow this command to work.
 
-1. Add "Hello Odin!" to a new line in `README.md` and save the file with <kbd>Ctrl</kbd> + <kbd>S</kbd> (Mac: <kbd>Cmd</kbd> + <kbd>S</kbd>) if your vs code is not auto saving changes.
+1. Add "Hello Odin!" to a new line in `README.md` and save the file with <kbd>Ctrl</kbd> + <kbd>S</kbd> (Mac: <kbd>Cmd</kbd> + <kbd>S</kbd>) if your VS Code is not auto saving changes.
 
 1. Go back to your terminal, or if you're using Visual Studio Code, open the built-in terminal by pressing <kbd>Ctrl</kbd> + <kbd>&#96;</kbd> (backtick). Then type `git status`. Notice how the output is similar to when we created our `hello_world.txt` file before adding it to the staging area, except the `README.md` file is listed in a section titled "Changes not staged for commit". The meaning is similar to the "Untracked files" section in that the file is not yet added to the staging area.
 


### PR DESCRIPTION
This PR fixes a small capitalization issue in the Foundations course lesson "Git Basics" where "VS Code" was written in all lowercase and it was fixed to be written in its normal capitalized form.

-   [X] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [X] The `Because` section summarizes the reason for this PR
-   [X] The `This PR` section has a bullet point list describing the changes in this PR
-   [X] If this PR addresses an open issue, it is linked in the `Issue` section
-   [X] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [X] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
