### PR TITLE
Motivation and Mindset: Remove the section on growth mindset

### DIFF
--- a/foundations/introduction/motivation_and_mindset.md
+++ b/foundations/introduction/motivation_and_mindset.md
@@ -22,7 +22,6 @@ Take a moment to think about why you have decided to learn programming.
 
 Your motivation could be a combination of these reasons or something else entirely. Whatever it is, hold on tightly to your motivation - this will be what pulls you through to the end of this journey, giving you a definitive goal to aim towards.
 
-
 ### The learning process
 
 Learning concepts and then practicing them will help you to more fully understand how things work and fit together. Projects are the ultimate method for ensuring that your theoretical understanding aligns with how the programming concepts and techniques actually operate.

--- a/foundations/introduction/motivation_and_mindset.md
+++ b/foundations/introduction/motivation_and_mindset.md
@@ -8,7 +8,6 @@ So before we get into the meat of the curriculum, we'll cover the following aspe
 
 This section contains a general overview of topics that you will learn in this lesson.
 
-- Recognize sensible mindsets that promote healthy learning.
 - Understand helpful ways to approach learning and struggling.
 - Things to avoid along your learning journey with TOP.
 
@@ -23,21 +22,6 @@ Take a moment to think about why you have decided to learn programming.
 
 Your motivation could be a combination of these reasons or something else entirely. Whatever it is, hold on tightly to your motivation - this will be what pulls you through to the end of this journey, giving you a definitive goal to aim towards.
 
-### Growth mindset
-
-Your mindset is very important when teaching yourself *any* new skills, not just programming. Your mindset will have more of an impact on your chances of success than just about anything else.
-
-Someone with the **fixed mindset** believes if they don't get something on their first attempt, they never will. They believe that they aren't smart enough to be able to do or understand some things.
-
-However, there is a wide body of research showing that intelligence is not fixed but can instead be developed. Someone with the **growth mindset** believes they can get better at anything with effort and persistence.
-
-What does this mean for you? It means you can learn new skills and develop new talents with **persistence and grit**.
-
-There will be many times throughout The Odin Project that you will get stuck on a concept or a programming problem and may find yourself questioning your ability to learn programming. When you find yourself in this position, remind yourself that you may not get it *yet* but that with persistence and grit you will. Struggling with something is growth. It doesn't matter how long you struggle with a concept or project; all that matters is that you have the grit and tenacity to see it through. That's how real learning happens.
-
-While you're working through the curriculum, embrace the struggles you encounter with difficult concepts and complex projects. Be sure to celebrate your persistence in overcoming those struggles!
-
-When you find yourself questioning your abilities, reflect on the successes you have already achieved while learning to program: the projects you have completed and the concepts you once didn't understand but now do. This is all the proof you need that you can do it.
 
 ### The learning process
 
@@ -176,10 +160,6 @@ Learning any new skill is a journey full of speed bumps and obstacles to overcom
 
 1. Have a look at how to [become a TOP Success Story](https://dev.to/theodinproject/becoming-a-top-success-story-mindset-3dp2)!
 1. Once you join the TOP Discord server, give your motivation a bit of a boost! Read about the success of others in the [TOP Discord server's Success Stories forum](https://discord.com/channels/505093832157691914/1089990025162260570).
-1. To learn more about the growth mindset, go through the following resources:
-   - [You can learn anything](https://www.khanacademy.org/college-careers-more/talks-and-interviews/talks-and-interviews-unit/conversations-with-sal/a/the-learning-myth-why-ill-never-tell-my-son-hes-smart)
-   - [Grit](https://ted.com/talks/angela_lee_duckworth_grit_the_power_of_passion_and_perseverance)
-   - [Believe you can get better](https://www.ted.com/talks/carol_dweck_the_power_of_believing_that_you_can_improve)
 
 </div>
 
@@ -187,8 +167,6 @@ Learning any new skill is a journey full of speed bumps and obstacles to overcom
 
 The following questions are an opportunity to reflect on key topics in this lesson. If you can't answer a question, click on it to review the material, but keep in mind you are not expected to memorize or master this knowledge.
 
-- [What is the key difference between a fixed mindset and a growth mindset when encountering programming challenges?](#growth-mindset)
 - [What are the two modes your mind switches between during the learning process, and how do they differ?](#the-learning-process)
 - [When you're stuck on a programming problem, what three main strategies does the curriculum recommend trying?](#what-to-do-when-youre-stuck)
 - [Why does the curriculum recommend against setting strict deadlines for completing The Odin Project?](#managing-your-study-time)
-- [How does Angela Duckworth define "grit" in her TED talk, and why is it important for learning to code?](#assignment)


### PR DESCRIPTION
## Because
The Growth Mindset section uses vague, self-help-style language that research suggests has limited practical impact on learners. Removing it simplifies the lesson without losing substantive guidance. See the linked issue for the full discussion.

## This PR
- Removed the Growth Mindset section
- Removed the Growth Mindset's associated resources and assignment


## Issue
Closes #30942

## Additional Information
The lesson title has been left unchanged. "mindset" in the title can carry a general meaning (how we approach learning), not necessarily referring to the specific Growth Mindset concept coined by Carol Dweck.


## Pull Request Requirements
- [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
- [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)