### PR TITLE
Fix typo in block_and_inline lesson

### DIFF
--- a/foundations/html_css/css_foundations/block_and_inline.md
+++ b/foundations/html_css/css_foundations/block_and_inline.md
@@ -13,7 +13,7 @@ This section contains a general overview of topics that you will learn in this l
 
 ### Block vs inline
 
-Most of the elements that you have learned about so far are block elements.  In other words, their default style is `display: block`. <span id="block-inline-difference"></span>By default, block elements will appear on the page stacked stacked on top of each other, each new element starting on a new line.
+Most of the elements that you have learned about so far are block elements.  In other words, their default style is `display: block`. <span id="block-inline-difference"></span>By default, block elements will appear on the page stacked on top of each other, each new element starting on a new line.
 
 Inline elements, however, do not start on a new line. They appear in line with whatever elements they are placed beside. A clear example of an inline element is a link, or `<a>` tag. If you stick one of these in the middle of a paragraph of text, [the link will behave like a part of the paragraph](https://www.youtube.com/watch?v=dQw4w9WgXcQ). Additionally, padding and margin behave differently on inline elements. In general, you do not want to try to put extra padding or margin on inline elements.
 

--- a/foundations/html_css/css_foundations/block_and_inline.md
+++ b/foundations/html_css/css_foundations/block_and_inline.md
@@ -13,7 +13,7 @@ This section contains a general overview of topics that you will learn in this l
 
 ### Block vs inline
 
-Most of the elements that you have learned about so far are block elements.  In other words, their default style is `display: block`. <span id="block-inline-difference"></span>By default, block elements will appear on the page stacked atop each other, each new element starting on a new line.
+Most of the elements that you have learned about so far are block elements.  In other words, their default style is `display: block`. <span id="block-inline-difference"></span>By default, block elements will appear on the page stacked stacked on top of each other, each new element starting on a new line.
 
 Inline elements, however, do not start on a new line. They appear in line with whatever elements they are placed beside. A clear example of an inline element is a link, or `<a>` tag. If you stick one of these in the middle of a paragraph of text, [the link will behave like a part of the paragraph](https://www.youtube.com/watch?v=dQw4w9WgXcQ). Additionally, padding and margin behave differently on inline elements. In general, you do not want to try to put extra padding or margin on inline elements.
 


### PR DESCRIPTION
Because
Fix typo in The Odin Project curriculum block_and_inline lesson. Improves clarity in sentence describing block elements stacking behavior.

This PR

Replace “atop each other” with “on top of each other” in foundations/html_css/css_foundations/block_and_inline.md

Pull Request Requirements

[x] I have thoroughly read and understand The Odin Project curriculum contributing guide
[ ] The title of this PR follows the location of change: brief description of change format
[x] The Because section summarizes the reason for this PR
[x] The This PR section has a bullet point list describing the changes in this PR
[ ] If this PR addresses an open issue, it is linked in the Issue section
[x] If any lesson files are included in this PR, they have been previewed with the Markdown preview tool
[x] If any lesson files are included in this PR, they follow the Layout Style Guide



