### PR TITLE
Fix grammatical errors in Rails testing lessons

### DIFF
--- a/ruby_on_rails/testing/model_testing.md
+++ b/ruby_on_rails/testing/model_testing.md
@@ -12,7 +12,7 @@ This section contains a general overview of topics that you will learn in this l
 
 ### What are model tests?
 
-A model test is a unit test in the context of Ruby on Rails. When testing our models we usually want to focus on testing the business logic. Essentially what goes on behind each model that enables the user experience to work correctly. This could mean ensuring promotion tickets prices are correct, only correct form data is accepted, custom user verification etc. It's important to note that each model should have it's own file in the `spec/models` file. This is helpful for keeping your model tests organized and readable.
+A model test is a unit test in the context of Ruby on Rails. When testing our models we usually want to focus on testing the business logic. Essentially what goes on behind each model that enables the user experience to work correctly. This could mean ensuring promotion tickets prices are correct, only correct form data is accepted, custom user verification etc. It's important to note that each model should have its own file in the `spec/models` directory. This is helpful for keeping your model tests organized and readable.
 
 ### Setting the test
 

--- a/ruby_on_rails/testing/unit_testing.md
+++ b/ruby_on_rails/testing/unit_testing.md
@@ -14,7 +14,7 @@ This section contains a general overview of topics that you will learn in this l
 
 A unit test is testing a single unit of code to ensure that method/unit works as it is supposed to! In Ruby on Rails your models are one of the areas that should be covered with unit tests. These model tests specifically are used to test the logic behind your model objects. This can include validating user inputs from form submissions and other logic between models. Such as if you need to ensure your object method for generating discounts work properly. It's important as you scale your projects to ensure that the logic behind your models works as your project consistently expands. This helps make the project more maintainable as the tests provide a safety net to ensure existing functionality continues working as expected when models need to be expanded or modified.
 
-Earlier you used RSpec for testing projects in the Ruby section. While Ruby on Rails comes with it's own testing framework. RSpec is a very popular framework for testing even in Ruby on Rail's. As such we will be using RSpec for the Ruby on Rails testing section.
+Earlier you used RSpec for testing projects in the Ruby section. While Ruby on Rails comes with its own testing framework, RSpec is a very popular framework for testing even in Ruby on Rails. As such we will be using RSpec for the Ruby on Rails testing section.
 
 ### Setting up RSpec
 
@@ -34,7 +34,7 @@ There you will find different folders for different areas of your application su
 
 ### Example test
 
-Each model should have it's own spec file within the spec/models folder. This will be created when you use the following command.
+Each model should have its own spec file within the spec/models folder. This will be created when you use the following command.
 
 ```bash
 rails generate model <model_name>


### PR DESCRIPTION
This PR fixes a few minor grammatical errors in the Ruby on Rails testing lessons:
- Fixed incorrect usage of \it's\ instead of \its\ in \unit_testing.md\ and \model_testing.md\
- Fixed incorrect \Ruby on Rail's\ to \Ruby on Rails\
- Fixed \in the spec/models file\ to \in the spec/models directory\ for correctness.