### PR TITLE
NodeJS - Introduction to Express lesson: Fix links to sendFile method

### DIFF
--- a/nodeJS/express/introduction_to_express.md
+++ b/nodeJS/express/introduction_to_express.md
@@ -87,7 +87,7 @@ If we had defined multiple routes, Express would pass the request through the fi
 
 Express takes the callback function we gave it and passes the request object into the first parameter (conventionally named `req`), and a [response object](https://expressjs.com/en/5x/api/response) into the second parameter (`res`). Our callback tells the response object to respond to the request by sending (via `res.send`) the string `"Hello, world!"`.
 
-There is no more code to run and the function returns. Since Express has been told to respond to the request, it ends the request-response cycle. Meanwhile, the browser receives our server's response and displays it on screen, which is our `"Hello, world!"` string. We could send nearly anything in our response. We could even [tell Express to send a file](https://expressjs.com/en/5x/api/response/#ressendfilepath--options--fn).
+There is no more code to run and the function returns. Since Express has been told to respond to the request, it ends the request-response cycle. Meanwhile, the browser receives our server's response and displays it on screen, which is our `"Hello, world!"` string. We could send nearly anything in our response. We could even [tell Express to send a file](https://expressjs.com/en/5x/api/response/#ressendfile).
 
 ### Auto-restarting your server upon file changes
 
@@ -110,5 +110,5 @@ The following questions are an opportunity to reflect on key topics in this less
 
 - [What is Express?](https://expressjs.com/)
 - [What happens when a server receives a request?](#a-requests-journey)
-- [What can we use to tell Express to send a file in response to a request?](https://expressjs.com/en/5x/api/response/#ressendfilepath--options--fn)
+- [What can we use to tell Express to send a file in response to a request?](https://expressjs.com/en/5x/api/response/#ressendfile)
 - [What can you use to automatically restart your server when you make changes to a file?](#auto-restarting-your-server-upon-file-changes)


### PR DESCRIPTION
## Because
Links send to the top of the page instead of the intended section


## This PR
Updates links in 2 lines

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)