### PR TITLE
The Cascade lesson: Clarify selector specificity explanation

### DIFF
--- a/foundations/html_css/css_foundations/the_cascade.md
+++ b/foundations/html_css/css_foundations/the_cascade.md
@@ -26,7 +26,7 @@ A CSS declaration that is more specific will take precedence over less specific 
 1. Class selectors
 1. Type selectors
 
-Specificity will only be taken into account when an element has multiple, conflicting declarations targeting it, sort of like a tie-breaker. An ID selector will always beat any number of class selectors, <span id="high-specificity-class-type">a class selector will always beat any number of type selectors</span>, and a type selector will always beat any number of less specific selectors. When no matching selector has a higher specificity, compare the number of selectors within the same specificity category. The rule with more selectors takes precedence.
+Specificity will only be taken into account when an element has multiple, conflicting declarations targeting it, sort of like a tie-breaker. An ID selector will always beat any number of class selectors, <span id="high-specificity-class-type">a class selector will always beat any number of type selectors</span>, and a type selector will always beat any number of less specific selectors. If comparing specificity doesn't determine a winner, compare the number of selectors in the same category (ID, class, or type selectors). The rule with more selectors takes precedence.
 
 Let's take a look at a few quick examples to visualize how specificity works.
 Consider the following HTML and CSS code:

--- a/foundations/html_css/css_foundations/the_cascade.md
+++ b/foundations/html_css/css_foundations/the_cascade.md
@@ -26,7 +26,7 @@ A CSS declaration that is more specific will take precedence over less specific 
 1. Class selectors
 1. Type selectors
 
-Specificity will only be taken into account when an element has multiple, conflicting declarations targeting it, sort of like a tie-breaker. An ID selector will always beat any number of class selectors, <span id="high-specificity-class-type">a class selector will always beat any number of type selectors</span>, and a type selector will always beat any number of less specific selectors. When there is no declaration with a selector of higher specificity, a rule with a greater number of selectors of the same type will take precedence over another rule with fewer selectors of the same type.
+Specificity will only be taken into account when an element has multiple, conflicting declarations targeting it, sort of like a tie-breaker. An ID selector will always beat any number of class selectors, <span id="high-specificity-class-type">a class selector will always beat any number of type selectors</span>, and a type selector will always beat any number of less specific selectors. When no matching selector has a higher specificity, compare the number of selectors within the same specificity category. The rule with more selectors takes precedence.
 
 Let's take a look at a few quick examples to visualize how specificity works.
 Consider the following HTML and CSS code:


### PR DESCRIPTION
## Because
The selector specificity explanation was difficult to parse and understand because it combined multiple ideas into a single sentence. This PR rephrases the explanation to make it easier to understand while preserving its original meaning.


## This PR

- Rephrases the selector specificity tie-breaker explanation.
- Makes it easier to read while preserving the original meaning.


## Issue

Closes #31253

## Additional Information
None.


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
