### PR TITLE
Clarify flex-shrink example in documentation

### DIFF
--- a/foundations/html_css/flexbox/flexbox_growing_and_shrinking.md
+++ b/foundations/html_css/flexbox/flexbox_growing_and_shrinking.md
@@ -44,7 +44,7 @@ In the following example the `flex` shorthand has values for `flex-shrink` and `
 
 The default shrink factor is `flex-shrink: 1`, which means all items will shrink evenly. If you do *not* want an item to shrink then you can specify `flex-shrink: 0;`. You can also specify higher numbers to make certain items shrink at a higher rate than normal.
 
-Here's an example. Note that we've also changed the `flex-basis` for reasons that will be explained shortly. If you shrink your browser window you'll notice that `.two` never gets smaller than the given width of 250px, even though the `flex-grow` rule would otherwise specify that each element should be equally sized.
+Here’s an example. Note that we’ve also changed the flex-basis for reasons that will be explained shortly. The .flex-container doesn't have an explicit width, so as a block-level element it automatically stretches to fill the available width of its parent (usually the browser window). As you shrink your browser window, the flex container also becomes narrower. When there is no longer enough space for all three items to keep their original width of 250px, Flexbox tries to shrink them. However, because .two has flex-shrink: 0, it never becomes smaller than 250px, even though the other items continue to shrink to fit the available space.
 
 <p class="codepen" data-height="300" data-default-tab="html,result" data-slug-hash="JjJXZVz" data-editable="true" data-user="TheOdinProjectExamples" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;">
 


### PR DESCRIPTION
## Because

The current explanation assumes readers already understand that shrinking the browser window also reduces the width of the flex container. For beginners, it may not be obvious that the flex container has no explicit width and, as a block-level element, automatically expands or contracts with the available width of its parent. Adding this explanation helps readers understand why resizing the browser causes the flex items to grow or shrink.

## This PR

- Clarifies that the `.flex-container` has no explicit width and automatically fills the available width of its parent.
- Explains that shrinking the browser window also shrinks the flex container.
- Makes it clearer why the flex items shrink when the available space decreases, while `.two` remains at `250px` because of `flex-shrink: 0`.

## Issue

N/A

## Additional Information

This change is intended to improve the learning experience for beginners by explicitly connecting browser resizing with the flex container's changing width. The original explanation assumes this behavior is already understood, which may cause confusion for readers encountering Flexbox for the first time.

## Pull Request Requirements

- [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If any lesson files are included in this PR, they have been previewed with the Markdown preview tool to ensure they are formatted correctly
- [x] If any lesson files are included in this PR, they follow the Layout Style Guide