### PR TITLE
Ruby: Linting and RuboCop - Replace broken link to current plugins page

### DIFF
--- a/ruby/object_oriented_programming_basics/linting_and_rubocop.md
+++ b/ruby/object_oriented_programming_basics/linting_and_rubocop.md
@@ -174,7 +174,7 @@ The latter means that while your code and the proposed code arrive at the same o
 
 Due to Ruby's ecosystem, <span id="configure-rubocop">RuboCop was built with extensive configurability in mind - both in terms of not using some parts of and in terms of adding onto it.</span> Every single Cop can be disabled, sometimes Cops offer alternative rules like preferring single- or double-quotes for Strings, you can disable Cops on a per-file basis and much more.
 
-Since [RuboCop is extensible](https://docs.rubocop.org/rubocop/extensions.html), there exist other departments that you can use - like Performance or RSpec. You could even write your own Cop! The process of adding an extension is easy. Suppose you wanted to add the `rubocop-performance` Gem to your project. You first install the Gem locally from the command line:
+Since [RuboCop is extensible](https://docs.rubocop.org/rubocop/latest/plugins.html), there exist other departments that you can use - like Performance or RSpec. You could even write your own Cop! The process of adding an extension is easy. Suppose you wanted to add the `rubocop-performance` Gem to your project. You first install the Gem locally from the command line:
 
 ```bash
 gem install rubocop-performance


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The original [extensions page](https://docs.rubocop.org/rubocop/extensions.html) destination does not work.
The new link redirects to the current [plugins page](https://docs.rubocop.org/rubocop/latest/plugins.html) which is how current Rubocop versions handle extensions.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Replaces https://docs.rubocop.org/rubocop/extensions.html with https://docs.rubocop.org/rubocop/latest/plugins.html

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #31003

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
