### PR TITLE
Note about new css features

### DIFF
--- a/intermediate_html_css/forms/form_basics.md
+++ b/intermediate_html_css/forms/form_basics.md
@@ -506,7 +506,8 @@ Certain aspects of other elements are downright impossible to style, for example
 #### Styling forms
 
  1. Read and follow along with [MDN's Form Styling Tutorials](https://developer.mozilla.org/en-US/docs/Learn/Forms#form_styling_tutorials). You can skip the "Customizable select elements" and "Customizable select listbox" tutorials, as they rely on very new CSS features that are not yet supported across many browsers.
- 1. Read and follow along with [the internetingishard guide to forms](https://internetingishard.netlify.app/html-and-css/forms/index.html).
+1. Read and follow along with [MDN's Form Styling Tutorials](https://developer.mozilla.org/en-US/docs/Learn/Forms#form_styling_tutorials). You can skip the "Customizable select elements" and "Customizable select listbox" tutorials, as they rely on very new CSS features that are not yet supported across many browsers.
+1. Read and follow along with [the internetingishard guide to forms](https://internetingishard.netlify.app/html-and-css/forms/index.html).
 
 </div>
 

--- a/intermediate_html_css/forms/form_basics.md
+++ b/intermediate_html_css/forms/form_basics.md
@@ -508,6 +508,8 @@ Certain aspects of other elements are downright impossible to style, for example
 1. Read and follow along with [MDN's Form Styling Tutorials](https://developer.mozilla.org/en-US/docs/Learn/Forms#form_styling_tutorials)
 1. Read and follow along with [the internetingishard guide to forms](https://internetingishard.netlify.app/html-and-css/forms/index.html)
 
+In these tutorials please skip the "Customizable select elements" and "Customizable select listbox" tutorials for now, as they rely on very new CSS features that are not yet widely supported across many browsers.
+
 </div>
 
 ### Knowledge check

--- a/intermediate_html_css/forms/form_basics.md
+++ b/intermediate_html_css/forms/form_basics.md
@@ -506,7 +506,6 @@ Certain aspects of other elements are downright impossible to style, for example
 #### Styling forms
 
 1. Read and follow along with [MDN's Form Styling Tutorials](https://developer.mozilla.org/en-US/docs/Learn/Forms#form_styling_tutorials). You can skip the "Customizable select elements" and "Customizable select listbox" tutorials, as they rely on very new CSS features that are not yet supported across many browsers.
-1. Read and follow along with [MDN's Form Styling Tutorials](https://developer.mozilla.org/en-US/docs/Learn/Forms#form_styling_tutorials). You can skip the "Customizable select elements" and "Customizable select listbox" tutorials, as they rely on very new CSS features that are not yet supported across many browsers.
 1. Read and follow along with [the internetingishard guide to forms](https://internetingishard.netlify.app/html-and-css/forms/index.html).
 
 </div>

--- a/intermediate_html_css/forms/form_basics.md
+++ b/intermediate_html_css/forms/form_basics.md
@@ -505,10 +505,8 @@ Certain aspects of other elements are downright impossible to style, for example
 
 #### Styling forms
 
-1. Read and follow along with [MDN's Form Styling Tutorials](https://developer.mozilla.org/en-US/docs/Learn/Forms#form_styling_tutorials)
-1. Read and follow along with [the internetingishard guide to forms](https://internetingishard.netlify.app/html-and-css/forms/index.html)
-
-In these tutorials please skip the "Customizable select elements" and "Customizable select listbox" tutorials for now, as they rely on very new CSS features that are not yet widely supported across many browsers.
+ 1. Read and follow along with [MDN's Form Styling Tutorials](https://developer.mozilla.org/en-US/docs/Learn/Forms#form_styling_tutorials). You can skip the "Customizable select elements" and "Customizable select listbox" tutorials, as they rely on very new CSS features that are not yet supported across many browsers.
+ 1. Read and follow along with [the internetingishard guide to forms](https://internetingishard.netlify.app/html-and-css/forms/index.html).
 
 </div>
 

--- a/intermediate_html_css/forms/form_basics.md
+++ b/intermediate_html_css/forms/form_basics.md
@@ -505,7 +505,7 @@ Certain aspects of other elements are downright impossible to style, for example
 
 #### Styling forms
 
- 1. Read and follow along with [MDN's Form Styling Tutorials](https://developer.mozilla.org/en-US/docs/Learn/Forms#form_styling_tutorials). You can skip the "Customizable select elements" and "Customizable select listbox" tutorials, as they rely on very new CSS features that are not yet supported across many browsers.
+1. Read and follow along with [MDN's Form Styling Tutorials](https://developer.mozilla.org/en-US/docs/Learn/Forms#form_styling_tutorials). You can skip the "Customizable select elements" and "Customizable select listbox" tutorials, as they rely on very new CSS features that are not yet supported across many browsers.
 1. Read and follow along with [MDN's Form Styling Tutorials](https://developer.mozilla.org/en-US/docs/Learn/Forms#form_styling_tutorials). You can skip the "Customizable select elements" and "Customizable select listbox" tutorials, as they rely on very new CSS features that are not yet supported across many browsers.
 1. Read and follow along with [the internetingishard guide to forms](https://internetingishard.netlify.app/html-and-css/forms/index.html).
 


### PR DESCRIPTION
Because

Two tutorials linked in the MDN Form Styling Tutorials section rely on very new CSS features that are not yet widely supported across browsers. Learners should be informed to skip those tutorials for now to avoid confusion or compatibility issues.

This PR
Updates the instructions in intermediate_html_css/forms/form_basics.md
Clarifies that learners should skip the "Customizable select elements" and "Customizable select listbox" tutorials for now due to limited browser support
Issue

Closes #31106