### PR TITLE
Form Validation lesson: Update Styling Validations paragraph

### DIFF
--- a/intermediate_html_css/forms/form_validations.md
+++ b/intermediate_html_css/forms/form_validations.md
@@ -198,9 +198,10 @@ To see this in action, we will be using our email and website example that we lo
 
 <script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
 
-First, we target valid inputs with a green border. Initially, our email and URL fields maintain their default browser styling, representing a neutral state because the user hasn't interacted with them yet.
+Initially, our email and URL fields maintain their default browser styling, representing a neutral state because the user hasn't interacted with them yet. We start by targetting valid inputs, setting a green border on the respective input field.
 
-Once a user enters an invalid value, the border switches to red. You can test this by entering an incorrectly formatted email or URL to see the validation in action.
+Once a user enters an invalid value and clicks or tabs away from the input (which would constitute a complete user interaction), the border switches to red. From then on, the border will automatically change between green and red depending on the validity of its contents. Test this out by entering an incorrectly formatted email or URL, clicking away to engage the validation, then editing the value between correctly formatted and incorrectly formatted.
+
 
 ### Conclusion
 

--- a/intermediate_html_css/forms/form_validations.md
+++ b/intermediate_html_css/forms/form_validations.md
@@ -198,10 +198,9 @@ To see this in action, we will be using our email and website example that we lo
 
 <script async src="https://cpwebassets.codepen.io/assets/embed/ei.js"></script>
 
-Initially, our email and URL fields maintain their default browser styling, representing a neutral state because the user hasn't interacted with them yet. We start by targetting valid inputs, setting a green border on the respective input field.
+Initially, our email and URL fields maintain their default browser styling, representing a neutral state because the user hasn't interacted with them yet. We start by targeting valid inputs, setting a green border on the respective input field.
 
 Once a user enters an invalid value and clicks or tabs away from the input (which would constitute a complete user interaction), the border switches to red. From then on, the border will automatically change between green and red depending on the validity of its contents. Test this out by entering an incorrectly formatted email or URL, clicking away to engage the validation, then editing the value between correctly formatted and incorrectly formatted.
-
 
 ### Conclusion
 


### PR DESCRIPTION
## Because
Improve clarity on the Styling Validation paragraphs

## This PR
- Minor clean ups to the order of the text, and clarification on the new expected behavior based on the current usage of `:user-valid` instead of the old `:valid`

## Issue

Closes [#31239](https://github.com/TheOdinProject/curriculum/issues/31239)

## Additional Information
I decided to change the order on the first paragraph to mention the initial state of the inputs first, followed by the valid state and then the invalid state. I feel like that makes it a bit easier to follow since it matches the visual feedback you see (the input isn't valid with a green border before you interact with it), while also matching the order of the CSS as suggested by [tshamsiddin](https://github.com/tshamsiddin).

I also noticed that the input fields remain validated with a green border even if you delete all the text. For example,  if you type in an invalid value, and click away the input gets invalidated (red border). But if you then delete the invalid value and leave it blank, the input then gets validated (green border). That might be worth checking out in the codepen.

Lastly, I wonder if it might be worth it to explain shortly the difference between `:valid :invalid` and `:user-valid :user-invalid`? Since we take the time to explain that the user is expected to click away from the input to trigger it's validation, this might leave the reader wondering why.

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
