### PR TITLE
Node.js: Add note about prettier-plugin-ejs in 'Views' lesson

### DIFF
--- a/nodeJS/express/views.md
+++ b/nodeJS/express/views.md
@@ -78,7 +78,7 @@ If you use Prettier for code formatting, you may want to install the [Prettier P
 npm install prettier-plugin-ejs --save-dev
 ```
 
-You will also need to add the configuration to your `.prettierrc` file in the root of your project.
+You will also need to add the configuration to a `.prettierrc` file in the root of your project.
 
 ```json
 {

--- a/nodeJS/express/views.md
+++ b/nodeJS/express/views.md
@@ -70,6 +70,22 @@ Here's a quick example that includes arrays and loop logic.
 </ul>
 ```
 
+#### Formatting EJS
+
+If you use Prettier for code formatting, you may want to install the [Prettier Plugin for EJS](https://www.npmjs.com/package/prettier-plugin-ejs), as Prettier doesn't natively support EJS tags.
+
+```bash
+npm install prettier-plugin-ejs --save-dev
+```
+
+You will also need to add the configuration to your `.prettierrc` file in the root of your project.
+
+```json
+{
+  "plugins": ["prettier-plugin-ejs"]
+}
+```
+
 ### Using EJS with Express
 
 Let's use EJS with Express. First, create an EJS template file called `index.ejs` in the `views` subdirectory, and add the following:


### PR DESCRIPTION
## Because
By default, Prettier throws syntax errors when attempting to format EJS-specific tags.

## This PR
- Adds instructions on how to install and configure `prettier-plugin-ejs` in the Views lesson.

## Pull Request Requirements
- [x] I have thoroughly read and understand The Odin Project curriculum contributing guide
- [x] The title of this PR follows the location of change: brief description of change format, e.g. Intro to HTML and CSS lesson: Fix link text
- [x] The Because section summarizes the reason for this PR
- [x] The This PR section has a bullet point list describing the changes in this PR
- [ ] If this PR addresses an open issue, it is linked in the Issue section
- [x] If any lesson files are included in this PR, they have been previewed with the Markdown preview tool to ensure it is formatted correctly
- [x] If any lesson files are included in this PR, they follow the Layout Style Guide