### PR TITLE
JS Bundling: Fix Yarn Classic installation link

### DIFF
--- a/ruby_on_rails/rails_sprinkles/js_bundling.md
+++ b/ruby_on_rails/rails_sprinkles/js_bundling.md
@@ -30,7 +30,7 @@ Rollup is another bundler that allows you to utilize a JavaScript syntax for imp
 
 The final bundler provided through jsbundling-rails is webpack which is a static module bundler that uses an entry point within your application to create a dependency graph that then combines every module your project needs into one or more bundles to be used by your application.
 
-Now that you have been introduced to the bundlers provided through jsbundling-rails, let's go into setting one up. But before that, go and [install Yarn Classic](https://yarnpkg.com/getting-started/install) first.
+Now that you have been introduced to the bundlers provided through jsbundling-rails, let's go into setting one up. But before that, go and [install Yarn Classic](https://classic.yarnpkg.com/en/docs/install) first (Yarn Classic is intentional).
 
 Much like Bundler for Ruby gems, Yarn is a JavaScript package manager that manages JavaScript dependencies in your project. You will already have npm (another JavaScript package manager) installed from Foundations, but Yarn Classic's defaults don't require us to do any further configuration with Rails and it's still widely used with Rails in the industry.
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
In #31150, for some reason the link to the installation instructions was changed, and those are for Yarn Modern, not Yarn Classic.


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Replaces href with Yarn Classic link
