### PR TITLE
Foundations Installations lesson: Fix missing 'for' in Linux distro support sentence

### DIFF
--- a/foundations/installations/installations.md
+++ b/foundations/installations/installations.md
@@ -25,7 +25,7 @@ If you're using a Mac, you're in great shape. The Odin Project instructions assu
 
 [Linux](https://en.wikipedia.org/wiki/Linux) is a free and open-source operating system that works well with all programming languages. Most development tools are written to work natively with Linux. Your tools will likely be updated more often, have more information available for troubleshooting, and just plain run better on Linux.
 
-In order to improve the availability of help in our community, we limit our supported Linux distros to Ubuntu and official flavours of Ubuntu only. This means we do not provide support any other distros, including ones "based on Ubuntu or Debian" (like Mint, Pop!_OS etc.).
+In order to improve the availability of help in our community, we limit our supported Linux distros to Ubuntu and official flavours of Ubuntu only. This means we do not provide support for any other distros, including ones "based on Ubuntu or Debian" (like Mint, Pop!_OS etc.).
 
 We support the following methods of running Linux (instructions for these are in the assignment section below):
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
The sentence "This means we do not provide support any other distros" was missing the word "for", making it grammatically incorrect.

## This PR
- Adds missing word "for" to the Linux distro support sentence in the Installations lesson

## Issue
Closes #31075

## Additional Information
N/A


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
