### PR TITLE
GitHub Actions: Bump actions to latest version

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -8,7 +8,7 @@ jobs:
         name: Check for spelling errors
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - uses: codespell-project/actions-codespell@master
           with:
             check_filenames: true

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -14,8 +14,8 @@ jobs:
     name: Lint lesson/project files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@v46
+      - uses: actions/checkout@v6
+      - uses: tj-actions/changed-files@v47
         id: changed-files
         with:
           files: |
@@ -26,7 +26,7 @@ jobs:
             !markdownlint/**
             !.github/**
           separator: ','
-      - uses: DavidAnson/markdownlint-cli2-action@v14
+      - uses: DavidAnson/markdownlint-cli2-action@v23
         if: steps.changed-files.outputs.all_changed_files
         with:
           globs: ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
- GitHub has deprecated Node 20 for running actions. See also https://github.com/TheOdinProject/theodinproject/pull/5362 and the warnings on https://github.com/TheOdinProject/curriculum/actions/runs/28044787158

## This PR
- Moves the following actions to their latest version:
  - `actions/checkout`: v4 -> v6
  - `tj-actions/changed-files`: v46 -> v47
  - `DavidAnson/markdownlint-cli2-action`: v14 -> v23

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR