### PR TITLE
NodeJS/Testing Database Operations: Fix incorrect PostgreSQL port in .env example (3306 → 5432)

### DIFF
--- a/nodeJS/testing_express/testing_database_operations.md
+++ b/nodeJS/testing_express/testing_database_operations.md
@@ -25,8 +25,8 @@ We'll leverage environment variables for your codebase to identify which databas
 
 ```properties
 NODE_ENV=development
-DATABASE_URL=postgresql://<user>:<password>@localhost:3306/inventory_application
-TEST_DATABASE_URL=postgresql://<user>:<password>@localhost:3306/test_inventory_application
+DATABASE_URL=postgresql://<user>:<password>@localhost:5432/inventory_application
+TEST_DATABASE_URL=postgresql://<user>:<password>@localhost:5432/test_inventory_application
 ```
 
 Next, setup appropriate npm scripts in your `package.json` file:


### PR DESCRIPTION
## Because
The `.env` example in this lesson uses port `3306`, which is MySQL's default port, not PostgreSQL's. Since the connection string uses the `postgresql://` scheme, this would cause a connection failure for anyone following the example with a default local Postgres setup.

## This PR
- Updates `DATABASE_URL=postgresql://<user>:<password>@localhost:3306/inventory_application` and `TEST_DATABASE_URL=postgresql://<user>:<password>@localhost:3306/test_inventory_application` example ports from `3306` to `5432` (PostgreSQL's default port) in `testing_database_operations.md`

## Issue
N/A
<!-- Replace with "Closes #XXXXX" only if a maintainer actually assigned you an issue for this -->

## Additional Information
- Fixed the wrong port problem for PostgreSQL using the MySQL's port.

## Pull Request Requirements
- [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [ ] If this PR addresses an open issue, it is linked in the `Issue` section
- [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
- [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)