### PR TITLE
GH Actions: Add auto-comment workflow for single pathway CS lesson changes

### DIFF
--- a/.github/workflows/edits_to_duplicated_lessons.yml
+++ b/.github/workflows/edits_to_duplicated_lessons.yml
@@ -1,0 +1,59 @@
+name: Auto Comment
+on:
+  pull_request:
+    types:
+      - opened
+    paths:
+      - "**/computer_science/**"
+
+jobs:
+  cs-auto-comment:
+    name: Remind about duplicated CS lessons
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Get changed CS files
+        uses: tj-actions/changed-files@v47
+        id: changed-files
+        with:
+          files: |
+            **/computer_science/**
+          separator: " "
+
+      - name: Check for unduplicated changes
+        id: change-duplication
+        env:
+          CHANGED_CS_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          changed_cs_files=($CHANGED_CS_FILES)
+          changed_js_count=0
+          changed_ruby_count=0
+
+          for filepath in "${changed_cs_files[@]}"; do
+            if [[ $filepath == *javascript/* ]]; then
+              (( changed_js_count+=1 ))
+            elif [[ $filepath == *ruby/* ]]; then
+              (( changed_ruby_count+=1 ))
+            fi
+          done
+
+          (( $changed_js_count == $changed_ruby_count )) && all_duplicated=true || all_duplicated=false
+          echo "all_duplicated=${all_duplicated}" >> $GITHUB_OUTPUT
+
+      - name: Comment if unduplicated changes
+        if: steps.change-duplication.outputs.all_duplicated == 'false'
+        run: |
+          GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          REPO=${{ github.repository }}
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          COMMENT="The computer science lessons have their own files for the JavaScript and Ruby pathways. It looks like you've made changes to a lesson for one pathway without also making changes to its twin in the other pathway.\n\nCheck if your changes are only needed for the one pathway, otherwise please make the equivalent changes to the other pathway's lesson file(s) as well."
+
+          curl -s \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2026-03-10" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            "https://api.github.com/repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            -d "{\"body\":\"${COMMENT}\"}"
+


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
We have JS and Ruby versions of all the CS content and it's very easy for people to forget this when they make or review CS changes. While not all changes will need to be made to both versions of a lesson, it'll help to automatically remind people if they open a PR where CS changes aren't duplicated (on open only, no need to remind on every push...would be dreadfully annoying). I'd wager if this happens, more times than not it'll be a mistake rather than intentionally only needing a single pathway change.

The check logic is naive - doesn't actually check individual lessons, only whether the changed lesson counts for JS CS and Ruby CS match. Don't think we need more complex logic for less naive checking.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds auto-comment GHA workflow

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
N/A

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
Example PRs:
- Auto comment when PR opened with unduplicated CS changes: https://github.com/mao-sz/curriculum/pull/15 
- No auto comment when PR opened with duplicated CS changes: https://github.com/mao-sz/curriculum/pull/16
- Proof of ignoring non-CS changes: https://github.com/mao-sz/curriculum/pull/17

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
