### PR TITLE
WAI-ARIA lesson: fix aria-hidden quote mismatch

### DIFF
--- a/advanced_html_css/accessibility/wai_aria.md
+++ b/advanced_html_css/accessibility/wai_aria.md
@@ -139,7 +139,7 @@ Similar to how you can visually hide elements with the `hidden` HTML attribute o
 
 While both of the above examples would look visually identical, the button in Example 1 would be announced by a screen reader as, "Add add book, button". The text content of the `<span>` and the text content of the button itself are concatenated as the accessible name of the button. The button in Example 2, however, hides the `<span>` from the accessibility tree so its text content *isn't* added to the button's accessible name, meaning a screen reader would correctly announce "Add book, button".
 
-Be careful when using this attribute, though. When you give an element `aria-hidden="true"`, all children of that element will also become hidden to the accessibility tree. Adding `aria-hidden="false"` to a child element won't have any effect if one of its parents still has `aria-hidden="true'`, either.
+Be careful when using this attribute, though. When you give an element `aria-hidden="true"`, all children of that element will also become hidden to the accessibility tree. Adding `aria-hidden="false"` to a child element won't have any effect if one of its parents still has `aria-hidden="true"`, either.
 
 You should also be careful not to give an element `aria-hidden="true"` if it is focusable. Doing so would cause nothing to be announced when the element receives focus, which would confuse users that use a screen reader and navigate the page via a keyboard.
 


### PR DESCRIPTION
## Summary

Closes #31092. The WAI-ARIA lesson at `advanced_html_css/accessibility/wai_aria.md:142` closed an `aria-hidden="true"` example with a single apostrophe (`true'`) instead of a matching double quote. The same paragraph uses `aria-hidden="true"` and `aria-hidden="false"` with paired double quotes everywhere else, so the apostrophe was a slip rather than intentional formatting.

## Why this matters

The lesson is the WAI-ARIA module's primary reference for the `aria-hidden` attribute, and #31092 was filed by a student who hit the mismatched quote in the second-to-last paragraph. For learners following along by copy-pasting, the apostrophe variant is invalid HTML, so leaving it would teach a syntax-breaking pattern.

## Because

Mismatched HTML attribute quoting in the lesson's example confuses readers and won't parse if pasted into a real document.

## This PR

- `advanced_html_css/accessibility/wai_aria.md:142` - `aria-hidden="true'` -> `aria-hidden="true"` (closing apostrophe replaced with the matching double quote).

## Issue

Closes #31092

## Additional Information

Diff is a single character. The surrounding sentence and code samples are unchanged.

## Pull Request Requirements

- [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format.

AI-assisted.
