### PR TITLE
Make profile name parameter optional in routing

### DIFF
--- a/react/the_react_ecosystem/react_router.md
+++ b/react/the_react_ecosystem/react_router.md
@@ -300,7 +300,7 @@ const router = createBrowserRouter([
     element: <App />,
   },
   {
-    path: "profile/:name",
+    path: "profile/:name?",
     element: <Profile />,
   },
 ]);


### PR DESCRIPTION
## Because
Visiting `/profile` without a `name` parameter returns a 404 Not Found error. Since the route requires `name` by default, any user navigating to `/profile` directly hits a dead end. Making the parameter optional fixes this by allowing the route to match both `/profile` and `/profile/:name`.

## This PR
- Makes the `name` route parameter optional by adding `?` (i.e. `:name?`)

## Issue
No related issue — this is a simple bug fix submitted directly as a PR per the contributing guide.

## Additional Information
N/A

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)