### PR TITLE
Landing Page: Update introduction text to reflect single design image

### DIFF
--- a/foundations/html_css/flexbox/project_landing_page.md
+++ b/foundations/html_css/flexbox/project_landing_page.md
@@ -2,13 +2,13 @@
 
 For this project you'll be creating an entire web page from a design we'll provide for you. If you've been following along you should have the skills you need to accomplish this, but it may not be easy!
 
-The design we're providing you comes in the form of 2 images: one is an image of the complete website, and one has some details about some of the fonts and colors we've used.
+The design we're providing you is an image of the complete website, along with details about the fonts and colors in the assignment section below.
 
 Do *not* be afraid to use Google or go back to previous lessons to look something up. **In real life, professional developers use Google *constantly* for things that they have been doing for years.** At this point it is not expected that you will have everything memorized, so don't worry about it. Additionally, there are a few small details that you may not have encountered in our lessons yet. *This is by design.* These details are minor, and easily searched (e.g. Google `css rounded corners`).
 
 Get your project as close as you can to the design, but do not worry about getting it pixel-perfect. Don't get out your ruler or count pixels to find the exact margins between the various sections. The point of this assignment is to create something from scratch and get the various elements in more or less the right position relative to the rest. It doesn't matter if you use `margin: 24px` when the design actually has `margin: 48px`.
 
-*Finally*, feel free to substitute your own content into this design. The images have some meaningless dummy content, but if you want to make up a business and personalize this page, please feel free to do so! Insert actual images in the placeholders, and feel free to play with the colors and fonts a bit too.
+*Finally*, feel free to substitute your own content into this design. The image has some meaningless dummy content, but if you want to make up a business and personalize this page, please feel free to do so! Insert actual images in the placeholders, and feel free to play with the colors and fonts a bit too.
 
 <div class="lesson-note" markdown="1">
 


### PR DESCRIPTION
## Because
PR #31254 converted the second design image into text in the assignment section. However, the Introduction section was missed during that update and still referred to "2 images" and "The images".


## This PR
- Updates the Introduction section text to state that the design is a single image of the complete website.
- Clarifies that font and color details can be found in the assignment section below.
- Changes "The images have" to "The image has".


## Issue


## Additional Information


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
