### PR TITLE
Knights Travails: Remove explicit instruction on search algorithm and implementation

### DIFF
--- a/javascript/computer_science/project_knights_travails.md
+++ b/javascript/computer_science/project_knights_travails.md
@@ -26,18 +26,6 @@ The edges are the valid knight moves between vertices. For example, from `[0,0]`
 
 While solving this problem, you don’t need to explicitly create a graph object with vertices and edges. Instead, you can think of the graph as implicit. The knight starts on a specific vertex, and the algorithm will dynamically explore all possible moves (edges) to other vertices (positions on the board) as it traverses the board.
 
-#### Helpful Concepts Before You Begin
-
-You’ve worked with BFS on binary trees in the previous lesson, but applying it on a chessboard (a grid) can feel like a big leap — and that’s totally normal!
-
-Here are some core ideas to keep in mind:
-
-- **Represent positions as coordinates**: Each square can be written as `[x, y]`, where both values range from 0 to 7.
-- **Use a queue**: Like in tree BFS, you’ll use a queue to keep track of the next positions to explore.
-- **Track visited positions**: Unlike trees, graphs can revisit the same position through different paths — so be sure to track visited positions to avoid loops or unnecessary repeats.
-
-Thinking of the board as a grid-based graph instead of a tree will help you apply BFS much more effectively here.
-
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">
@@ -62,16 +50,16 @@ Sometimes *there is more than one fastest path*. Examples of this are shown belo
 
 1. Think about the rules of the board and knight, and make sure to follow them.
 1. From every square, multiple moves are possible. Choose a data structure that will allow you to work with them. Don't allow any moves to go off the board.
-1. Decide which search algorithm is best to use for this case.  Hint: one of them could be a potentially infinite series.
+1. Both DFS and BFS are viable here, though think carefully about how each of them work. One of them will require you to handle the possibility of getting stuck in an endless cycle.
 1. Use the chosen search algorithm to find the shortest path between the starting square (or node) and the ending square.  Output what that full path looks like, e.g.:
 
 ```bash
-  > knightMoves([3,3],[4,3])
-  => You made it in 3 moves!  Here's your path:
-    [3,3]
-    [4,5]
-    [2,4]
-    [4,3]
+> knightMoves([3,3],[4,3])
+=> You made it in 3 moves!  Here's your path:
+  [3,3]
+  [4,5]
+  [2,4]
+  [4,3]
 ```
 
 </div>

--- a/javascript/computer_science/project_knights_travails.md
+++ b/javascript/computer_science/project_knights_travails.md
@@ -17,12 +17,12 @@ Each square on the board is a node (or vertex).
 A knight’s valid moves from any square represent the edges (or connections) between the vertices.
 Thus, the problem of finding the shortest path for the knight’s movement becomes a graph traversal problem. The goal is to traverse the graph (the chessboard) to find the shortest route between two nodes (the start and end positions).
 
-#### Vertices and Edges
+#### Vertices and edges
 
 The vertices in this graph are each of the possible positions on the chessboard, represented by a pair of coordinates like `[x, y]`, where x and y are between 0 and 7.
 The edges are the valid knight moves between vertices. For example, from `[0,0]`, a knight can move to `[2,1]`, `[1,2]`, and so on. Each of these moves represents a connection between the vertex `[0,0]` and the other reachable vertices.
 
-#### Graph Representation
+#### Graph representation
 
 While solving this problem, you don’t need to explicitly create a graph object with vertices and edges. Instead, you can think of the graph as implicit. The knight starts on a specific vertex, and the algorithm will dynamically explore all possible moves (edges) to other vertices (positions on the board) as it traverses the board.
 

--- a/ruby/computer_science/project_knights_travails.md
+++ b/ruby/computer_science/project_knights_travails.md
@@ -16,12 +16,12 @@ Each square on the board is a node (or vertex).
 A knight’s valid moves from any square represent the edges (or connections) between the vertices.
 Thus, the problem of finding the shortest path for the knight’s movement becomes a graph traversal problem. The goal is to traverse the graph (the chessboard) to find the shortest route between two nodes (the start and end positions).
 
-#### Vertices and Edges
+#### Vertices and edges
 
 The vertices in this graph are each of the possible positions on the chessboard, represented by a pair of coordinates like `[x, y]`, where x and y are between 0 and 7.
 The edges are the valid knight moves between vertices. For example, from `[0,0]`, a knight can move to `[2,1]`, `[1,2]`, and so on. Each of these moves represents a connection between the vertex `[0,0]` and the other reachable vertices.
 
-#### Graph Representation
+#### Graph representation
 
 While solving this problem, you don’t need to explicitly create a graph object with vertices and edges. Instead, you can think of the graph as implicit. The knight starts on a specific vertex, and the algorithm will dynamically explore all possible moves (edges) to other vertices (positions on the board) as it traverses the board.
 

--- a/ruby/computer_science/project_knights_travails.md
+++ b/ruby/computer_science/project_knights_travails.md
@@ -25,18 +25,6 @@ The edges are the valid knight moves between vertices. For example, from `[0,0]`
 
 While solving this problem, you don’t need to explicitly create a graph object with vertices and edges. Instead, you can think of the graph as implicit. The knight starts on a specific vertex, and the algorithm will dynamically explore all possible moves (edges) to other vertices (positions on the board) as it traverses the board.
 
-#### Helpful Concepts Before You Begin
-
-You’ve worked with BFS on binary trees in the previous lesson, but applying it on a chessboard (a grid) can feel like a big leap — and that’s totally normal!
-
-Here are some core ideas to keep in mind:
-
-- **Represent positions as coordinates**: Each square can be written as `[x, y]`, where both values range from 0 to 7.
-- **Use a queue**: Like in tree BFS, you’ll use a queue to keep track of the next positions to explore.
-- **Track visited positions**: Unlike trees, graphs can revisit the same position through different paths — so be sure to track visited positions to avoid loops or unnecessary repeats.
-
-Thinking of the board as a grid-based graph instead of a tree will help you apply BFS much more effectively here.
-
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">
@@ -61,16 +49,16 @@ Sometimes *there is more than one fastest path*. Examples of this are shown belo
 
 1. Think about the rules of the board and knight, make sure to follow them.
 1. From every square, multiple moves are possible. Choose a data structure that will allow you to work with them.  Don't allow any moves to go off the board.
-1. Decide which search algorithm is best to use for this case.  Hint: one of them could be a potentially infinite series.
+1. Both DFS and BFS are viable here, though think carefully about how each of them work. One of them will require you to handle the possibility of getting stuck in an endless cycle.
 1. Use the chosen search algorithm to find the shortest path between the starting square (or node) and the ending square.  Output what that full path looks like, e.g.:
 
 ```bash
-  > knight_moves([3,3],[4,3])
-  => You made it in 3 moves!  Here's your path:
-    [3,3]
-    [4,5]
-    [2,4]
-    [4,3]
+> knight_moves([3,3],[4,3])
+=> You made it in 3 moves!  Here's your path:
+  [3,3]
+  [4,5]
+  [2,4]
+  [4,3]
 ```
 
 </div>


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
#29827 added explicit instruction to use BFS as a "helpful tip", though this directly conflicts with the assignment step to think through DFS and BFS and decide which to use.

I firmly believe that though it's a tricky project, this is still an extremely important learning opp that shouldn't be spoilt (both deciding between the algos and thinking through implementation - learners have been exposed to BFS and DFS implementations before). I do think the original wording is a little vague though (I've come across plenty who'd over-think "search algorithm" and miss that it essentially refers to DFS/BFS).

Other problems include stating that visited positions need tracking - this is only required for DFS and is only an optimisation for BFS. This IMHO is a big part of understanding DFS and BFS, when someone realises how BFS doesn't actually require it.

Landing #30700 will also help learners a lot in the long run, though I believe this PR should be a good middle ground that doesn't need to be blocked until that lands.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
For both pathways' KT projects:
  - Removes section explicitly instructing what to use
  - Rephrases assignment step for clarity on search algos and key considerations
  - Fixes heading case and unnecessary indentations

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.

_Note:_ any pull request created for an issue that already has someone else assigned **will be closed without review**.
-->
Closes #29783

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
