### PR TITLE
Ruby on Rails: Sessions Cookies and Authentication: Fix link to documentation section

### DIFF
--- a/ruby_on_rails/forms_and_authentication/sessions_cookies_authentication.md
+++ b/ruby_on_rails/forms_and_authentication/sessions_cookies_authentication.md
@@ -184,7 +184,7 @@ Configuration will be dependent on your use case.  Do you want to make the user 
 
 1. Read this article about [how Rails sessions work](https://www.justinweiss.com/articles/how-rails-sessions-work/).
 1. Watch this video to [dive deep into sessions](https://www.youtube.com/watch?v=mqUbnZIY3OQ).
-1. Read sections 5 and 6 of the [Rails Guides on Controllers](http://guides.rubyonrails.org/action_controller_overview.html#session).  Don't worry too much about the details of `session_store` configurations in 5.1 right now.
+1. Read sections 5 and 6 of the [Rails Guides on Controllers](http://guides.rubyonrails.org/action_controller_overview.html#cookies).  Don't worry too much about the details of `session_store` configurations in 5.1 right now.
 1. Read section 7 of the [Rails Guides on Controllers](https://guides.rubyonrails.org/action_controller_overview.html#controller-callbacks) to understand controller filters.
 1. Read section 4 of the [Rails Guides on Controller Advanced Topics](https://guides.rubyonrails.org/action_controller_advanced_topics.html#http-authentication) to understand more about authentication.
 1. Glance over the [Devise Documentation](https://github.com/plataformatec/devise). Read about how to install it in your Rails App and what the different modules do.  You'll be using it with upcoming projects.


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
This PR updates a link to the Rails docs to point to the right section. The reader is instructed to go through chapters 5 and 6 of a certain page of the docs, but the link points to the 6th rather than the 5th.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- I updated the link in the assignment section of the Session Cookies and Authentication lesson in the Ruby on Rails path.

## Issue
None.

## Additional Information
None.


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [X] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [X] The `Because` section summarizes the reason for this PR
-   [X] The `This PR` section has a bullet point list describing the changes in this PR
-   [X] If this PR addresses an open issue, it is linked in the `Issue` section
-   [X] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [X] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
