### PR TITLE
Typo fix in curriculum docs

### DIFF
--- a/foundations/installations/setting_up_git.md
+++ b/foundations/installations/setting_up_git.md
@@ -96,7 +96,7 @@ This section contains a general overview of topics that you will learn in this l
 
    #### Multiple SSH keys
 
-   If you have already setup an ssh key pair with GitHub on a different machine prior to starting The Odin Project, GitHub allows you to have multiple key pairs associated with your account. You can just follow these instructions again to set up another key pair and register it with GitHub.
+   If you have already setup an SSH key pair with GitHub on a different machine prior to starting The Odin Project, GitHub allows you to have multiple key pairs associated with your account. You can just follow these instructions again to set up another key pair and register it with GitHub.
 
    </div>
 

--- a/nodeJS/express/installation_guides/postgresql/linux.md
+++ b/nodeJS/express/installation_guides/postgresql/linux.md
@@ -80,7 +80,7 @@ Instead, we will set up our own role to avoid switching to the `postgres` role a
 
    Remember that you should change the `<role_database_name>` and `<role_name>` (they should both be the same)! If you see `GRANT` in response to the command, then you can type `\q` to exit the prompt.
 
-1. After finishing our configuration, the last step is save it into the environment to access later.
+1. After finishing our configuration, the last step is to save it into the environment to access later.
 
    In order to save our password to the environment, we can run this command:
 

--- a/nodeJS/express/views.md
+++ b/nodeJS/express/views.md
@@ -12,7 +12,7 @@ In this course, we will use [EJS](https://ejs.co/). EJS's syntax is very similar
 
 This section contains a general overview of topics that you will learn in this lesson.
 
-- How to setup EJS in an Express project.
+- How to set up EJS in an Express project.
 - How to use EJS.
 
 ### Setting up EJS

--- a/nodeJS/testing_express/testing_database_operations.md
+++ b/nodeJS/testing_express/testing_database_operations.md
@@ -29,7 +29,7 @@ DATABASE_URL=postgresql://<user>:<password>@localhost:3306/inventory_application
 TEST_DATABASE_URL=postgresql://<user>:<password>@localhost:3306/test_inventory_application
 ```
 
-Next, setup appropriate npm scripts in your `package.json` file:
+Next, set up appropriate npm scripts in your `package.json` file:
 
 ```json
 {

--- a/ruby_on_rails/introduction/installation_guides/postgresql/linux.md
+++ b/ruby_on_rails/introduction/installation_guides/postgresql/linux.md
@@ -80,7 +80,7 @@ Instead, we will set up our own role to avoid switching to the `postgres` role a
 
    Remember that you should change the `<role_database_name>` and `<role_name>` (they should both be the same)! If you see `GRANT` in response to the command, then you can type `\q` to exit the prompt.
 
-1. After finishing our configuration, the last step is save it into the environment to access later.
+1. After finishing our configuration, the last step is to save it into the environment to access later.
 
    In order to save our password to the environment, we can run this command:
 


### PR DESCRIPTION
## Because
While working through the curriculum, I noticed a few small typos in the docs that could be corrected for clarity.

## This PR
- Fixes a typo in `<foundations/installations/setting_up_git.md>`  ( ssh to SSH )
- Fixes a typo in `<nodeJS/express/installation_guides/postgresql/linux.md>` (fixed typos)
- Fixes a typo in `<nodeJS/express/views.md>` (fixed grammatical error by changing setup to set up.)
-  Fixes a typo in `<nodeJS/testing_express/testing_database_operations.md>`  (fixed grammatical error by changing setup to set up.)
-  Fixes a typo in `<ruby_on_rails/introduction/installation_guides/postgresql/linux.md>` (fixed typos)


## Issue
N/A

## Additional Information
N/A

## Pull Request Requirements
- [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `location of change: brief description of change` format
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [ ] If this PR addresses an open issue, it is linked in the `Issue` section
- [ ] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
- [ ] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)