### PR TITLE
Advanced HTML & CSS - Natural Responsiveness: Fixed grammar

### DIFF
--- a/advanced_html_css/responsive_design/natural_responsiveness.md
+++ b/advanced_html_css/responsive_design/natural_responsiveness.md
@@ -32,7 +32,7 @@ You have most likely already been using this tag if you've been using Emmet to g
 
 ### Avoid fixed width and height
 
-The number one enemy of flexibility is a fixed width on an element. If you put `width: 600px` on anything, then it will never be able to shrink below that width, which ruins your chances of getting that thing to fit on most phone screens. Likewise, sticking a fixed height on an element can cause issues if the contents of that element run out of room.
+The number one enemy of flexibility is a fixed width on an element. If you put `width: 600px` on anything, then it will never be able to shrink below that width, which ruins your chances of getting that thing to fit on most phone screens. Likewise, sticking a fixed height on an element can cause issues if the contents of that element runs out of room.
 
 Obviously the context will determine what works in a given situation, but an easy fix in many cases is replacing `width` or `height` with `max-width` or `min-height` (`min-width` and `max-height` are also valid and may be useful depending on the context).
 


### PR DESCRIPTION
## Because
The current grammar in the last sentence of the first paragraph of "Avoid fixed width and height" is incorrect .

## This PR
 - changes "run" to "runs" in the "Avoid fixed width and height" sub-section 

## Issue
There is no issue # currently assigned to this fix

## Additional Information
- if the wording still sounds awkward with "runs", an alternative fix could be changing "run" to "**has** run". this would yield: _Likewise, sticking a fixed height on an element can cause issues if the contents of that element **has** run out of room._

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
