### PR TITLE
Advanced Selectors lesson: Update all "adjacent sibling combinator" text

### DIFF
--- a/intermediate_html_css/intermediate_css_concepts/advanced_selectors.md
+++ b/intermediate_html_css/intermediate_css_concepts/advanced_selectors.md
@@ -22,7 +22,7 @@ This section contains a general overview of topics that you will learn in this l
 Let's have a look at some more ways we can access different elements *without* referring to their classes. Here are three new selectors to do just that.
 
 - `>` - the child combinator
-- `+` - the adjacent sibling combinator
+- `+` - the Next-sibling combinator
 - `~` - the general sibling combinator
 
 We'll tackle some practical examples using this sample markup.
@@ -63,7 +63,7 @@ main > div > div {
 }
 ```
 
-Phrased another way, the child selector will select an element that is one level of indentation down. In order to select an element that is adjacent (immediately following) to our target, or on the same level of indentation, we can use the adjacent sibling combinator `+`.
+Phrased another way, the child selector will select an element that is one level of indentation down. In order to select an element that is adjacent (immediately following) to our target, or on the same level of indentation, we can use the Next-sibling combinator `+`.
 
 ```css
 /* Only the div with the classes "child group2" will get selected by this */

--- a/intermediate_html_css/intermediate_css_concepts/advanced_selectors.md
+++ b/intermediate_html_css/intermediate_css_concepts/advanced_selectors.md
@@ -22,7 +22,7 @@ This section contains a general overview of topics that you will learn in this l
 Let's have a look at some more ways we can access different elements *without* referring to their classes. Here are three new selectors to do just that.
 
 - `>` - the child combinator
-- `+` - the Next-sibling combinator
+- `+` - the next-sibling combinator
 - `~` - the general sibling combinator
 
 We'll tackle some practical examples using this sample markup.

--- a/intermediate_html_css/intermediate_css_concepts/advanced_selectors.md
+++ b/intermediate_html_css/intermediate_css_concepts/advanced_selectors.md
@@ -63,7 +63,7 @@ main > div > div {
 }
 ```
 
-Phrased another way, the child selector will select an element that is one level of indentation down. In order to select an element that is adjacent (immediately following) to our target, or on the same level of indentation, we can use the Next-sibling combinator `+`.
+Phrased another way, the child selector will select an element that is one level of indentation down. In order to select an element that is next to (immediately following) our target, or on the same level of indentation, we can use the next-sibling combinator `+`.
 
 ```css
 /* Only the div with the classes "child group2" will get selected by this */


### PR DESCRIPTION
Update all 'adjacent sibling combinator' text to 'Next-sibling combinator' for clarity & latest update. ref: MDN Web Docs
Link: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/Next-sibling_combinator

## Because
Benefit: It makes the term "adjacent sibling combinator" more readable & easier to understand.

## This PR
- replaces all "adjacent sibling combinator" text with "Next-sibling combinator" on the page (Page Link: https://www.theodinproject.com/lessons/node-path-intermediate-html-and-css-advanced-selectors)

## Issue
Closes #31327 

## Additional Information
Discussion, Comment, permission: https://github.com/TheOdinProject/curriculum/issues/31327#issuecomment-5369151120


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project curriculum contributing guide](https://github.com/TheOdinProject/curriculum/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If any lesson files are included in this PR, they have been previewed with the [Markdown preview tool](https://www.theodinproject.com/lessons/preview) to ensure it is formatted correctly
-   [x] If any lesson files are included in this PR, they follow the [Layout Style Guide](https://github.com/TheOdinProject/curriculum/blob/main/LAYOUT_STYLE_GUIDE.md)
