### PR TITLE
nodejs-routes lesson: remove "Express v5 Changes" note

### DIFF
--- a/nodeJS/express/routing.md
+++ b/nodeJS/express/routing.md
@@ -218,12 +218,6 @@ To test these routes, use [Postman](https://www.postman.com/downloads/) which wi
 
 <div class="lesson-note" markdown="1">
 
-#### Express v5 changes
-
-We are currently using Express v5 and as of writing this, some of the sections in the article below will not work in v5, though they are clearly marked and links provided to more relevant documentation.
-
-This resource will be updated once a v5-only routing primer exists.
-
 </div>
 
 1. Read through the Express' [primer on Routing](https://expressjs.com/en/guide/routing.html) for an overview of this lesson's topics. Remember to reference the [Express documentation](https://expressjs.com/en/api.html) for more information on specific methods.

--- a/nodeJS/express/routing.md
+++ b/nodeJS/express/routing.md
@@ -216,10 +216,6 @@ To test these routes, use [Postman](https://www.postman.com/downloads/) which wi
 
 <div class="lesson-content__panel" markdown="1">
 
-<div class="lesson-note" markdown="1">
-
-</div>
-
 1. Read through the Express' [primer on Routing](https://expressjs.com/en/guide/routing.html) for an overview of this lesson's topics. Remember to reference the [Express documentation](https://expressjs.com/en/api.html) for more information on specific methods.
 
 </div>


### PR DESCRIPTION
## Because
Express docs have been properly updated to version 5 making the Note on [Express v5 changes](https://www.theodinproject.com/lessons/nodejs-routes#express-v5-changes) unnecessary.

## This PR
- Removes the [Express v5 changes](https://www.theodinproject.com/lessons/nodejs-routes#express-v5-changes) note from the [nodejs-routes](https://www.theodinproject.com/lessons/nodejs-routes) lesson.

## Issue
Closes #31101

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section