### PR TITLE
Browser Compatibility lesson: Fix assignment list to ordered

### DIFF
--- a/intermediate_html_css/intermediate_css_concepts/browser_compatibility.md
+++ b/intermediate_html_css/intermediate_css_concepts/browser_compatibility.md
@@ -64,8 +64,8 @@ It's important to remember that mobile browsers are not one-to-one with their de
 
 <div class="lesson-content__panel" markdown="1">
 
-- Review [Can I Use](https://caniuse.com/). Are all technologies you have encountered so far supported by popular browsers?
-- Read this article [about browsers on iOS](https://adactio.com/journal/17428).
+1. Review [Can I Use](https://caniuse.com/). Are all technologies you have encountered so far supported by popular browsers?
+1. Read this article [about browsers on iOS](https://adactio.com/journal/17428).
 
 </div>
 


### PR DESCRIPTION
## Because
The assignment section in the browser compatibility lesson uses an unordered list (`- `) instead of an ordered list (`1. `), which is inconsistent with other lessons and the style guide.

## This PR
- Changed the assignment list from unordered (`- `) to ordered (`1. `) in the browser compatibility lesson

## Issue
Closes #31033

## Additional Information
N/A

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)