### PR TITLE
join_the_odin_community lesson: fix typo in community text

### DIFF
--- a/foundations/introduction/join_the_odin_community.md
+++ b/foundations/introduction/join_the_odin_community.md
@@ -6,7 +6,7 @@ Working and collaborating with other people is an important part of working as a
 
 This section contains a general overview of topics that you will learn in this lesson.
 
-- Learn about The Odin's community and how to join it.
+- Learn about The Odin Project's community and how to join it.
 - Explain how to ask good and detailed questions.
 - Explain good practices for helping others with their questions.
 


### PR DESCRIPTION
## Because
The phrase "join The Odin's community" is grammatically incorrect and inconsistent with the project’s name.


## This PR
- Fixes the typo on the join_the_odin_community page
- Updates the text to "join The Odin Project's community"


## Issue
Closes #30952

## Additional Information
This is a minor typo fix.


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
