### PR TITLE
Node Conclusion: Remove 90 Days of DevOps resource

### DIFF
--- a/nodeJS/final_project/conclusion.md
+++ b/nodeJS/final_project/conclusion.md
@@ -38,7 +38,6 @@ Here are a few extra resources that will take you a bit deeper into software arc
 
 - Explore additional [frameworks built on Express](https://web.archive.org/web/20240328030121/https://expressjs.com/en/resources/frameworks.html) that might be more suited to building certain types of applications.
 - Watch [more about APIs](https://www.youtube.com/watch?v=oBW_VNg4qD0) to learn a bit more about how APIs work.
-- [90 Days of DevOps](https://github.com/MichaelCade/90DaysOfDevOps) is a great repo if you wish to explore more about DevOps.
 - [Design Patterns: Elements of Reusable Object-Oriented Software](https://www.amazon.com/Design-Patterns-Object-Oriented-Addison-Wesley-Professional-ebook/dp/B000SEIBB8) is a classic book on object-oriented design patterns.
 - Read [Clean Code](https://www.amazon.com/Clean-Code-Handbook-Software-Craftsmanship-ebook/dp/B001GSTOAM/ref=sr_1_1?dchild=1&keywords=Clean+Code&qid=1602168590&s=digital-text&sr=1-1) to learn principles for writing readable and maintainable code.
 - Check out [syntax.fm Podcast](https://syntax.fm), a podcast covering web development.


### PR DESCRIPTION
Removes the leftover 90 Days of DevOps link from the Node conclusion's
Other resources list.

## Because

In issue #30357 we removed the DevOps section from this lesson because devops roles are generally not the kind of engineering roles our learners are striving for, and because in the Discord server we regularly encourage learners to narrow their focus rather than branch into devops. Entry level engineers seeking programming roles don't need devops skills.

In this PR, #30358, we removed the `#### DevOps` subsection under Next steps, but missed this bullet in the Other resources list further down the page. It points learners at the same kind of devops material for the same reasons we just removed, so it should go too.

## This PR

- Removes the 90 Days of DevOps bullet from the Other resources list.

## Issue

Follow-up to #30357 / #30358.

## Additional Information

## Pull Request Requirements

-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
