### PR TITLE
Transforms: Change composite transforms to left-to-right order

### DIFF
--- a/advanced_html_css/animation/transforms.md
+++ b/advanced_html_css/animation/transforms.md
@@ -157,9 +157,7 @@ on <a href="https://codepen.io">CodePen</a>.</span>
 
 <script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
 
-If you guessed correctly, congratulations! But this is a tricky concept. MDN's transform docs state that "[composite transforms are effectively applied in order from right to left](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#values)".
-
-The blue box rotates 45 degrees on the spot, then translates on the X axis by 200%, moving it directly to the right. The red box translates by 200% first, so moves to the right, but the transform origin is still where it used to be. Therefore, it rotates 45 degrees around that original point, making the red box "swing down" to end up diagonally from where it started.
+If you guessed correctly, congratulations! The blue box translates on the X axis by 200%, moving it directly to the right, then rotates in place by 45 degrees. The red box rotates by 45 degrees first, then translates on the now-rotated X axis by 200%, moving it to the bottom-right.
 
 While you can generally chain multiple transforms in any order for various results, there is one exception: `perspective`. This brings us nicely to the next section where `perspective` is involved.
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Composite transform order has long confused learners because the original wording of the MDN Transform docs was
> The transform functions are multiplied in order from left to right, meaning that composite transforms are effectively applied in order from right to left.

This right-to-left order was backed by other doc pages (like for `animation-composition`).

Reading left-to-right, each transform establishes a new coordinate space as a result. Technically, it can be read right-to-left which requires retaining the parent coordinate space across the transforms. According to the CSS spec, both orders are viable depending on which exact part of the underlying process you're dealing with. The MDN docs were confusing because they talk about and switch between both perspectives without saying or explaining, so things seem almost contradictory.

When https://github.com/mdn/content/pull/43496 is merged and the changes are live (~~will undraft this PR once it is~~ now merged), the Transform docs will be clearer about the two orders - left-to-right is, for all practical purposes, the order to use. This is also way more intuitive just in general. Since our lesson currently describes the right-to-left order, we'll need to change it once this goes live. No CodePen changes should be necessary.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Amends composite transform example description to reference left-to-right application order.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
N/A

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
